### PR TITLE
Add missing German translations for sma

### DIFF
--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV1.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV1.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Scyther",
 		fr: "Insécateur",
+		de: "Sichlor"
 	},
 	illustrator: "Shigenori Negishi",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Twin Play",
 				fr: "Duo",
+				de: "Doppeltes Spiel"
 			},
 			effect: {
 				en: "Search your deck for up to 2 Scyther and put them onto your Bench. Then, shuffle your deck.",
 				fr: "Cherchez jusqu’à 2 Insécateur dans votre deck et placez-les sur votre Banc. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach bis zu 2 Sichlor und lege sie auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},
@@ -45,10 +48,12 @@ const card: Card = {
 			name: {
 				en: "Agility",
 				fr: "Hâte",
+				de: "Agilität"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c’est face, évitez tous les effets d’attaques, y compris les dégâts, infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei Kopf während des nächsten Zuges deines Gegners alle Effekte von Attacken, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 20,
 
@@ -68,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "While young, they live together deep in the mountains, training themselves in how to fight with their scythes and move at high speeds.",
+		de: "Junge Sichlor wohnen in Gruppen tief in den Bergen. Dort trainieren sie ihre Schnelligkeit und üben den Kampf mit Sicheln."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV10.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV10.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Quagsire",
 		fr: "Maraiste",
+		de: "Morlord"
 	},
 	illustrator: "Saya Tsuruta",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wooper",
 		fr: "Axoloto",
+		de: "Felino"
 	},
 	stage: "Stage1",
 
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Wash Out",
 				fr: "Surlavage",
+				de: "Wegspülen"
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may move a Water Energy from 1 of your Benched Pokémon to your Active Pokémon.",
 				fr: "Autant de fois que vous le voulez pendant votre tour (avant votre attaque), vous pouvez déplacer une Énergie Water de l’un de vos Pokémon de Banc vers votre Pokémon Actif.",
+				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 {W}-Energie von 1 Pokémon auf deiner Bank auf dein Aktives Pokémon verschieben."
 			},
 		},
 	],
@@ -47,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Hydro Pump",
 				fr: "Hydrocanon",
+				de: "Hydropumpe"
 			},
 			effect: {
 				en: "This attack does 20 more damage times the amount of Water Energy attached to this Pokémon.",
 				fr: "Cette attaque inflige 20 dégâts supplémentaires multipliés par le nombre d’Énergies Water attachées à ce Pokémon.",
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu."
 			},
 			damage: 60,
 
@@ -70,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "This carefree Pokémon has an easygoing nature. While swimming, it always bumps into boat hulls.",
+		de: "Dieses genügsame Pokémon ist sehr umgänglich. Beim Schwimmen stößt es immer wieder gegen Schiffe."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV11.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV11.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Froakie",
 		fr: "Grenousse",
+		de: "Froxy"
 	},
 	illustrator: "sui",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Frubbles",
 				fr: "Grebulles",
+				de: "Flubba"
 			},
 			effect: {
 				en: "If this Pokémon has any Water Energy attached to it, it has no Retreat Cost.",
 				fr: "Si de l’Énergie Water est attachée à ce Pokémon, il n’a pas de coût de Retraite.",
+				de: "Wenn an dieses Pokémon mindestens 1 {W}-Energie angelegt ist, hat es keine Rückzugskosten."
 			},
 		},
 	],
@@ -43,6 +46,7 @@ const card: Card = {
 			name: {
 				en: "Flop",
 				fr: "Flop",
+				de: "Plumps"
 			},
 
 			damage: 20,
@@ -63,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It protects its skin by covering its body in delicate bubbles. Beneath its happy-go-lucky air, it keeps a watchful eye on its surroundings.",
+		de: "Es schützt seine Haut mit feinen Blasen, die seinen Körper umhüllen. Es mag unbekümmert aussehen, behält die Umgebung aber immer aufmerksam im Auge."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV12.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV12.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Frogadier",
 		fr: "Croâporal",
+		de: "Amphizel"
 	},
 	illustrator: "Anesaki Dynamic",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Froakie",
 		fr: "Grenousse",
+		de: "Froxy"
 	},
 	stage: "Stage1",
 
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Gale Shuriken",
 				fr: "Bourrasque Shuriken",
+				de: "Shurikenwind"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may put 2 damage counters on 1 of your opponent's Pokémon.",
 				fr: "Lorsque vous jouez ce Pokémon de votre main pour faire évoluer l’un de vos Pokémon pendant votre tour, vous pouvez placer 2 marqueurs de dégâts sur l’un des Pokémon de votre adversaire.",
+				de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du 2 Schadensmarken auf 1 Pokémon deines Gegners legen."
 			},
 		},
 	],
@@ -45,6 +49,7 @@ const card: Card = {
 			name: {
 				en: "Water Drip",
 				fr: "Goutte à Goutte",
+				de: "Spritzwasser"
 			},
 
 			damage: 20,
@@ -65,6 +70,7 @@ const card: Card = {
 
 	description: {
 		en: "Its swiftness is unparalleled. It can scale a tower of more than 2,000 feet in a minute's time.",
+		de: "Seine Flinkheit sucht ihresgleichen. Es kann einen 600 m hohen Turm in weniger als einer Minute erklimmen."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV13.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV13.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Voltorb",
 		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 	illustrator: "Shin Nagasawa",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Floating Electrons",
 				fr: "Électrons Flottants",
+				de: "Schwebende Elektronen"
 			},
 			effect: {
 				en: "If this Pokémon has any Energy attached to it, it has no Retreat Cost.",
 				fr: "Si de l’Énergie est attachée à ce Pokémon, il n’a pas de Coût de Retraite.",
+				de: "Wenn an dieses Pokémon mindestens 1 Energie angelegt ist, hat es keine Rückzugskosten."
 			},
 		},
 	],
@@ -43,10 +46,12 @@ const card: Card = {
 			name: {
 				en: "Thunder Shock",
 				fr: "Éclair",
+				de: "Donnerschock"
 			},
 			effect: {
 				en: "Flip a coin. If heads, your opponent's Active Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei Kopf ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 20,
 
@@ -71,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "Usually found in power plants. Easily mistaken for a Poké Ball, it has zapped many people.",
+		de: "Dieses Pokémon wird oftmals mit einem Pokéball verwechselt. Es lebt vorwiegend in Kraftwerken."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV14.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV14.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Xurkitree",
 		fr: "Câblifère",
+		de: "Voltriant"
 	},
 	illustrator: "Naoki Saito",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Dazzle Blast",
 				fr: "Explosion de Lumière",
+				de: "Blendende Explosion"
 			},
 			effect: {
 				en: "Your opponent's Active Pokémon is now Confused.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
 			},
 			damage: 20,
 
@@ -47,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Cablegram",
 				fr: "Câblogramme",
+				de: "Telegramm"
 			},
 			effect: {
 				en: "If you have exactly 3 Prize cards remaining, your opponent's Active Pokémon is now Paralyzed.",
 				fr: "S’il vous reste exactement 3 cartes Récompense, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+				de: "Wenn du genau 3 verbleibende Preiskarten hast, ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 100,
 
@@ -75,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It appeared from the Ultra Wormhole. It raided a power plant, so people think it energizes itself with electricity.",
+		de: "Es ist durch die Ultrapforte erschienen. Seine Überfälle auf Kraftwerke lassen vermuten, dass es seine Lebensenergie aus Strom bezieht."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV15.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV15.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Seviper",
 		fr: "Séviper",
+		de: "Vipitis"
 	},
 	illustrator: "SATOSHI NAKAI",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "More Poison",
 				fr: "Poison Sans Fin",
+				de: "Giftschub"
 			},
 			effect: {
 				en: "Put 1 more damage counter on your opponent's Poisoned Pokémon between turns.",
 				fr: "Placez 1 marqueur de dégâts supplémentaire sur le Pokémon Empoisonné de votre adversaire entre chaque tour.",
+				de: "Lege zwischen den Zügen 1 Schadensmarke mehr auf das vergiftete Pokémon deines Gegners."
 			},
 		},
 	],
@@ -44,10 +47,12 @@ const card: Card = {
 			name: {
 				en: "Venomous Fang",
 				fr: "Croc-Poison",
+				de: "Gifthauer"
 			},
 			effect: {
 				en: "Your opponent's Active Pokémon is now Poisoned.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Empoisonné.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt vergiftet."
 			},
 			damage: 30,
 
@@ -67,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "In battle, it uses its bladed tail to counter any Zangoose. It secretes a deadly venom in its tail.",
+		de: "Die flinken Angriffe von Sengo kontert es mit seinem messerscharfen Schweif, aus dem Gift austritt."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV16.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV16.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Shuppet",
 		fr: "Polichombr",
+		de: "Shuppet"
 	},
 	illustrator: "sui",
 	rarity: "Shiny rare",
@@ -30,6 +31,7 @@ const card: Card = {
 			name: {
 				en: "Headbutt",
 				fr: "Coup d’Boule",
+				de: "Kopfnuss"
 			},
 
 			damage: 10,
@@ -43,6 +45,7 @@ const card: Card = {
 			name: {
 				en: "Will-O-Wisp",
 				fr: "Feu Follet",
+				de: "Irrlicht"
 			},
 
 			damage: 20,
@@ -68,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It loves vengeful emotions and hangs in rows under the eaves of houses where vengeful people live.",
+		de: "Es liebt Rachegefühle. Diese Pokémon hängen sich an Dachrinnen von Häusern, in denen Rachsüchtige leben."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV17.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV17.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Inkay",
 		fr: "Sepiatop",
+		de: "Iscalar"
 	},
 	illustrator: "Shigenori Negishi",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Hypnosis",
 				fr: "Hypnose",
+				de: "Hypnose"
 			},
 			effect: {
 				en: "Your opponent's Active Pokémon is now Asleep.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi.",
+				de: "Das Aktive Pokémon deines Gegners schläft jetzt."
 			},
 
 		},
@@ -52,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It flashes the light-emitting spots on its body, which drains its opponent's will to fight. It takes the opportunity to scuttle away and hide.",
+		de: "Mit den blinkenden Punkten auf seinem Körper raubt es Gegnern den Kampfeswillen. Es nutzt diese Gelegenheit, um sich zu verstecken."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV18.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV18.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Malamar",
 		fr: "Sepiatroce",
+		de: "Calamanero"
 	},
 	illustrator: "Hideki Ishikawa",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Inkay",
 		fr: "Sepiatop",
+		de: "Iscalar"
 	},
 	stage: "Stage1",
 
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Psychic Recharge",
 				fr: "Recharge Psy",
+				de: "Psycho-Aufladung"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may attach a Psychic Energy card from your discard pile to 1 of your Benched Pokémon.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie Psychic de votre pile de défausse à l’un de vos Pokémon de Banc.",
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 {P}-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank anlegen."
 			},
 		},
 	],
@@ -47,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Psychic Sphere",
 				fr: "Sphère Psy",
+				de: "Psychosphäre"
 			},
 
 			damage: 60,
@@ -67,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "It lures prey close with hypnotic motions, then wraps its tentacles around it before finishing it off with digestive fluids.",
+		de: "Mit seinen hypnotischen Kräften lockt es Gegner an, hält sie mit den Tentakeln an seinem Kopf fest und zersetzt sie dann mit Verdauungssekret."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV19.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV19.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Poipole",
 		fr: "Vémini",
+		de: "Venicro"
 	},
 	illustrator: "Akira Komayama",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Spit Poison",
 				fr: "Crache-Venin",
+				de: "Giftspucke"
 			},
 			effect: {
 				en: "Your opponent's Active Pokémon is now Poisoned.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Empoisonné.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt vergiftet."
 			},
 
 		},
@@ -45,10 +48,12 @@ const card: Card = {
 			name: {
 				en: "Knockout Reviver",
 				fr: "K.O. Futile",
+				de: "Fruchtloser K. o."
 			},
 			effect: {
 				en: "During your opponent's next turn, if this Pokémon is Knocked Out, your opponent can't take any Prize cards for it.",
 				fr: "Pendant le prochain tour de votre adversaire, si ce Pokémon est mis K.O., votre adversaire ne peut pas récupérer de carte Récompense pour ce Pokémon.",
+				de: "Wenn dieses Pokémon während des nächsten Zuges deines Gegners kampfunfähig wird, kann dein Gegner dafür keine Preiskarten nehmen."
 			},
 
 		},
@@ -67,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "This Ultra Beast is well enough liked to be chosen as a first partner in its own world.",
+		de: "Diese Ultrabestie wird in der Welt, aus der sie kommt, so gemocht, dass sie oft als Partner für Reisen gewählt wird."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV2.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV2.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rowlet",
 		fr: "Brindibou",
+		de: "Bauz"
 	},
 	illustrator: "sui",
 	rarity: "Shiny rare",
@@ -30,6 +31,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -43,6 +45,7 @@ const card: Card = {
 			name: {
 				en: "Leafage",
 				fr: "Feuillage",
+				de: "Blattwerk"
 			},
 
 			damage: 20,
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "This wary Pokémon uses photosynthesis to store up energy during the day, while becoming active at night.",
+		de: "Ein wachsames und nachtaktives Pokémon. Tagsüber sammelt es per Photosynthese Kräfte, um fit für die Nacht zu sein."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV20.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV20.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Sudowoodo",
 		fr: "Simularbre",
+		de: "Mogelbaum"
 	},
 	illustrator: "Kyoko Umemoto",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Roadblock",
 				fr: "Barrage Routier",
+				de: "Hindernis"
 			},
 			effect: {
 				en: "Your opponent can't have more than 4 Benched Pokémon. If they have 5 or more Benched Pokémon, they discard Benched Pokémon until they have 4 Pokémon on the Bench. If more than one effect changes the number of Benched Pokémon allowed, use the smaller number.",
 				fr: "Votre adversaire ne peut pas avoir plus de 4 Pokémon de Banc. S’il a 5 Pokémon de Banc ou plus, il doit défausser des Pokémon de Banc jusqu’à en avoir 4 sur le Banc. Si plus d’un effet change le nombre de Pokémon de Banc autorisés, utilisez le nombre le plus petit.",
+				de: "Dein Gegner kann nicht mehr als 4 Pokémon auf seiner Bank haben. Wenn er 5 Pokémon oder mehr auf seiner Bank hat, legt er so lange Pokémon von seiner Bank auf seinen Ablagestapel, bis er 4 Pokémon auf seiner Bank hat. Wenn mehr als 1 Effekt die Anzahl der auf der Bank erlaubten Pokémon verändert, verwende die kleinere Anzahl."
 			},
 		},
 	],
@@ -43,6 +46,7 @@ const card: Card = {
 			name: {
 				en: "Rock Throw",
 				fr: "Jet-Pierres",
+				de: "Steinwurf"
 			},
 
 			damage: 40,
@@ -63,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "To avoid attack, it mimics a tree. It will run off if splashed with water, which it hates.",
+		de: "Es tarnt sich als Baum, um Angriffen aus dem Weg zu gehen. Es hasst jedoch Wasser und ergreift die Flucht, wenn man es nass macht."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV21.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV21.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 	illustrator: "Misa Tsutsui",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Detect",
 				fr: "Détection",
+				de: "Scanner"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c’est face, évitez tous les effets d’attaques, y compris les dégâts, infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei Kopf während des nächsten Zuges deines Gegners alle Effekte von Attacken, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 
 		},
@@ -44,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Jab",
 				fr: "Taquet",
+				de: "Boxschlag"
 			},
 
 			damage: 10,
@@ -64,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "It's tough enough to run right through the night, and it's also a hard worker, but it's still just a youngster.",
+		de: "Dieses junge Pokémon ist bereits so robust und willensstark, dass es die ganze Nacht hindurch rennen kann."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV22.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV22.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lucario",
 		fr: "Lucario",
+		de: "Lucario"
 	},
 	illustrator: "Kouki Saitou",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 	stage: "Stage1",
 
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Precognitive Aura",
 				fr: "Aura Prémonitoire",
+				de: "Vorhersehende Aura"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if you have Garchomp in play, you may search your deck for a card and put it into your hand. Then, shuffle your deck.",
 				fr: "Une seule fois lors de votre tour (avant votre attaque), si vous avez Carchacrok en jeu, vous pouvez chercher une carte dans votre deck puis l’ajouter à votre main. Mélangez ensuite votre deck.",
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du, wenn du Knakrack im Spiel hast, dein Deck nach 1 Karte durchsuchen und sie auf deine Hand nehmen. Mische anschließend dein Deck."
 			},
 		},
 	],
@@ -46,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Missile Jab",
 				fr: "Coup Propulsé",
+				de: "Wieselflinke Gerade"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieser Attacke wird durch Resistenz nicht verändert."
 			},
 			damage: 70,
 
@@ -69,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "They can detect the species of a living being—and its emotions—from over half a mile away. They control auras and hunt their prey in packs.",
+		de: "Es kann aus 1 km Entfernung die Art und auch die Gefühle von Lebewesen erfassen. Es jagt im Rudel und manipuliert die Aura der Beute."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV23.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV23.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Rockruff",
 		fr: "Rocabot",
+		de: "Wuffels"
 	},
 	illustrator: "Masakazu Fukuda",
 	rarity: "Shiny rare",
@@ -31,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Surprise Attack",
 				fr: "Attaque Surprise",
+				de: "Überraschungsangriff"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this attack does nothing.",
 				fr: "Lancez une pièce. Si c’est pile, cette attaque ne fait rien.",
+				de: "Wirf 1 Münze. Bei Zahl hat diese Attacke keine Auswirkungen."
 			},
 			damage: 50,
 
@@ -54,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon has lived with people since times long ago. It can sense when its Trainer is in the dumps and will stick close by its Trainer's side.",
+		de: "Es lebte schon immer mit Menschen zusammen und kann spüren, wenn sein Trainer traurig ist. Es weicht dann nicht mehr von seiner Seite."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV24.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV24.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Buzzwole",
 		fr: "Mouscoto",
+		de: "Masskito"
 	},
 	illustrator: "Shin Nagasawa",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Sledgehammer",
 				fr: "Coup de Masse",
+				de: "Vorschlaghammer"
 			},
 			effect: {
 				en: "If your opponent has exactly 4 Prize cards remaining, this attack does 90 more damage.",
 				fr: "S’il reste exactement 4 cartes Récompense à votre adversaire, cette attaque inflige 90 dégâts supplémentaires.",
+				de: "Wenn dein Gegner genau 4 verbleibende Preiskarten hat, fügt diese Attacke 90 Schadenspunkte mehr zu."
 			},
 			damage: 30,
 
@@ -47,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Swing Around",
 				fr: "Balançoire",
+				de: "Gegenschwung"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Diese Attacke fügt 20 Schadenspunkte mehr pro Kopf zu."
 			},
 			damage: 80,
 
@@ -70,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "A mysterious life-form called an Ultra Beast. Witnesses saw it pulverize a dump truck with a single punch.",
+		de: "Eine rätselhafte Ultrabestie, die angeblich mit einem einzigen Schlag einen beladenen Laster pulverisieren kann."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV25.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV25.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Zorua",
 		fr: "Zorua",
+		de: "Zorua"
 	},
 	illustrator: "Saya Tsuruta",
 	rarity: "Shiny rare",
@@ -30,6 +31,7 @@ const card: Card = {
 			name: {
 				en: "Stampede",
 				fr: "Ruée",
+				de: "Zertrampeln"
 			},
 
 			damage: 10,
@@ -43,6 +45,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 20,
@@ -68,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "It changes so it looks like its foe, tricks it, and then uses that opportunity to flee.",
+		de: "Nicht selten überrumpelt es Gegner, indem es ihre Gestalt annimmt und den Überraschungseffekt zur Flucht nutzt."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV26.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV26.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Guzzlord",
 		fr: "Engloutyran",
+		de: "Schlingking"
 	},
 	illustrator: "Masakazu Fukuda",
 	rarity: "Shiny rare",
@@ -33,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Lord's Valley",
 				fr: "Vallée du Tyran",
+				de: "Tal des Königs"
 			},
 			effect: {
 				en: "If you have exactly 2, 4, or 6 Prize cards remaining, discard the top 10 cards of your deck.",
 				fr: "S’il vous reste exactement 2, 4 ou 6 cartes Récompense, défaussez les 10 cartes du dessus de votre deck.",
+				de: "Wenn du genau 2, 4 oder 6 verbleibende Preiskarten hast, lege die obersten 10 Karten deines Decks auf deinen Ablagestapel."
 			},
 			damage: 160,
 
@@ -61,6 +64,7 @@ const card: Card = {
 
 	description: {
 		en: "A dangerous Ultra Beast, it appears to be eating constantly, but for some reason its droppings have never been found.",
+		de: "Eine gefährliche Ultrabestie, die ununterbrochen mit Fressen beschäftigt zu sein scheint. Es wurden jedoch nie Exkremente gefunden."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV27.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV27.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Magnemite",
 		fr: "Magnéti",
+		de: "Magnetilo"
 	},
 	illustrator: "SATOSHI NAKAI",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Searching Magnet",
 				fr: "Aimant Inquisiteur",
+				de: "Suchmagnet"
 			},
 			effect: {
 				en: "Search your deck for up to 3 Metal Energy cards, reveal them, and put them into your hand. Then, shuffle your deck.",
 				fr: "Cherchez jusqu’à 3 cartes Énergie Metal dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach bis zu 3 {M}-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -44,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -69,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "It sends out electromagnetic waves, which let it float through the air. Touching it while it's eating electricity will give you a full-body shock.",
+		de: "Es sendet elektromagnetische Wellen aus und segelt durch die Luft. Berührt man es, während es Strom saugt, bekommt man einen Schlag."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV28.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV28.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Magneton",
 		fr: "Magnéton",
+		de: "Magneton"
 	},
 	illustrator: "Kyoko Umemoto",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magnemite",
 		fr: "Magnéti",
+		de: "Magnetilo"
 	},
 	stage: "Stage1",
 
@@ -33,6 +35,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 20,
@@ -47,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Zap Cannon",
 				fr: "Élecanon",
+				de: "Blitzkanone"
 			},
 			effect: {
 				en: "This Pokémon can't use Zap Cannon during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Élecanon pendant votre prochain tour.",
+				de: "Dieses Pokémon kann Blitzkanone während deines nächsten Zuges nicht einsetzen."
 			},
 			damage: 80,
 
@@ -75,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "It has about three times the electrical power of Magnemite. For some reason, outbreaks of this Pokémon happen when lots of sunspots appear.",
+		de: "Seine Stromstärke ist fast dreimal so hoch wie die eines Magnetilos. Es erscheint vermehrt, wenn Flecken auf der Sonne auftauchen."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV29.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV29.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Magnezone",
 		fr: "Magnézone",
+		de: "Magnezone"
 	},
 	illustrator: "Misa Tsutsui",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magneton",
 		fr: "Magnéton",
+		de: "Magneton"
 	},
 	stage: "Stage2",
 
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Magnetic Circuit",
 				fr: "Circuit Magnétique",
+				de: "Magnetischer Kreislauf"
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may attach a Metal Energy card from your hand to 1 of your Pokémon.",
 				fr: "Autant de fois que vous le voulez pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie Metal de votre main à l’un de vos Pokémon.",
+				de: "Beliebig oft während deines Zuges (bevor du angreifst) kannst du 1 {M}-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -48,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Zap Cannon",
 				fr: "Élecanon",
+				de: "Blitzkanone"
 			},
 			effect: {
 				en: "This Pokémon can't use Zap Cannon during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Élecanon pendant votre prochain tour.",
+				de: "Dieses Pokémon kann Blitzkanone während deines nächsten Zuges nicht einsetzen."
 			},
 			damage: 130,
 
@@ -76,6 +82,7 @@ const card: Card = {
 
 	description: {
 		en: "As it zooms through the sky, this Pokémon seems to be receiving signals of unknown origin, while transmitting signals of unknown purpose.",
+		de: "Es heißt, dass es beim Herumfliegen mysteriöse Funkwellen aussende und unbekannte empfange."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV3.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV3.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Dartrix",
 		fr: "Efflèche",
+		de: "Arboretoss"
 	},
 	illustrator: "Shigenori Negishi",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rowlet",
 		fr: "Brindibou",
+		de: "Bauz"
 	},
 	stage: "Stage1",
 
@@ -33,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Sharp Blade Quill",
 				fr: "Plum’acérée Tranchante",
+				de: "Scharfe Flügelklinge"
 			},
 			effect: {
 				en: "This attack does 20 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à l’un des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Diese Attacke fügt 1 Pokémon deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -49,10 +53,12 @@ const card: Card = {
 			name: {
 				en: "Leaf Blade",
 				fr: "Lame-Feuille",
+				de: "Laubklinge"
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 more damage.",
 				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts supplémentaires.",
+				de: "Wirf 1 Münze. Bei Kopf fügt diese Attacke 20 Schadenspunkte mehr zu."
 			},
 			damage: 50,
 
@@ -72,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "A bit of a dandy, it spends its free time preening its wings. Its preoccupation with any dirt on its plumage can leave it unable to battle.",
+		de: "Dieses affektierte Pokémon pflegt sein Gefieder, wann immer es kann. Mit verschmutzten Federn hat es nämlich oft keine Lust zu kämpfen."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV30.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV30.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Beldum",
 		fr: "Terhal",
+		de: "Tanhel"
 	},
 	illustrator: "Mizue",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Core Beam",
 				fr: "Faisceau Central",
+				de: "Kernstrahl"
 			},
 			effect: {
 				en: "Discard a Metal Energy from this Pokémon.",
 				fr: "Défaussez une Énergie Metal de ce Pokémon.",
+				de: "Lege 1 {M}-Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 20,
 
@@ -58,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "Its cells are all magnets. It uses magnetism to communicate with others of its kind.",
+		de: "Seine Zellen sind magnetisch geladen. Es kommuniziert mit anderen, indem es magnetische Impulse aussendet."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV31.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV31.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Metang",
 		fr: "Métang",
+		de: "Metang"
 	},
 	illustrator: "Saya Tsuruta",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Beldum",
 		fr: "Terhal",
+		de: "Tanhel"
 	},
 	stage: "Stage1",
 
@@ -33,6 +35,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 20,
@@ -47,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Core Beam",
 				fr: "Faisceau Central",
+				de: "Kernstrahl"
 			},
 			effect: {
 				en: "Discard a Metal Energy from this Pokémon.",
 				fr: "Défaussez une Énergie Metal de ce Pokémon.",
+				de: "Lege 1 {M}-Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -75,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "When two Beldum link together, their psychic power is doubled. Their intelligence, however, remains unchanged.",
+		de: "Zwei Tanhel haben sich vereinigt und so ihre Psycho-Kräfte verdoppelt. Ihre Denkfähigkeit bleibt dabei aber unverändert."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV32.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV32.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Celesteela",
 		fr: "Bamboiselle",
+		de: "Kaguron"
 	},
 	illustrator: "Kouki Saitou",
 	rarity: "Shiny rare",
@@ -34,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Moon Raker",
 				fr: "Ratissage Lunaire",
+				de: "Mondharke"
 			},
 			effect: {
 				en: "If the total of both players' remaining Prize cards is exactly 6, this attack can be used for Metal.",
 				fr: "S’il reste exactement 6 cartes Récompense aux deux joueurs réunis, cette attaque peut être utilisée pour Metal.",
+				de: "Wenn die Summe der verbleibenden Preiskarten beider Spieler genau 6 ist, kann diese Attacke für {M} eingesetzt werden."
 			},
 			damage: 160,
 
@@ -62,6 +65,7 @@ const card: Card = {
 
 	description: {
 		en: "One kind of Ultra Beast. Witnesses have seen it burn down a forest by expelling gas from its two arms.",
+		de: "Diese Ultrabestie wurde dabei gesichtet, wie sie mithilfe des Gases, das aus ihren beiden Armen strömt, große Waldflächen niederbrannte."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV33.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV33.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kartana",
 		fr: "Katagami",
+		de: "Katagami"
 	},
 	illustrator: "Anesaki Dynamic",
 	rarity: "Shiny rare",
@@ -31,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Divine Paper",
 				fr: "Papier Sublime",
+				de: "Himmelspapier"
 			},
 			effect: {
 				en: "If your opponent has exactly 6 Prize cards remaining, this attack does 90 more damage.",
 				fr: "S’il reste exactement 6 cartes Récompense à votre adversaire, cette attaque inflige 90 dégâts supplémentaires.",
+				de: "Wenn dein Gegner genau 6 verbleibende Preiskarten hat, fügt diese Attacke 90 Schadenspunkte mehr zu."
 			},
 			damage: 40,
 
@@ -59,6 +62,7 @@ const card: Card = {
 
 	description: {
 		en: "One of the Ultra Beast life-forms, it was observed cutting down a gigantic steel tower with one stroke of its blade.",
+		de: "Diese Ultrabestie wurde dabei beobachtet, wie sie einen riesigen stählernen Turm mit nur einem Hieb ihrer Klingen zerteilte."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV34.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV34.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ralts",
 		fr: "Tarsal",
+		de: "Trasla"
 	},
 	illustrator: "Kyoko Umemoto",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Draining Kiss",
 				fr: "Vampibaiser",
+				de: "Diebeskuss"
 			},
 			effect: {
 				en: "Heal 10 damage from this Pokémon.",
 				fr: "Soignez 10 dégâts à ce Pokémon.",
+				de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 10,
 
@@ -58,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "If its horns capture the warm feelings of people or Pokémon, its body warms up slightly.",
+		de: "Es erfasst warme Gefühle von Menschen und Pokémon mit seinen Hörnern und wärmt sich daran auf."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV35.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV35.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kirlia",
 		fr: "Kirlia",
+		de: "Kirlia"
 	},
 	illustrator: "Sumiyoshi Kizuki",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ralts",
 		fr: "Tarsal",
+		de: "Trasla"
 	},
 	stage: "Stage1",
 
@@ -33,6 +35,7 @@ const card: Card = {
 			name: {
 				en: "Smack",
 				fr: "Claque",
+				de: "Klatscher"
 			},
 
 			damage: 20,
@@ -46,6 +49,7 @@ const card: Card = {
 			name: {
 				en: "Magical Shot",
 				fr: "Coup Magique",
+				de: "Magischer Schuss"
 			},
 
 			damage: 30,
@@ -71,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "The cheerful spirit of its Trainer gives it energy for its psychokinetic power. It spins and dances when happy.",
+		de: "Die fröhliche Stimmung seines Trainers verleiht ihm Energie für psychokinetische Kraft. Wenn es glücklich ist, tanzt und dreht es sich."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV36.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV36.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Diancie",
 		fr: "Diancie",
+		de: "Diancie"
 	},
 	illustrator: "Akira Komayama",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Sparkling Wish",
 				fr: "Espoir Étincelant",
+				de: "Funkelnder Wunsch"
 			},
 			effect: {
 				en: "Search your deck for a card that evolves from 1 of your Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck.",
 				fr: "Cherchez dans votre deck une carte Évolution de l’un de vos Pokémon et placez-la sur ce dernier pour le faire évoluer. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 Karte, die sich aus 1 deiner Pokémon entwickelt, und lege sie auf jenes Pokémon, um es zu entwickeln. Mische anschließend dein Deck."
 			},
 
 		},
@@ -45,10 +48,12 @@ const card: Card = {
 			name: {
 				en: "Diamond Storm",
 				fr: "Orage Adamantin",
+				de: "Diamantsturm"
 			},
 			effect: {
 				en: "Heal 30 damage from each of your Fairy Pokémon.",
 				fr: "Soignez 30 dégâts à chacun de vos Pokémon Fairy.",
+				de: "Heile 30 Schadenspunkte bei jedem deiner {FAIRY}-Pokémon."
 			},
 			damage: 30,
 
@@ -73,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "A sudden transformation of Carbink, its pink, glimmering body is said to be the loveliest sight in the whole world.",
+		de: "Dieses Pokémon ist eine Mutation von Rocara. Sein rosafarben schimmernder Körper gilt als schönster Anblick überhaupt."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV37.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV37.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Altaria",
 		fr: "Altaria",
+		de: "Altaria"
 	},
 	illustrator: "kirisAki",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 	stage: "Stage1",
 
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Fight Song",
 				fr: "Hymne au Combat",
+				de: "Angriffsarie"
 			},
 			effect: {
 				en: "Your Dragon Pokémon's attacks do 20 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
 				fr: "Les attaques de vos Pokémon Dragon infligent 20 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
+				de: "Die Attacken deiner {N}-Pokémon fügen dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],
@@ -46,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Pierce",
 				fr: "Transpercement",
+				de: "Durchbohren"
 			},
 
 			damage: 20,
@@ -66,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "On sunny days, it flies freely through the sky and blends into the clouds. It sings in a beautiful soprano.",
+		de: "Bei gutem Wetter mischt es sich unter die Wolken und genießt die Freiheit. Es hat eine entzückende Sopranstimme."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV38.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV38.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gible",
 		fr: "Griknot",
+		de: "Kaumalat"
 	},
 	illustrator: "Saya Tsuruta",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Ascension",
 				fr: "Ascension",
+				de: "Aufstieg"
 			},
 			effect: {
 				en: "Search your deck for a card that evolves from this Pokémon and put it onto this Pokémon to evolve it. Then, shuffle your deck.",
 				fr: "Cherchez dans votre deck une carte Évolution de ce Pokémon et placez-la sur ce Pokémon pour le faire évoluer. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 Karte, die sich aus diesem Pokémon entwickelt, und lege sie auf dieses Pokémon, um es zu entwickeln. Mische anschließend dein Deck."
 			},
 
 		},
@@ -52,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It skulks in caves, and when prey or an enemy passes by, it leaps out and chomps them. The force of its attack sometimes chips its teeth.",
+		de: "Es verbirgt sich in kleinen Höhlen, aus denen es herausspringt und vorbeilaufende Gegner beißt. Manchmal bricht dabei ein Zahn ab."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV39.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV39.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gabite",
 		fr: "Carmache",
+		de: "Knarksel"
 	},
 	illustrator: "Masakazu Fukuda",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gible",
 		fr: "Griknot",
+		de: "Kaumalat"
 	},
 	stage: "Stage1",
 
@@ -33,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Ascension",
 				fr: "Ascension",
+				de: "Aufstieg"
 			},
 			effect: {
 				en: "Search your deck for a card that evolves from this Pokémon and put it onto this Pokémon to evolve it. Then, shuffle your deck.",
 				fr: "Cherchez dans votre deck une carte Évolution de ce Pokémon et placez-la sur ce Pokémon pour le faire évoluer. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach 1 Karte, die sich aus diesem Pokémon entwickelt, und lege sie auf dieses Pokémon, um es zu entwickeln. Mische anschließend dein Deck."
 			},
 
 		},
@@ -48,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 40,
@@ -68,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Shiny objects are its passion. It can be found in its cave, scarcely moving, its gaze fixed on the jewels it's amassed or Carbink it has caught.",
+		de: "Es liebt funkelnde Dinge. Edelsteine und gefangene Rocara nimmt es mit in sein Nest, um sich an ihrem Anblick zu weiden."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV4.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV4.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Wimpod",
 		fr: "Sovkipou",
+		de: "Reißlaus"
 	},
 	illustrator: "SATOSHI NAKAI",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Wimp Out",
 				fr: "Escampette",
+				de: "Reißaus"
 			},
 			effect: {
 				en: "During your first turn, this Pokémon has no Retreat Cost.",
 				fr: "Pendant votre premier tour, ce Pokémon n’a pas de Coût de Retraite.",
+				de: "Während deines ersten Zuges hat dieses Pokémon keine Rückzugskosten."
 			},
 		},
 	],
@@ -44,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				de: "Nagen"
 			},
 
 			damage: 30,
@@ -64,6 +68,7 @@ const card: Card = {
 
 	description: {
 		en: "This Pokémon is a coward. As it desperately dashes off, the flailing of its many legs leaves a sparkling clean path in its wake.",
+		de: "Es ist so feige, dass es wild mit seinen vielen Füßen herumschlägt und verzweifelt davonläuft. Nach seiner Flucht glänzt der Boden herrlich."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV40.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV40.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Garchomp",
 		fr: "Carchacrok",
+		de: "Knakrack"
 	},
 	illustrator: "Shin Nagasawa",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Gabite",
 		fr: "Carmache",
+		de: "Knarksel"
 	},
 	stage: "Stage2",
 
@@ -34,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Quick Dive",
 				fr: "Plongeon Rapide",
+				de: "Schnelltaucher"
 			},
 			effect: {
 				en: "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 50 dégâts à l’un des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Diese Attacke fügt 1 Pokémon deines Gegners 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -50,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Royal Blades",
 				fr: "Lames Royales",
+				de: "Königsklingen"
 			},
 			effect: {
 				en: "If you played Cynthia from your hand during this turn, this attack does 100 more damage.",
 				fr: "Si vous avez joué Cynthia de votre main pendant ce tour, cette attaque inflige 100 dégâts supplémentaires.",
+				de: "Wenn du Cynthia während dieses Zuges aus deiner Hand gespielt hast, fügt diese Attacke 100 Schadenspunkte mehr zu."
 			},
 			damage: 100,
 
@@ -73,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "The protuberances on its head serve as sensors. It can even detect distant prey.",
+		de: "Die beiden Fortsätze an seinem Kopf haben die Funktion eines Sensors. Mit ihnen kann es auch weit entfernte Beute aufspüren."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV41.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV41.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 	illustrator: "kirisAki",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Energy Evolution",
 				fr: "Évolution de l'Énergie",
+				de: "Energie-Evolution"
 			},
 			effect: {
 				en: "When you attach a basic Energy card from your hand to this Pokémon during your turn, you may search your deck for a card that evolves from this Pokémon that is the same type as that Energy card and put it onto this Pokémon to evolve it. Then, shuffle your deck.",
 				fr: "Lorsque vous attachez pendant votre tour une carte Énergie de base de votre main à ce Pokémon, vous pouvez chercher dans votre deck une carte qui est l’évolution de ce Pokémon et du même type que cette carte Énergie. Mettez-la sur ce Pokémon pour le faire évoluer. Mélangez ensuite votre deck.",
+				de: "Wenn du während deines Zuges 1 Basis-Energiekarte aus deiner Hand an dieses Pokémon anlegst, kannst du dein Deck nach 1 Karte, die sich aus diesem Pokémon entwickelt und die denselben Typ wie jene Energiekarte hat, durchsuchen und sie auf dieses Pokémon legen, um es zu entwickeln. Mische anschließend dein Deck."
 			},
 		},
 	],
@@ -42,10 +45,12 @@ const card: Card = {
 			name: {
 				en: "Quick Draw",
 				fr: "Pioche Rapide",
+				de: "Schnellzieher"
 			},
 			effect: {
 				en: "Flip a coin. If heads, draw a card.",
 				fr: "Lancez une pièce. Si c’est face, piochez une carte.",
+				de: "Wirf 1 Münze. Ziehe bei Kopf 1 Karte."
 			},
 
 		},
@@ -64,6 +69,7 @@ const card: Card = {
 
 	description: {
 		en: "Current studies show it can evolve into an incredible eight different species of Pokémon.",
+		de: "Sein instabiles Erbmaterial ermöglicht es ihm, sich zu verschiedenen Pokémon zu entwickeln."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV42.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV42.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 	illustrator: "Shigenori Negishi",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Collect",
 				fr: "Collecte",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw a card.",
 				fr: "Piochez une carte.",
+				de: "Ziehe 1 Karte."
 			},
 
 		},
@@ -45,6 +48,7 @@ const card: Card = {
 			name: {
 				en: "Peck",
 				fr: "Picpic",
+				de: "Schnabel"
 			},
 
 			damage: 20,
@@ -70,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It constantly grooms its cotton-like wings. It takes a shower to clean itself if it becomes dirty.",
+		de: "Ständig pflegt es seine watteartigen Flügel. Falls es schmutzig wird, nimmt es eine Dusche, um sich zu putzen."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV43.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV43.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Noibat",
 		fr: "Sonistrelle",
+		de: "eF-eM"
 	},
 	illustrator: "Mizue",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Agility",
 				fr: "Hâte",
+				de: "Agilität"
 			},
 			effect: {
 				en: "Flip a coin. If heads, prevent all effects of attacks, including damage, done to this Pokémon during your opponent's next turn.",
 				fr: "Lancez une pièce. Si c’est face, évitez tous les effets d’attaques, y compris les dégâts, infligés à ce Pokémon pendant le prochain tour de votre adversaire.",
+				de: "Wirf 1 Münze. Verhindere bei Kopf während des nächsten Zuges deines Gegners alle Effekte von Attacken, einschließlich Schaden, die diesem Pokémon zugefügt werden."
 			},
 			damage: 10,
 
@@ -58,6 +61,7 @@ const card: Card = {
 
 	description: {
 		en: "They live in pitch black caves. Their enormous ears can emit ultrasonic waves of 200,000 hertz.",
+		de: "Es lebt im Inneren pechschwarzer Höhlen. Seine riesigen Ohren setzen Ultraschallwellen von 200 000 Hz frei."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV44.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV44.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Oranguru",
 		fr: "Gouroutan",
+		de: "Kommandutan"
 	},
 	illustrator: "Akira Komayama",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Instruct",
 				fr: "Sommation",
+				de: "Kommando"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may draw cards until you have 3 cards in your hand.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez piocher des cartes jusqu’à ce que vous ayez 3 cartes en main.",
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du so lange Karten ziehen, bis du 3 Karten auf deiner Hand hast."
 			},
 		},
 	],
@@ -44,10 +47,12 @@ const card: Card = {
 			name: {
 				en: "Psychic",
 				fr: "Psyko",
+				de: "Psychokinese"
 			},
 			effect: {
 				en: "This attack does 20 more damage times the amount of Energy attached to your opponent's Active Pokémon.",
 				fr: "Cette attaque inflige 20 dégâts supplémentaires multipliés par le nombre d’Énergies attachées au Pokémon Actif de votre adversaire.",
+				de: "Diese Attacke fügt 20 Schadenspunkte mehr mal der Anzahl der an das Aktive Pokémon deines Gegners angelegten Energien zu."
 			},
 			damage: 60,
 
@@ -67,6 +72,7 @@ const card: Card = {
 
 	description: {
 		en: "Deep in the jungle, high in the lofty canopy, this Pokémon abides. On rare occasions, it shows up at the beach to match wits with Slowking.",
+		de: "Lebt auf Baumwipfeln im tiefsten Dschungel. Ab und an erscheint es am Strand, um sich epische Quiz-Duelle mit Laschoking zu liefern."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV45.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV45.ts
@@ -6,6 +6,7 @@ const card: Card = {
 	name: {
 		en: "Type: Null",
 		fr: "Type:0",
+		de: "Typ:Null"
 	},
 	illustrator: "Shin Nagasawa",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Armor Press",
 				fr: "Pression Cuirassée",
+				de: "Panzerpresse"
 			},
 			effect: {
 				en: "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit 30 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 30,
 
@@ -47,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Slashing Claw",
 				fr: "Griffe Taillante",
+				de: "Schlitzende Klaue"
 			},
 
 			damage: 70,
@@ -67,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "The heavy control mask it wears suppresses its intrinsic capabilities. This Pokémon has some hidden special power.",
+		de: "Seine schwere Maske unterdrückt seine wahre Macht. In ihm schlummern nämlich besondere Kräfte."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV46.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV46.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Leafeon-GX",
 		fr: "Phyllali-GX",
+		de: "Folipurba-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Breath of the Leaves",
 				fr: "Souffle du Feuillage",
+				de: "Atem der Blätter"
 			},
 			effect: {
 				en: "If this Pokémon is your Active Pokémon, once during your turn (before your attack), you may heal 50 damage from 1 of your Pokémon that has any Energy attached to it.",
 				fr: "Si ce Pokémon est votre Pokémon Actif, une seule fois pendant votre tour (avant votre attaque), vous pouvez soigner 50 dégâts à l’un de vos Pokémon auquel de l’Énergie est attachée.",
+				de: "Wenn dieses Pokémon dein Aktives Pokémon ist, kannst du einmal während deines Zuges (bevor du angreifst) 50 Schadenspunkte bei 1 deiner Pokémon heilen, an das mindestens 1 Energie angelegt ist."
 			},
 		},
 	],
@@ -47,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Solar Beam",
 				fr: "Lance-Soleil",
+				de: "Solarstrahl"
 			},
 
 			damage: 110,
@@ -59,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Grand Bloom-GX",
 				fr: "Efflorescence-GX",
+				de: "Blütezeit-GX"
 			},
 			effect: {
 				en: "For each of your Benched Basic Pokémon, search your deck for a card that evolves from that Pokémon and put it onto that Pokémon to evolve it. Then, shuffle your deck. (You can't use more than 1 GX attack in a game.)",
 				fr: "Pour chacun de vos Pokémon de Banc de base, cherchez dans votre deck une carte Évolution de ce Pokémon et placez-la sur ce Pokémon pour le faire évoluer. Mélangez ensuite votre deck. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Durchsuche pro Basis-Pokémon auf deiner Bank dein Deck nach 1 Karte, die sich aus jenem Pokémon entwickelt, und lege sie auf jenes Pokémon, um es zu entwickeln. Mische anschließend dein Deck. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV47.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV47.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Decidueye-GX",
 		fr: "Archéduc-GX",
+		de: "Silvarro-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Dartrix",
 		fr: "Efflèche",
+		de: "Arboretoss"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Feather Arrow",
 				fr: "Flèche Empennée",
+				de: "Federpfeil"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may put 2 damage counters on 1 of your opponent's Pokémon.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez placer 2 marqueurs de dégâts sur l’un des Pokémon de votre adversaire.",
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 2 Schadensmarken auf 1 Pokémon deines Gegners legen."
 			},
 		},
 	],
@@ -47,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Razor Leaf",
 				fr: "Tranch’Herbe",
+				de: "Rasierblatt"
 			},
 
 			damage: 90,
@@ -59,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Hollow Hunt-GX",
 				fr: "Chasse Éthérée-GX",
+				de: "Pirschjagd GX"
 			},
 			effect: {
 				en: "Put 3 cards from your discard pile into your hand. (You can't use more than 1 GX attack in a game.)",
 				fr: "Prenez 3 cartes dans votre pile de défausse et ajoutez-les à votre main. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Nimm 3 Karten aus deinem Ablagestapel auf deine Hand. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV48.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV48.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Golisopod-GX",
 		fr: "Sarmuraï-GX",
+		de: "Tectass-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Wimpod",
 		fr: "Sovkipou",
+		de: "Reißlaus"
 	},
 
 	suffix: "GX",
@@ -33,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "First Impression",
 				fr: "Escarmouche",
+				de: "Überrumpler"
 			},
 			effect: {
 				en: "If this Pokémon was on the Bench and became your Active Pokémon this turn, this attack does 90 more damage.",
 				fr: "Si ce Pokémon était sur le Banc et est devenu votre Pokémon Actif pendant ce tour, cette attaque inflige 90 dégâts supplémentaires.",
+				de: "Wenn dieses Pokémon auf der Bank war und in diesem Zug zu deinem Aktiven Pokémon wurde, fügt diese Attacke 90 Schadenspunkte mehr zu."
 			},
 			damage: 30,
 
@@ -50,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Armor Press",
 				fr: "Pression Cuirassée",
+				de: "Panzerpresse"
 			},
 			effect: {
 				en: "During your opponent's next turn, this Pokémon takes 20 less damage from attacks (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit 20 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 20 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 100,
 
@@ -67,10 +73,12 @@ const card: Card = {
 			name: {
 				en: "Crossing Cut-GX",
 				fr: "Coupe Croisée-GX",
+				de: "Quertreiber-GX"
 			},
 			effect: {
 				en: "Switch this Pokémon with 1 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Échangez ce Pokémon avec l’un de vos Pokémon de Banc. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Tausche dieses Pokémon gegen 1 Pokémon auf deiner Bank aus. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 150,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV49.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV49.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charizard-GX",
 		fr: "Dracaufeu-GX",
+		de: "Glurak-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmeleon",
 		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	suffix: "GX",
@@ -35,6 +37,7 @@ const card: Card = {
 			name: {
 				en: "Wing Attack",
 				fr: "Cru-Aile",
+				de: "Flügelschlag"
 			},
 
 			damage: 70,
@@ -51,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Crimson Storm",
 				fr: "Tempête Écarlate",
+				de: "Feuerroter Sturm"
 			},
 			effect: {
 				en: "Discard 3 Fire Energy from this Pokémon.",
 				fr: "Défaussez 3 Énergies Fire de ce Pokémon.",
+				de: "Lege 3 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 300,
 
@@ -68,10 +73,12 @@ const card: Card = {
 			name: {
 				en: "Raging Out-GX",
 				fr: "Déchaînement Furieux-GX",
+				de: "Tobsuchtsanfall-GX"
 			},
 			effect: {
 				en: "Discard the top 10 cards of your opponent's deck. (You can't use more than 1 GX attack in a game.)",
 				fr: "Défaussez les 10 cartes du dessus du deck de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Lege die obersten 10 Karten des Decks deines Gegners auf seinen Ablagestapel. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV5.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV5.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pheromosa",
 		fr: "Cancrelove",
+		de: "Schabelle"
 	},
 	illustrator: "Mizue",
 	rarity: "Shiny rare",
@@ -30,6 +31,7 @@ const card: Card = {
 			name: {
 				en: "High Jump Kick",
 				fr: "Pied Voltige",
+				de: "Turmkick"
 			},
 
 			damage: 20,
@@ -44,10 +46,12 @@ const card: Card = {
 			name: {
 				en: "White Ray",
 				fr: "Rayon Blanc",
+				de: "Weißer Strahl"
 			},
 			effect: {
 				en: "If you have only 1 Prize card remaining, this attack does 90 more damage.",
 				fr: "S’il vous reste exactement 1 carte Récompense, cette attaque inflige 90 dégâts supplémentaires.",
+				de: "Wenn du genau 1 verbleibende Preiskarte hast, fügt diese Attacke 90 Schadenspunkte mehr zu."
 			},
 			damage: 90,
 
@@ -67,6 +71,7 @@ const card: Card = {
 
 	description: {
 		en: "One of the Ultra Beasts. It refuses to touch anything, perhaps because it senses some uncleanness in this world.",
+		de: "Diese Ultrabestie scheint diese Welt für unrein zu halten und zieht es daher vor, mit nichts und niemandem in Berührung zu kommen."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV50.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV50.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ho-Oh-GX",
 		fr: "Ho-Oh-GX",
+		de: "Ho-Oh-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Sacred Fire",
 				fr: "Feu Sacré",
+				de: "Läuterfeuer"
 			},
 			effect: {
 				en: "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 50 dégâts à l’un des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Diese Attacke fügt 1 Pokémon deines Gegners 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -49,10 +52,12 @@ const card: Card = {
 			name: {
 				en: "Phoenix Burn",
 				fr: "Éclat du Phénix",
+				de: "Phönix-Brand"
 			},
 			effect: {
 				en: "This Pokémon can't use Phoenix Burn during your next turn.",
 				fr: "Ce Pokémon ne peut pas utiliser Éclat du Phénix pendant votre prochain tour.",
+				de: "Dieses Pokémon kann Phönix-Brand während deines nächsten Zuges nicht einsetzen."
 			},
 			damage: 180,
 
@@ -66,10 +71,12 @@ const card: Card = {
 			name: {
 				en: "Eternal Flame-GX",
 				fr: "Flamme Éternelle-GX",
+				de: "Ewige Flamme-GX"
 			},
 			effect: {
 				en: "Put 3 in any combination of Fire Pokémon-GX or Fire Pokémon-EX from your discard pile onto your Bench. (You can't use more than 1 GX attack in a game.)",
 				fr: "Ajoutez de votre pile de défausse à votre Banc une combinaison de 3 cartes choisies parmi des Pokémon-GX Fire et des Pokémon-EX Fire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Lege eine beliebige Kombination aus 3 {R}-Pokémon-GX oder {R}-Pokémon-EX aus deinem Ablagestapel auf deine Bank. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV51.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV51.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Reshiram-GX",
 		fr: "Reshiram-GX",
+		de: "Reshiram-GX"
 	},
 	illustrator: "PLANETA Igarashi",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Flame Charge",
 				fr: "Nitrocharge",
+				de: "Nitroladung"
 			},
 			effect: {
 				en: "Search your deck for up to 2 Fire Energy cards and attach them to this Pokémon. Then, shuffle your deck.",
 				fr: "Cherchez jusqu’à 2 cartes Énergie Fire dans votre deck et attachez-les à ce Pokémon. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach bis zu 2 {R}-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -47,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Scorching Column",
 				fr: "Colonne Torride",
+				de: "Versengende Säule"
 			},
 			effect: {
 				en: "Your opponent's Active Pokémon is now Burned.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Brûlé.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt verbrannt."
 			},
 			damage: 110,
 
@@ -65,10 +70,12 @@ const card: Card = {
 			name: {
 				en: "Vermilion-GX",
 				fr: "Vermillon-GX",
+				de: "Zinnober-GX"
 			},
 			effect: {
 				en: "You may attach up to 5 Fire Energy cards from your hand to your Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)",
 				fr: "Vous pouvez attacher jusqu’à 5 cartes Énergie Fire de votre main à vos Pokémon, de la manière que vous voulez. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Du kannst bis zu 5 {R}-Energiekarten aus deiner Hand beliebig an deine Pokémon anlegen. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 180,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV52.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV52.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Turtonator-GX",
 		fr: "Boumata-GX",
+		de: "Tortunator-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -31,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Shell Trap",
 				fr: "Carapiège",
+				de: "Panzerfalle"
 			},
 			effect: {
 				en: "During your opponent's next turn, if this Pokémon is damaged by an attack (even if this Pokémon is Knocked Out), put 8 damage counters on the Attacking Pokémon.",
 				fr: "Pendant le prochain tour de votre adversaire, si ce Pokémon subit les dégâts d’une attaque (même si ce Pokémon est mis K.O.), placez 8 marqueurs de dégâts sur le Pokémon Attaquant.",
+				de: "Wenn diesem Pokémon während des nächsten Zuges deines Gegners durch eine Attacke Schaden zugefügt wird (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 8 Schadensmarken auf das Angreifende Pokémon."
 			},
 			damage: 20,
 
@@ -48,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Bright Flame",
 				fr: "Flamme Éclatante",
+				de: "Helle Flamme"
 			},
 			effect: {
 				en: "Discard 2 Fire Energy from this Pokémon.",
 				fr: "Défaussez 2 Énergies Fire de ce Pokémon.",
+				de: "Lege 2 {R}-Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 160,
 
@@ -63,10 +68,12 @@ const card: Card = {
 			name: {
 				en: "Nitro Tank-GX",
 				fr: "Réservoir Nitro-GX",
+				de: "Nitrotank-GX"
 			},
 			effect: {
 				en: "Attach 5 Fire Energy cards from your discard pile to your Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)",
 				fr: "Attachez 5 cartes Énergie Fire de votre pile de défausse à vos Pokémon, de la manière que vous voulez. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Lege 5 {R}-Energiekarten aus deinem Ablagestapel beliebig an deine Pokémon an. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV53.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV53.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Alolan Ninetales-GX",
 		fr: "Feunard d’Alola-GX",
+		de: "Alola-Vulnona-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Alolan Vulpix",
 		fr: "Goupix d’Alola",
+		de: "Alola-Vulpix"
 	},
 
 	suffix: "GX",
@@ -34,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Ice Blade",
 				fr: "Lame de Glace",
+				de: "Eisklinge"
 			},
 			effect: {
 				en: "This attack does 50 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 50 dégâts à l’un des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Diese Attacke fügt 1 Pokémon deines Gegners 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -50,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Blizzard Edge",
 				fr: "Lame Tempête",
+				de: "Blizzardklinge"
 			},
 			effect: {
 				en: "Discard 2 Energy from this Pokémon.",
 				fr: "Défaussez 2 Énergies de ce Pokémon.",
+				de: "Lege 2 Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 160,
 
@@ -66,10 +72,12 @@ const card: Card = {
 			name: {
 				en: "Ice Path-GX",
 				fr: "Route Verglacée-GX",
+				de: "Eisiger Pfad GX"
 			},
 			effect: {
 				en: "Move all damage counters from this Pokémon to your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Déplacez tous les marqueurs de dégâts de ce Pokémon vers le Pokémon Actif de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Verschiebe alle Schadensmarken von diesem Pokémon auf das Aktive Pokémon deines Gegners. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV54.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV54.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Articuno-GX",
 		fr: "Artikodin-GX",
+		de: "Arktos-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Legendary Ascent",
 				fr: "Ascension Légendaire",
+				de: "Legendärer Aufstieg"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand onto your Bench during your turn, you may switch it with your Active Pokémon. If you do, move any number of Water Energy from your other Pokémon to this Pokémon.",
 				fr: "Lorsque vous jouez ce Pokémon de votre main sur votre Banc pendant votre tour, vous pouvez l’échanger avec votre Pokémon Actif. Dans ce cas, déplacez autant d’Énergies Water que vous voulez de vos autres Pokémon vers ce Pokémon.",
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du es gegen dein Aktives Pokémon austauschen. Wenn du das machst, verschiebe beliebig viele {W}-Energien von deinen anderen Pokémon auf dieses Pokémon."
 			},
 		},
 	],
@@ -44,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Ice Wing",
 				fr: "Aile Glace",
+				de: "Frostschwinge"
 			},
 
 			damage: 130,
@@ -56,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Cold Crush-GX",
 				fr: "Écraser Net-GX",
+				de: "Eiskalt zerquetscht-GX"
 			},
 			effect: {
 				en: "Discard all Energy from both Active Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Défaussez toute l’Énergie des deux Pokémon Actifs. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Lege alle Energien von beiden Aktiven Pokémon auf den Ablagestapel. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV55.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV55.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Glaceon-GX",
 		fr: "Givrali-GX",
+		de: "Glaziola-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Freezing Gaze",
 				fr: "Regard Glacial",
+				de: "Gefrierblick"
 			},
 			effect: {
 				en: "As long as this Pokémon is your Active Pokémon, your opponent's Pokémon-GX and Pokémon-EX in play, in their hand, and in their discard pile have no Abilities, except for Freezing Gaze.",
 				fr: "Tant que ce Pokémon est votre Pokémon Actif, les Pokémon-GX et les Pokémon-EX de votre adversaire en jeu, dans sa main et dans sa pile de défausse n’ont pas de talent, à l’exception de Regard Glacial.",
+				de: "Solang dieses Pokémon dein Aktives Pokémon ist, haben die Pokémon-GX und Pokémon-EX deines Gegners im Spiel, auf seiner Hand und in seinem Ablagestapel keine Fähigkeiten, außer Gefrierblick."
 			},
 		},
 	],
@@ -47,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Frost Bullet",
 				fr: "Kunaï Givré",
+				de: "Frostprojektil"
 			},
 			effect: {
 				en: "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 30 dégâts à l’un des Pokémon de Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Diese Attacke fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 90,
 
@@ -64,10 +70,12 @@ const card: Card = {
 			name: {
 				en: "Polar Spear-GX",
 				fr: "Lance Polaire-GX",
+				de: "Polarspeer-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each damage counter on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 50 dégâts pour chaque marqueur de dégâts placé sur le Pokémon Actif de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der Schadensmarken auf dem Aktiven Pokémon deines Gegners zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 50,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV56.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV56.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Greninja-GX",
 		fr: "Amphinobi-GX",
+		de: "Quajutsu-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Frogadier",
 		fr: "Croâporal",
+		de: "Amphizel"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Shuriken Flurry",
 				fr: "Rafale de Shuriken",
+				de: "Shurikenschauer"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may put 3 damage counters on 1 of your opponent's Pokémon.",
 				fr: "Lorsque vous jouez ce Pokémon de votre main pour faire évoluer l’un de vos Pokémon pendant votre tour, vous pouvez placer 3 marqueurs de dégâts sur l’un des Pokémon de votre adversaire.",
+				de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du 3 Schadensmarken auf 1 Pokémon deines Gegners legen."
 			},
 		},
 	],
@@ -47,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Haze Slash",
 				fr: "Brouillard Lacérant",
+				de: "Dunstschlitzer"
 			},
 			effect: {
 				en: "You may shuffle this Pokémon and all cards attached to it into your deck.",
 				fr: "Vous pouvez mélanger ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck.",
+				de: "Du kannst dieses Pokémon und alle an es angelegten Karten in dein Deck mischen."
 			},
 			damage: 110,
 
@@ -64,10 +70,12 @@ const card: Card = {
 			name: {
 				en: "Shadowy Hunter-GX",
 				fr: "Chasseur Tapi-GX",
+				de: "Verborgener Jäger-GX"
 			},
 			effect: {
 				en: "This attack does 130 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 130 dégâts à l’un des Pokémon de Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt 1 Pokémon auf der Bank deines Gegners 130 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV57.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV57.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Electrode-GX",
 		fr: "Électrode-GX",
+		de: "Lektrobal-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Voltorb",
 		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Extra Energy Bomb",
 				fr: "Bombe Extra-Énergétique",
+				de: "Extra Energiebombe"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may attach 5 Energy cards from your discard pile to your Pokémon, except Pokémon-GX or Pokémon-EX, in any way you like. If you do, this Pokémon is Knocked Out.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher 5 cartes Énergie de votre pile de défausse à vos Pokémon, à l’exception des Pokémon-GX et Pokémon-EX, de la manière que vous voulez. Dans ce cas, ce Pokémon est mis K.O.",
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 5 Energiekarten aus deinem Ablagestapel beliebig an deine Pokémon, außer Pokémon-GX oder Pokémon-EX, anlegen. Wenn du das machst, ist dieses Pokémon kampfunfähig."
 			},
 		},
 	],
@@ -46,6 +50,7 @@ const card: Card = {
 			name: {
 				en: "Electro Ball",
 				fr: "Boule Élek",
+				de: "Elektroball"
 			},
 
 			damage: 50,
@@ -59,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Crush and Burn-GX",
 				fr: "Écra-Brûle-GX",
+				de: "Falten und Frittieren-GX"
 			},
 			effect: {
 				en: "Discard any amount of Energy from your Pokémon. This attack does 50 more damage for each card you discarded in this way. (You can't use more than 1 GX attack in a game.)",
 				fr: "Défaussez n’importe quel nombre d’Énergies de vos Pokémon. Cette attaque inflige 50 dégâts supplémentaires pour chaque carte défaussée de cette façon. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Lege beliebig viele Energien von deinen Pokémon auf deinen Ablagestapel. Diese Attacke fügt 50 Schadenspunkte mehr mal der Anzahl der auf diese Weise auf deinen Ablagestapel gelegten Karten zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 30,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV58.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV58.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Xurkitree-GX",
 		fr: "Câblifère-GX",
+		de: "Voltriant-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Flashing Head",
 				fr: "Tête Clignotante",
+				de: "Leuchtender Kopf"
 			},
 			effect: {
 				en: "Prevent all damage done to this Pokémon by attacks from your opponent's Pokémon that have any Special Energy attached to them.",
 				fr: "Évitez tous les dégâts d’attaque infligés à ce Pokémon par les Pokémon de votre adversaire auxquels est attachée de l’Énergie spéciale.",
+				de: "Verhindere allen Schaden, der diesem Pokémon durch Attacken von Pokémon deines Gegners, an die mindestens 1 Spezial-Energie angelegt ist, zugefügt wird."
 			},
 		},
 	],
@@ -44,10 +47,12 @@ const card: Card = {
 			name: {
 				en: "Rumbling Wires",
 				fr: "Câbles Grondants",
+				de: "Rumpelnde Kabel"
 			},
 			effect: {
 				en: "Discard the top card of your opponent's deck.",
 				fr: "Défaussez la carte du dessus du deck de votre adversaire.",
+				de: "Lege die oberste Karte vom Deck deines Gegners auf seinen Ablagestapel."
 			},
 			damage: 100,
 
@@ -59,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Lighting-GX",
 				fr: "Éclair-GX",
+				de: "Beleuchten-GX"
 			},
 			effect: {
 				en: "Your opponent reveals their hand. Add a card you find there to their Prize cards face down. (You can't use more than 1 GX attack in a game.)",
 				fr: "Votre adversaire dévoile sa main. Ajoutez une des cartes que vous y trouvez à ses cartes Récompense, face cachée. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Dein Gegner zeigt dir seine Handkarten. Füge 1 Karte, die du dort findest, verdeckt seinen Preiskarten hinzu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV59.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV59.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mewtwo-GX",
 		fr: "Mewtwo-GX",
+		de: "Mewtu-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Full Burst",
 				fr: "Pleine Puissance",
+				de: "Vollkraft"
 			},
 			effect: {
 				en: "This attack does 30 damage times the amount of Energy attached to this Pokémon.",
 				fr: "Cette attaque inflige 30 dégâts multipliés par le nombre d’Énergies attachées à ce Pokémon.",
+				de: "Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der an dieses Pokémon angelegten Energien zu."
 			},
 			damage: 30,
 
@@ -46,10 +49,12 @@ const card: Card = {
 			name: {
 				en: "Super Absorption",
 				fr: "Super Absorption",
+				de: "Super-Absorber"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 60,
 
@@ -63,10 +68,12 @@ const card: Card = {
 			name: {
 				en: "Psystrike-GX",
 				fr: "Frappe Psy-GX",
+				de: "Psychostoß-GX"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by any effects on your opponent's Active Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Actif de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Der Schaden dieser Attacke wird durch Effekte auf dem Aktiven Pokémon deines Gegners nicht verändert. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 200,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV6.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV6.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charmander",
 		fr: "Salamèche",
+		de: "Glumanda"
 	},
 	illustrator: "kirisAki",
 	rarity: "Shiny rare",
@@ -31,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Fire Fang",
 				fr: "Crocs Feu",
+				de: "Feuerzahn"
 			},
 			effect: {
 				en: "Your opponent's Active Pokémon is now Burned.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Brûlé.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt verbrannt."
 			},
 			damage: 20,
 
@@ -54,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "From the time it is born, a flame burns at the tip of its tail. Its life would end if the flame were to go out.",
+		de: "Von Geburt an brennt die Flamme auf seiner Schwanzspitze. Sobald sie erlischt, erlischt auch sein Lebenslicht."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV60.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV60.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Espeon-GX",
 		fr: "Mentali-GX",
+		de: "Psiana-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -33,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Psybeam",
 				fr: "Rafale Psy",
+				de: "Psystrahl"
 			},
 			effect: {
 				en: "Your opponent's Active Pokémon is now Confused.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
 			},
 			damage: 30,
 
@@ -50,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Psychic",
 				fr: "Psyko",
+				de: "Psychokinese"
 			},
 			effect: {
 				en: "This attack does 30 more damage times the amount of Energy attached to your opponent's Active Pokémon.",
 				fr: "Cette attaque inflige 30 dégâts supplémentaires multipliés par le nombre d’Énergies attachées au Pokémon Actif de votre adversaire.",
+				de: "Diese Attacke fügt 30 Schadenspunkte mehr mal der Anzahl der an das Aktive Pokémon deines Gegners angelegten Energien zu."
 			},
 			damage: 60,
 
@@ -67,10 +73,12 @@ const card: Card = {
 			name: {
 				en: "Divide-GX",
 				fr: "Scission-GX",
+				de: "Division GX"
 			},
 			effect: {
 				en: "Put 10 damage counters on your opponent's Pokémon in any way you like. (You can't use more than 1 GX attack in a game.)",
 				fr: "Placez 10 marqueurs de dégâts sur les Pokémon de votre adversaire, de la manière que vous voulez. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Verteile 10 Schadensmarken beliebig auf die Pokémon deines Gegners. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV61.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV61.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Banette-GX",
 		fr: "Branette-GX",
+		de: "Banette-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Shuppet",
 		fr: "Polichombr",
+		de: "Shuppet"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Shady Move",
 				fr: "Déplacement Louche",
+				de: "Zwielichtige Aktion"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if this Pokémon is your Active Pokémon, you may move 1 damage counter from 1 Pokémon to another Pokémon.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si ce Pokémon est votre Pokémon Actif, vous pouvez déplacer un marqueur de dégâts d’un Pokémon vers un autre Pokémon.",
+				de: "Einmal während deines Zuges (bevor du angreifst), wenn dieses Pokémon dein Aktives Pokémon ist, kannst du 1 Schadensmarke von 1 Pokémon auf 1 anderes Pokémon verschieben."
 			},
 		},
 	],
@@ -45,10 +49,12 @@ const card: Card = {
 			name: {
 				en: "Shadow Chant",
 				fr: "Chant d’Ombre",
+				de: "Schattengesang"
 			},
 			effect: {
 				en: "This attack does 10 more damage for each Supporter card in your discard pile. You can't add more than 100 damage in this way.",
 				fr: "Cette attaque inflige 10 dégâts supplémentaires pour chaque carte Supporter dans votre pile de défausse. Vous ne pouvez pas ajouter plus de 100 dégâts de cette façon.",
+				de: "Diese Attacke fügt 10 Schadenspunkte mehr mal der Anzahl der Unterstützerkarten in deinem Ablagestapel zu. Du kannst auf diese Weise höchstens 100 Schadenspunkte mehr zufügen."
 			},
 			damage: 30,
 
@@ -60,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Tomb Hunt-GX",
 				fr: "Chasse Sépulcre-GX",
+				de: "Grabjagd-GX"
 			},
 			effect: {
 				en: "Put 3 cards from your discard pile into your hand. (You can't use more than 1 GX attack in a game.)",
 				fr: "Prenez 3 cartes dans votre pile de défausse et ajoutez-les à votre main. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Nimm 3 Karten aus deinem Ablagestapel auf deine Hand. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV62.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV62.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Nihilego-GX",
 		fr: "Zéroïd-GX",
+		de: "Anego-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Empty Light",
 				fr: "Lumière Vide",
+				de: "Licht der Leere"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand onto your Bench during your turn, you may leave both Active Pokémon Confused and Poisoned.",
 				fr: "Lorsque vous jouez ce Pokémon de votre main sur votre Banc pendant votre tour, vous pouvez laisser les deux Pokémon Actifs Confus et Empoisonnés.",
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du beide Aktiven Pokémon verwirren und vergiften."
 			},
 		},
 	],
@@ -44,10 +47,12 @@ const card: Card = {
 			name: {
 				en: "Lock Up",
 				fr: "Cage",
+				de: "Einsperren"
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
 				fr: "Le Pokémon Défenseur ne peut pas battre en retraite pendant le prochain tour de votre adversaire.",
+				de: "Das Verteidigende Pokémon kann sich während des nächsten Zuges deines Gegners nicht zurückziehen."
 			},
 			damage: 120,
 
@@ -61,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Symbiont-GX",
 				fr: "Parasite-GX",
+				de: "Schmarotzer-GX"
 			},
 			effect: {
 				en: "Add the top 2 cards of your opponent's deck to their Prize cards. (You can't use more than 1 GX attack in a game.)",
 				fr: "Ajoutez les 2 cartes du dessus du deck de votre adversaire à ses cartes Récompense. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Füge die obersten 2 Karten des Decks deines Gegners seinen Preiskarten hinzu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV63.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV63.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Naganadel-GX",
 		fr: "Mandrillon-GX",
+		de: "Agoyon-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Poipole",
 		fr: "Vémini",
+		de: "Venicro"
 	},
 
 	suffix: "GX",
@@ -33,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Beast Raid",
 				fr: "Raid Chimérique",
+				de: "Bestien-Raubzug"
 			},
 			effect: {
 				en: "This attack does 20 damage for each of your Ultra Beasts in play.",
 				fr: "Cette attaque inflige 20 dégâts pour chacune de vos Ultra-Chimères en jeu.",
+				de: "Diese Attacke fügt 20 Schadenspunkte mal der Anzahl deiner Ultrabestien im Spiel zu."
 			},
 			damage: 20,
 
@@ -50,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Jet Needle",
 				fr: "Gerbe d’Aiguilles",
+				de: "Jetnadel"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Weakness or Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Faiblesse ou la Résistance.",
+				de: "Der Schaden dieser Attacke wird durch Schwäche und Resistenz nicht verändert."
 			},
 			damage: 110,
 
@@ -67,10 +73,12 @@ const card: Card = {
 			name: {
 				en: "Stinger-GX",
 				fr: "Aiguillon-GX",
+				de: "Stachel-GX"
 			},
 			effect: {
 				en: "Both players shuffle their Prize cards into their decks. Then, each player puts the top 3 cards of their deck face down as their Prize cards. (You can't use more than 1 GX attack in a game.)",
 				fr: "Les deux joueurs mélangent leurs cartes Récompense avec leurs decks. Ensuite, chaque joueur place les 3 cartes du dessus de son deck, face cachée, comme cartes Récompense. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Beide Spieler mischen ihre Preiskarten in ihre Decks. Anschließend legt jeder Spieler die obersten 3 Karten seines Decks als seine verdeckten Preiskarten ab. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV64.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV64.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lucario-GX",
 		fr: "Lucario-GX",
+		de: "Lucario-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Riolu",
 		fr: "Riolu",
+		de: "Riolu"
 	},
 
 	suffix: "GX",
@@ -33,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Aura Strike",
 				fr: "Aura Frappante",
+				de: "Aura-Schlag"
 			},
 			effect: {
 				en: "If this Pokémon evolved from Riolu during this turn, this attack does 90 more damage.",
 				fr: "Si ce Pokémon a évolué de Riolu pendant ce tour, cette attaque inflige 90 dégâts supplémentaires.",
+				de: "Wenn sich dieses Pokémon während dieses Zuges aus Riolu entwickelt hat, fügt diese Attacke 90 Schadenspunkte mehr zu."
 			},
 			damage: 30,
 
@@ -50,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Cyclone Kick",
 				fr: "Pied Cyclone",
+				de: "Wirbeltritt"
 			},
 
 			damage: 130,
@@ -63,10 +68,12 @@ const card: Card = {
 			name: {
 				en: "Cantankerous Beatdown-GX",
 				fr: "Dérouillée Revêche-GX",
+				de: "Zorniger Niederprügler-GX"
 			},
 			effect: {
 				en: "This attack does 30 damage for each damage counter on this Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 30 dégâts pour chaque marqueur de dégâts placé sur ce Pokémon. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der Schadensmarken auf diesem Pokémon zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 30,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV65.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV65.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Zygarde-GX",
 		fr: "Zygarde-GX",
+		de: "Zygarde-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -31,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Cell Connector",
 				fr: "Connecteur de Cellules",
+				de: "Zellenanschluss"
 			},
 			effect: {
 				en: "Attach 2 Fighting Energy cards from your discard pile to this Pokémon.",
 				fr: "Attachez 2 cartes Énergie Fighting de votre pile de défausse à ce Pokémon.",
+				de: "Lege 2 {F}-Energiekarten aus deinem Ablagestapel an dieses Pokémon an."
 			},
 			damage: 50,
 
@@ -49,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Land's Wrath",
 				fr: "Force Chtonienne",
+				de: "Bodengewalt"
 			},
 
 			damage: 130,
@@ -64,10 +68,12 @@ const card: Card = {
 			name: {
 				en: "Verdict-GX",
 				fr: "Verdict-GX",
+				de: "Urteilsspruch-GX"
 			},
 			effect: {
 				en: "Prevent all damage done to this Pokémon by attacks from Pokémon-GX and Pokémon-EX during your opponent's next turn. (You can't use more than 1 GX attack in a game.)",
 				fr: "Évitez tous les dégâts infligés à ce Pokémon par des attaques de Pokémon-GX et de Pokémon-EX pendant le prochain tour de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Verhindere allen Schaden, der diesem Pokémon während des nächsten Zuges deines Gegners durch Attacken von Pokémon-GX und Pokémon-EX zugefügt wird. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 150,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV66.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV66.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lycanroc-GX",
 		fr: "Lougaroc-GX",
+		de: "Wolwerock-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rockruff",
 		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Bloodthirsty Eyes",
 				fr: "Regard Sanguinaire",
+				de: "Blutrünstige Augen"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may switch 1 of your opponent's Benched Pokémon with their Active Pokémon.",
 				fr: "Lorsque vous jouez ce Pokémon de votre main pour faire évoluer l’un de vos Pokémon pendant votre tour, vous pouvez échanger l’un des Pokémon de Banc de votre adversaire avec son Pokémon Actif.",
+				de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon austauschen."
 			},
 		},
 	],
@@ -47,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Claw Slash",
 				fr: "Tranch’Griffe",
+				de: "Klauenschlitzer"
 			},
 
 			damage: 110,
@@ -60,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Dangerous Rogue-GX",
 				fr: "Dangereux Truand-GX",
+				de: "Gaunergefahr-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 50 dégâts pour chaque Pokémon de Banc de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der Pokémon auf der Bank deines Gegners zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 50,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV67.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV67.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lycanroc-GX",
 		fr: "Lougaroc-GX",
+		de: "Wolwerock-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Rockruff",
 		fr: "Rocabot",
+		de: "Wuffels"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Twilight Eyes",
 				fr: "Regard du Crépuscule",
+				de: "Zwielichtaugen"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may discard an Energy attached to your opponent's Active Pokémon.",
 				fr: "Lorsque vous jouez ce Pokémon de votre main pour faire évoluer l’un de vos Pokémon pendant votre tour, vous pouvez défausser une Énergie attachée au Pokémon Actif de votre adversaire.",
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand spielst, um 1 deiner Pokémon zu entwickeln, kannst du 1 an das Aktive Pokémon deines Gegners angelegte Energie auf seinen Ablagestapel legen."
 			},
 		},
 	],
@@ -47,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Accelerock",
 				fr: "Vif Roc",
+				de: "Turbofelsen"
 			},
 
 			damage: 120,
@@ -59,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Splintered Shards-GX",
 				fr: "Roches-Lames-GX",
+				de: "Splitterregen-GX"
 			},
 			effect: {
 				en: "This attack does 30 damage for each Energy card in your opponent's discard pile. (You can't use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 30 dégâts pour chaque carte Énergie dans la pile de défausse de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der Energiekarten im Ablagestapel deines Gegners zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 30,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV68.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV68.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Buzzwole-GX",
 		fr: "Mouscoto-GX",
+		de: "Masskito-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Jet Punch",
 				fr: "Coup Rapide",
+				de: "Jet-Schlag"
 			},
 			effect: {
 				en: "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 30 dégâts à l’un des Pokémon de Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Diese Attacke fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 30,
 
@@ -47,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Knuckle Impact",
 				fr: "Coup d’Articulations",
+				de: "Knöchelprall"
 			},
 			effect: {
 				en: "This Pokémon can't attack during your next turn.",
 				fr: "Ce Pokémon ne peut pas attaquer pendant votre prochain tour.",
+				de: "Dieses Pokémon kann während deines nächsten Zuges nicht angreifen."
 			},
 			damage: 160,
 
@@ -64,10 +69,12 @@ const card: Card = {
 			name: {
 				en: "Absorption-GX",
 				fr: "Expansion-GX",
+				de: "Expander-GX"
 			},
 			effect: {
 				en: "This attack does 40 damage for each of your remaining Prize cards. (You can't use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 40 dégâts pour chacune des cartes Récompense qu’il vous reste. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt 40 Schadenspunkte mal der Anzahl deiner verbleibenden Preiskarten zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 40,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV69.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV69.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Umbreon-GX",
 		fr: "Noctali-GX",
+		de: "Nachtara-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -33,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Strafe",
 				fr: "Bombarder",
+				de: "Beharken"
 			},
 			effect: {
 				en: "You may switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Vous pouvez échanger ce Pokémon avec l’un de vos Pokémon de Banc.",
+				de: "Du kannst dieses Pokémon gegen 1 Pokémon auf deiner Bank austauschen."
 			},
 			damage: 30,
 
@@ -50,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Shadow Bullet",
 				fr: "Kunaï Sournois",
+				de: "Schattenkugel"
 			},
 			effect: {
 				en: "This attack does 30 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 30 dégâts à l’un des Pokémon de Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Diese Attacke fügt 1 Pokémon auf der Bank deines Gegners 30 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 90,
 
@@ -66,10 +72,12 @@ const card: Card = {
 			name: {
 				en: "Dark Call-GX",
 				fr: "Appel Obscur-GX",
+				de: "Nachtgeheul GX"
 			},
 			effect: {
 				en: "Discard 2 Energy from your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Défaussez 2 Énergies des Pokémon de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Lege 2 Energien von den Pokémon deines Gegners auf seinen Ablagestapel. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV7.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV7.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charmeleon",
 		fr: "Reptincel",
+		de: "Glutexo"
 	},
 	illustrator: "nagimiso",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmander",
 		fr: "Salamèche",
+		de: "Glumanda"
 	},
 	stage: "Stage1",
 
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Burning Fighter",
 				fr: "Combattant Brûlant",
+				de: "Feuerkämpfer"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand to evolve 1 of your Pokémon during your turn, you may discard the top 5 cards of your deck. If any of those cards are Fire Energy cards, attach them to this Pokémon.",
 				fr: "Lorsque vous jouez ce Pokémon de votre main pour faire évoluer l’un de vos Pokémon pendant votre tour, vous pouvez défausser les 5 cartes du dessus de votre deck. Si vous y trouvez des cartes Énergie Fire, attachez-les à ce Pokémon.",
+				de: "Wenn du dieses Pokémon aus deiner Hand spielst, um 1 deiner Pokémon während deines Zuges zu entwickeln, kannst du die obersten 5 Karten deines Decks auf deinen Ablagestapel legen. Wenn unter jenen Karten {R}-Energiekarten sind, lege sie an dieses Pokémon an."
 			},
 		},
 	],
@@ -47,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Flamethrower",
 				fr: "Lance-Flammes",
+				de: "Flammenwurf"
 			},
 			effect: {
 				en: "Discard an Energy from this Pokémon.",
 				fr: "Défaussez une Énergie de ce Pokémon.",
+				de: "Lege 1 Energie von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 80,
 
@@ -70,6 +76,7 @@ const card: Card = {
 
 	description: {
 		en: "When it swings its burning tail, it elevates the air temperature to unbearably high levels.",
+		de: "Wenn Glutexo mit seinem Schwanz schwingt, steigt die Temperatur ins Unermessliche."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV70.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV70.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Darkrai-GX",
 		fr: "Darkrai-GX",
+		de: "Darkrai-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Restoration",
 				fr: "Renouveau",
+				de: "Restauration"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if this Pokémon is in your discard pile, you may put it onto your Bench. Then, attach a Darkness Energy card from your discard pile to this Pokémon.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), si ce Pokémon se trouve dans votre pile de défausse, vous pouvez le placer sur votre Banc. Ensuite, attachez une carte Énergie Darkness de votre pile de défausse à ce Pokémon.",
+				de: "Einmal während deines Zuges (bevor du angreifst), wenn sich dieses Pokémon in deinem Ablagestapel befindet, kannst du es auf deine Bank legen. Lege anschließend 1 {D}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 			},
 		},
 	],
@@ -44,10 +47,12 @@ const card: Card = {
 			name: {
 				en: "Dark Cleave",
 				fr: "Pénombre Pourfendue",
+				de: "Dunkle Spaltung"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by Resistance.",
 				fr: "Les dégâts de cette attaque ne sont pas affectés par la Résistance.",
+				de: "Der Schaden dieser Attacke wird durch Resistenz nicht verändert."
 			},
 			damage: 130,
 
@@ -61,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Dead End-GX",
 				fr: "Sans Issue-GX",
+				de: "Sackgasse-GX"
 			},
 			effect: {
 				en: "If your opponent's Active Pokémon is affected by a Special Condition, that Pokémon is Knocked Out. (You can't use more than 1 GX attack in a game.)",
 				fr: "Si le Pokémon Actif de votre adversaire est affecté par un État Spécial, ce dernier est mis K.O. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Wenn das Aktive Pokémon deines Gegners von einem Speziellen Zustand betroffen ist, ist jenes Pokémon kampfunfähig. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV71.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV71.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Guzzlord-GX",
 		fr: "Engloutyran-GX",
+		de: "Schlingking-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Eat Sloppily",
 				fr: "Repas Baveux",
+				de: "Kleckerkost"
 			},
 			effect: {
 				en: "Discard the top 5 cards of your deck. If any of those cards are Energy cards, attach them to this Pokémon.",
 				fr: "Défaussez les 5 cartes du dessus de votre deck. Si vous y trouvez des cartes Énergie, attachez-les à ce Pokémon.",
+				de: "Lege die obersten 5 Karten von deinem Deck auf deinen Ablagestapel. Wenn unter jenen Karten Energiekarten sind, lege sie an dieses Pokémon an."
 			},
 
 		},
@@ -48,6 +51,7 @@ const card: Card = {
 			name: {
 				en: "Tyrannical Hole",
 				fr: "Trou Tyrannique",
+				de: "Despotischer Schlund"
 			},
 
 			damage: 180,
@@ -64,10 +68,12 @@ const card: Card = {
 			name: {
 				en: "Glutton-GX",
 				fr: "Gourmandise-GX",
+				de: "Vielfraß-GX"
 			},
 			effect: {
 				en: "If your opponent's Pokémon is Knocked Out by damage from this attack, take 2 more Prize cards. (You can't use more than 1 GX attack in a game.)",
 				fr: "Si le Pokémon de votre adversaire est mis K.O. par les dégâts de cette attaque, récupérez 2 cartes Récompense supplémentaires. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Wenn das Pokémon deines Gegners durch Schaden dieser Attacke kampfunfähig wird, nimm 2 Preiskarten mehr. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 100,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV72.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV72.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Scizor-GX",
 		fr: "Cizayox-GX",
+		de: "Scherox-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Scyther",
 		fr: "Insécateur",
+		de: "Sichlor"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Danger Perception",
 				fr: "Perception du Danger",
+				de: "Gefahrensinn"
 			},
 			effect: {
 				en: "If this Pokémon's remaining HP is 100 or less, its attacks do 80 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
 				fr: "S’il reste 100 PV ou moins à ce Pokémon, ses attaques infligent 80 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance).",
+				de: "Wenn die verbleibenden KP dieses Pokémon 100 oder weniger betragen, fügen seine Attacken dem Aktiven Pokémon deines Gegners 80 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 			},
 		},
 	],
@@ -46,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Steel Wing",
 				fr: "Aile d’Acier",
+				de: "Stahlflügel"
 			},
 			effect: {
 				en: "During your opponent's next turn, this Pokémon takes 30 less damage from attacks (after applying Weakness and Resistance).",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit 30 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance).",
+				de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 80,
 
@@ -63,10 +69,12 @@ const card: Card = {
 			name: {
 				en: "Cross-Cut-GX",
 				fr: "Coupe Transversale-GX",
+				de: "Überkreuzzerschneider-GX"
 			},
 			effect: {
 				en: "If your opponent's Active Pokémon is an Evolution Pokémon, this attack does 100 more damage. (You can't use more than 1 GX attack in a game.)",
 				fr: "Si le Pokémon Actif de votre adversaire est un Pokémon Évolutif, cette attaque inflige 100 dégâts supplémentaires. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Wenn das Aktive Pokémon deines Gegners ein Entwicklungs-Pokémon ist, fügt diese Attacke 100 Schadenspunkte mehr zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 100,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV73.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV73.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kartana-GX",
 		fr: "Katagami-GX",
+		de: "Katagami-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Slice Off",
 				fr: "Trancher",
+				de: "Abschneiden"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand onto your Bench during your turn, you may discard a Special Energy from 1 of your opponent's Pokémon.",
 				fr: "Lorsque vous jouez ce Pokémon de votre main sur votre Banc pendant votre tour, vous pouvez défausser une Énergie spéciale attachée à l’un des Pokémon de votre adversaire.",
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du 1 Spezial-Energie von 1 Pokémon deines Gegners auf seinen Ablagestapel legen."
 			},
 		},
 	],
@@ -44,10 +47,12 @@ const card: Card = {
 			name: {
 				en: "Gale Blade",
 				fr: "Lame Bourrasque",
+				de: "Sturmschwert"
 			},
 			effect: {
 				en: "You may shuffle this Pokémon and all cards attached to it into your deck.",
 				fr: "Vous pouvez mélanger ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck.",
+				de: "Du kannst dieses Pokémon und alle an es angelegten Karten in dein Deck mischen."
 			},
 			damage: 70,
 
@@ -59,10 +64,12 @@ const card: Card = {
 			name: {
 				en: "Blade-GX",
 				fr: "Lame-GX",
+				de: "Schwerthieb-GX"
 			},
 			effect: {
 				en: "Take a Prize card. (You can't use more than 1 GX attack in a game.)",
 				fr: "Récupérez une carte Récompense. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Nimm 1 Preiskarte. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV74.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV74.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Stakataka-GX",
 		fr: "Ama-Ama-GX",
+		de: "Muramura-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Ultra Wall",
 				fr: "Ultra-Mur",
+				de: "Ultrawand"
 			},
 			effect: {
 				en: "Your Ultra Beasts take 10 less damage from your opponent's attacks (after applying Weakness and Resistance).",
 				fr: "Vos Ultra-Chimères subissent 10 dégâts de moins provenant des attaques de votre adversaire (après application de la Faiblesse et de la Résistance).",
+				de: "Deinen Ultrabestien werden durch Attacken deines Gegners 10 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],
@@ -44,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Gigaton Stomp",
 				fr: "Écrasement Gigatonne",
+				de: "Gigatonnen-Stampfer"
 			},
 
 			damage: 120,
@@ -58,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Assembly-GX",
 				fr: "Empilage-GX",
+				de: "Mauerwerk-GX"
 			},
 			effect: {
 				en: "This attack does 50 more damage for each Prize card you have taken. (You can't use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 50 dégâts supplémentaires pour chaque carte Récompense que vous avez récupérée. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt 50 Schadenspunkte mehr mal der Anzahl der von dir genommenen Preiskarten zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 50,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV75.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV75.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gardevoir-GX",
 		fr: "Gardevoir-GX",
+		de: "Guardevoir-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Kirlia",
 		fr: "Kirlia",
+		de: "Kirlia"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Secret Spring",
 				fr: "Rebond Secret",
+				de: "Geheime Quelle"
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may attach a Fairy Energy card from your hand to 1 of your Pokémon.",
 				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie Fairy de votre main à l’un de vos Pokémon.",
+				de: "Einmal während deines Zuges (bevor du angreifst) kannst du 1 {FAIRY}-Energiekarte aus deiner Hand an 1 deiner Pokémon anlegen."
 			},
 		},
 	],
@@ -45,10 +49,12 @@ const card: Card = {
 			name: {
 				en: "Infinite Force",
 				fr: "Force Infinie",
+				de: "Unendliche Macht"
 			},
 			effect: {
 				en: "This attack does 30 damage times the amount of Energy attached to both Active Pokémon.",
 				fr: "Cette attaque inflige 30 dégâts multipliés par le nombre d’Énergies attachées aux deux Pokémon Actifs.",
+				de: "Diese Attacke fügt 30 Schadenspunkte mal der Anzahl der an beide Aktiven Pokémon angelegten Energien zu."
 			},
 			damage: 30,
 
@@ -60,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Twilight-GX",
 				fr: "Tombée de la Nuit-GX",
+				de: "Zwielicht-GX"
 			},
 			effect: {
 				en: "Shuffle 10 cards from your discard pile into your deck. (You can't use more than 1 GX attack in a game.)",
 				fr: "Mélangez 10 cartes de votre pile de défausse avec votre deck. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Mische 10 Karten aus deinem Ablagestapel in dein Deck. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV76.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV76.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Sylveon-GX",
 		fr: "Nymphali-GX",
+		de: "Feelinara-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	suffix: "GX",
@@ -33,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Magical Ribbon",
 				fr: "Ruban Magique",
+				de: "Zauberband"
 			},
 			effect: {
 				en: "Search your deck for up to 3 cards and put them into your hand. Then, shuffle your deck.",
 				fr: "Cherchez jusqu’à 3 cartes dans votre deck et ajoutez-les à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach bis zu 3 Karten und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -49,6 +53,7 @@ const card: Card = {
 			name: {
 				en: "Fairy Wind",
 				fr: "Vent Féérique",
+				de: "Feenbrise"
 			},
 
 			damage: 110,
@@ -63,10 +68,12 @@ const card: Card = {
 			name: {
 				en: "Plea-GX",
 				fr: "Supplique-GX",
+				de: "Anflehen-GX"
 			},
 			effect: {
 				en: "Put 2 of your opponent's Benched Pokémon and all cards attached to them into your opponent's hand. (You can't use more than 1 GX attack in a game.)",
 				fr: "Placez 2 des Pokémon de Banc de votre adversaire et toutes les cartes qui leur sont attachées dans la main de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Gib deinem Gegner 2 Pokémon von seiner Bank und alle an sie angelegten Karten auf seine Hand. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV77.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV77.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Altaria-GX",
 		fr: "Altaria-GX",
+		de: "Altaria-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Swablu",
 		fr: "Tylton",
+		de: "Wablu"
 	},
 
 	suffix: "GX",
@@ -34,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Bright Tone",
 				fr: "Tonalité Claire",
+				de: "Heller Klang"
 			},
 			effect: {
 				en: "During your opponent's next turn, prevent all damage done to this Pokémon by attacks from Pokémon-GX and Pokémon-EX.",
 				fr: "Pendant le prochain tour de votre adversaire, évitez tous les dégâts infligés à ce Pokémon par des attaques de Pokémon-GX ou de Pokémon-EX.",
+				de: "Verhindere allen Schaden, der diesem Pokémon während des nächsten Zuges deines Gegners durch Attacken von Pokémon-GX und Pokémon-EX zugefügt wird."
 			},
 			damage: 50,
 
@@ -51,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Sonic Edge",
 				fr: "Tranchant Sonique",
+				de: "Schallkante"
 			},
 			effect: {
 				en: "This attack's damage isn't affected by any effects on your opponent's Active Pokémon.",
 				fr: "Les dégâts de cette attaque ne sont affectés par aucun effet en action sur le Pokémon Actif de votre adversaire.",
+				de: "Der Schaden dieser Attacke wird durch Effekte auf dem Aktiven Pokémon deines Gegners nicht verändert."
 			},
 			damage: 110,
 
@@ -67,10 +73,12 @@ const card: Card = {
 			name: {
 				en: "Euphoria-GX",
 				fr: "Euphorie-GX",
+				de: "Euphorie-GX"
 			},
 			effect: {
 				en: "Your opponent's Active Pokémon is now Asleep. Heal all damage from all of your Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi. Soignez tous les dégâts de vos Pokémon. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Das Aktive Pokémon deines Gegners schläft jetzt. Heile allen Schaden bei jedem deiner Pokémon. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV78.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV78.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Noivern-GX",
 		fr: "Bruyverne-GX",
+		de: "UHaFnir-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Noibat",
 		fr: "Sonistrelle",
+		de: "eF-eM"
 	},
 
 	suffix: "GX",
@@ -34,10 +36,12 @@ const card: Card = {
 			name: {
 				en: "Distort",
 				fr: "Torsion",
+				de: "Knistern"
 			},
 			effect: {
 				en: "Your opponent can't play any Item cards from their hand during their next turn.",
 				fr: "Votre adversaire ne peut pas jouer de carte Objet de sa main pendant son prochain tour.",
+				de: "Dein Gegner kann während seines nächsten Zuges keine Itemkarten aus seiner Hand spielen."
 			},
 			damage: 50,
 
@@ -51,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Sonic Volume",
 				fr: "Volume Sonique",
+				de: "Schallvolumen"
 			},
 			effect: {
 				en: "Your opponent can't play any Special Energy cards from their hand during their next turn.",
 				fr: "Votre adversaire ne peut pas jouer de carte Énergie spéciale de sa main pendant son prochain tour.",
+				de: "Dein Gegner kann während seines nächsten Zuges keine Spezial-Energiekarten aus seiner Hand spielen."
 			},
 			damage: 120,
 
@@ -68,10 +74,12 @@ const card: Card = {
 			name: {
 				en: "Boomburst-GX",
 				fr: "Bang Sonique-GX",
+				de: "Überschallknall-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) (You can't use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 50 dégâts à chacun des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt jedem Pokémon deines Gegners 50 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV79.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV79.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Silvally-GX",
 		fr: "Silvallié-GX",
+		de: "Amigento-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -21,6 +22,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Type: Null",
 		fr: "Type:0",
+		de: "Typ:Null"
 	},
 
 	suffix: "GX",
@@ -30,10 +32,12 @@ const card: Card = {
 			name: {
 				en: "Gyro Unit",
 				fr: "Gyro-Unité",
+				de: "Gyro-Aggregat"
 			},
 			effect: {
 				en: "Your Basic Pokémon in play have no Retreat Cost.",
 				fr: "Vos Pokémon de base en jeu n’ont pas de Coût de Retraite.",
+				de: "Deine Basis-Pokémon im Spiel haben keine Rückzugskosten."
 			},
 		},
 	],
@@ -47,10 +51,12 @@ const card: Card = {
 			name: {
 				en: "Turbo Drive",
 				fr: "Propulsion Turbo",
+				de: "Turboantrieb"
 			},
 			effect: {
 				en: "Attach a basic Energy card from your discard pile to 1 of your Benched Pokémon.",
 				fr: "Attachez une carte Énergie de base de votre pile de défausse à l’un de vos Pokémon de Banc.",
+				de: "Lege 1 Basis-Energiekarte aus deinem Ablagestapel an 1 Pokémon auf deiner Bank an."
 			},
 			damage: 120,
 
@@ -64,10 +70,12 @@ const card: Card = {
 			name: {
 				en: "Rebel-GX",
 				fr: "Rebelle-GX",
+				de: "Rebellieren-GX"
 			},
 			effect: {
 				en: "This attack does 50 damage for each of your opponent's Benched Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 50 dégâts pour chaque Pokémon de Banc de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der Pokémon auf der Bank deines Gegners zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 50,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV8.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV8.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Alolan Vulpix",
 		fr: "Goupix d’Alola",
+		de: "Alola-Vulpix"
 	},
 	illustrator: "Kouki Saitou",
 	rarity: "Shiny rare",
@@ -28,10 +29,12 @@ const card: Card = {
 			name: {
 				en: "Beacon",
 				fr: "Flambeau",
+				de: "Lichtsignal"
 			},
 			effect: {
 				en: "Search your deck for up to 2 Pokémon, reveal them, and put them into your hand. Then, shuffle your deck.",
 				fr: "Cherchez jusqu’à 2 Pokémon dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+				de: "Durchsuche dein Deck nach bis zu 2 Pokémon, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -43,6 +46,7 @@ const card: Card = {
 			name: {
 				en: "Icy Snow",
 				fr: "Verglas",
+				de: "Eisiger Schnee"
 			},
 
 			damage: 20,
@@ -63,6 +67,7 @@ const card: Card = {
 
 	description: {
 		en: "It exhales air colder than -58 degrees Fahrenheit. Elderly people in Alola call this Pokémon by an older name—Keokeo.",
+		de: "Sein eisiger Atem beträgt -50 °C. Einige der älteren Einwohner von Alola nennen es bei seinem früheren Namen „Ke’oke’o“."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV80.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV80.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Drampa-GX",
 		fr: "Draïeul-GX",
+		de: "Sen-Long-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Shiny rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Righteous Edge",
 				fr: "Lame Vertueuse",
+				de: "Edle Klinge"
 			},
 			effect: {
 				en: "Discard a Special Energy from your opponent's Active Pokémon.",
 				fr: "Défaussez une Énergie spéciale du Pokémon Actif de votre adversaire.",
+				de: "Lege 1 Spezial-Energie vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel."
 			},
 			damage: 20,
 
@@ -47,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Berserk",
 				fr: "Dracolère",
+				de: "Wutausbruch"
 			},
 			effect: {
 				en: "If your Benched Pokémon have any damage counters on them, this attack does 70 more damage.",
 				fr: "Si des marqueurs de dégâts sont placés sur vos Pokémon de Banc, cette attaque inflige 70 dégâts supplémentaires.",
+				de: "Wenn auf den Pokémon auf deiner Bank mindestens 1 Schadensmarke liegt, fügt diese Attacke 70 Schadenspunkte mehr zu."
 			},
 			damage: 80,
 
@@ -62,10 +67,12 @@ const card: Card = {
 			name: {
 				en: "Big Wheel-GX",
 				fr: "Grande Roue-GX",
+				de: "Riesenrad-GX"
 			},
 			effect: {
 				en: "Shuffle your hand into your deck. Then, draw 10 cards. (You can't use more than 1 GX attack in a game.)",
 				fr: "Mélangez votre main avec votre deck. Ensuite, piochez 10 cartes. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 10 Karten. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV81.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV81.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Aether Foundation Employee",
 		fr: "Employés de la Fondation Æther",
+		de: "Angestellte der Æther Foundation"
 	},
 	illustrator: "take",
 	rarity: "Shiny rare",
@@ -25,6 +26,7 @@ const card: Card = {
 	effect: {
 		en: "Put 3 Pokémon that have \"Alolan\" in their names from your discard pile into your hand. You may play only 1 Supporter card during your turn (before your attack).",
 		fr: "Ajoutez 3 Pokémon avec « d’Alola » dans leur nom, de votre pile de défausse à votre main.",
+		de: "Nimm 3 Pokémon, bei denen Alola zum Namen gehört, aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV82.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV82.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Cynthia",
 		fr: "Cynthia",
+		de: "Cynthia"
 	},
 	illustrator: "Yusuke Ohmura",
 	rarity: "Shiny rare",
@@ -25,6 +26,7 @@ const card: Card = {
 	effect: {
 		en: "Shuffle your hand into your deck. Then, draw 6 cards. You may play only 1 Supporter card during your turn (before your attack).",
 		fr: "Mélangez votre main avec votre deck. Ensuite, piochez 6 cartes.",
+		de: "Mische deine Handkarten in dein Deck. Ziehe anschließend 6 Karten. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV83.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV83.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Fisherman",
 		fr: "Pêcheur",
+		de: "Angler"
 	},
 	illustrator: "Masakazu Fukuda",
 	rarity: "Shiny rare",
@@ -25,6 +26,7 @@ const card: Card = {
 	effect: {
 		en: "Put 4 basic Energy cards from your discard pile into your hand. You may play only 1 Supporter card during your turn (before your attack).",
 		fr: "Ajoutez 4 cartes Énergie de base de votre pile de défausse à votre main.",
+		de: "Nimm 4 Basis-Energiekarten aus deinem Ablagestapel auf deine Hand. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV84.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV84.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Guzma",
 		fr: "Guzma",
+		de: "Bromley"
 	},
 	illustrator: "Hitoshi Ariga",
 	rarity: "Shiny rare",
@@ -25,6 +26,7 @@ const card: Card = {
 	effect: {
 		en: "Switch 1 of your opponent's Benched Pokémon with their Active Pokémon. If you do, switch your Active Pokémon with 1 of your Benched Pokémon. You may play only 1 Supporter card during your turn (before your attack).",
 		fr: "Échangez l’un des Pokémon de Banc de votre adversaire avec son Pokémon Actif. Dans ce cas, échangez votre Pokémon Actif avec l’un de vos Pokémon de Banc.",
+		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Wenn du das machst, tausche dein Aktives Pokémon gegen 1 Pokémon auf deiner Bank aus. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV85.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV85.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Hiker",
 		fr: "Montagnard",
+		de: "Wanderer"
 	},
 	illustrator: "Naoki Saito",
 	rarity: "Shiny rare",
@@ -25,6 +26,7 @@ const card: Card = {
 	effect: {
 		en: "Look at the top 5 cards of either player's deck and choose 1 of them. That player shuffles the other cards back into their deck. Then, put the card you chose on top of that deck. You may play only 1 Supporter card during your turn (before your attack).",
 		fr: "Regardez les 5 cartes du dessus du deck de l’un des joueurs et choisissez-en une. Ce joueur mélange les autres cartes avec son deck. Ensuite, placez la carte choisie sur le dessus de ce deck.",
+		de: "Schau dir die obersten 5 Karten des Decks eines der beiden Spieler an und wähle 1 Karte. Jener Spieler mischt die anderen Karten zurück in sein Deck. Lege anschließend die von dir gewählte Karte oben auf jenes Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV86.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV86.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lady",
 		fr: "Mademoiselle",
+		de: "Lady"
 	},
 	illustrator: "Kanako Eo",
 	rarity: "Shiny rare",
@@ -25,6 +26,7 @@ const card: Card = {
 	effect: {
 		en: "Search your deck for up to 4 basic Energy cards, reveal them, and put them into your hand. Then, shuffle your deck. You may play only 1 Supporter card during your turn (before your attack).",
 		fr: "Cherchez jusqu’à 4 cartes Énergie de base dans votre deck, montrez-les, puis ajoutez-les à votre main. Mélangez ensuite votre deck.",
+		de: "Durchsuche dein Deck nach bis zu 4 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV87.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV87.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Aether Paradise Conservation Area",
 		fr: "Réserve Naturelle du Paradis Æther",
+		de: "Schutzzone des Æther-Paradieses"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
@@ -25,6 +26,7 @@ const card: Card = {
 	effect: {
 		en: "Basic Grass and Basic Lightning Pokémon (both yours and your opponent's) take 30 less damage from the opponent's attacks (after applying Weakness and Resistance). This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
 		fr: "Les Pokémon Grass de base et les Pokémon Lightning de base (les vôtres et ceux de votre adversaire) reçoivent 30 dégâts de moins des attaques de l’adversaire (après application de la Faiblesse et de la Résistance).",
+		de: "{G}-Basis-Pokémon und {L}-Basis-Pokémon (deine und die deines Gegners) werden durch Attacken des Gegners 30 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 	trainerType: "Stadium",
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV88.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV88.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Brooklet Hill",
 		fr: "Colline Clapotis",
+		de: "Plätscherhügel"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
@@ -25,6 +26,7 @@ const card: Card = {
 	effect: {
 		en: "Once during each player's turn, that player may search their deck for a Basic Water Pokémon or Basic Fighting Pokémon and, put it onto their Bench, and shuffle their deck. This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
 		fr: "Une seule fois pendant le tour de chaque joueur, ce joueur peut chercher un Pokémon Water de base ou un Pokémon Fighting de base dans son deck, le placer sur son Banc, puis mélanger son deck.",
+		de: "Einmal während des Zuges jedes Spielers kann der Spieler sein Deck nach 1 {W}-Basis-Pokémon oder 1 {F}-Basis-Pokémon durchsuchen, es auf seine Bank legen und sein Deck mischen. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 	trainerType: "Stadium",
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV89.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV89.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mt. Coronet",
 		fr: "Mont Couronné",
+		de: "Kraterberg"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
@@ -25,6 +26,7 @@ const card: Card = {
 	effect: {
 		en: "Once during each player's turn, that player may put 2 Metal Energy cards from their discard pile into their hand. This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
 		fr: "Une seule fois pendant le tour de chaque joueur, ce joueur peut placer 2 cartes Énergie Metal de sa pile de défausse dans sa main.",
+		de: "Einmal während des Zuges jedes Spielers kann der Spieler 2 {M}-Energiekarten aus seinem Ablagestapel auf seine Hand nehmen. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 	trainerType: "Stadium",
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV9.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV9.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Wooper",
 		fr: "Axoloto",
+		de: "Felino"
 	},
 	illustrator: "Misa Tsutsui",
 	rarity: "Shiny rare",
@@ -30,6 +31,7 @@ const card: Card = {
 			name: {
 				en: "Ram",
 				fr: "Collision",
+				de: "Ramme"
 			},
 
 			damage: 10,
@@ -43,6 +45,7 @@ const card: Card = {
 			name: {
 				en: "Rain Splash",
 				fr: "Pluie Éclaboussante",
+				de: "Regenplatscher"
 			},
 
 			damage: 20,
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "When the temperature cools in the evening, they emerge from water to seek food along the shore.",
+		de: "Wenn es am Abend kühler wird, kommen sie an Land, um nach Nahrung zu suchen."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV90.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV90.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Shrine of Punishment",
 		fr: "Chapelle des Châtiments",
+		de: "Schrein der Bestrafung"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
@@ -25,6 +26,7 @@ const card: Card = {
 	effect: {
 		en: "Between turns, put 1 damage counter on each Pokémon-GX and Pokémon-EX (both yours and your opponent's). This card stays in play when you play it. Discard this card if another Stadium card comes into play. If another card with the same name is in play, you can't play this card.",
 		fr: "Entre chaque tour, placez un marqueur de dégâts sur chaque Pokémon-GX et Pokémon-EX (les vôtres et ceux de votre adversaire).",
+		de: "Lege zwischen den Zügen 1 Schadensmarke auf jedes Pokémon-GX und Pokémon-EX (deine und die deines Gegners) Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 	trainerType: "Stadium",
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV91.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV91.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tapu Bulu-GX",
 		fr: "Tokotoro-GX",
+		de: "Kapu-Toro-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
@@ -30,6 +31,7 @@ const card: Card = {
 			name: {
 				en: "Horn Attack",
 				fr: "Koud’Korne",
+				de: "Hornattacke"
 			},
 
 			damage: 30,
@@ -44,10 +46,12 @@ const card: Card = {
 			name: {
 				en: "Nature's Judgment",
 				fr: "Jugement de la Nature",
+				de: "Gebot der Natur"
 			},
 			effect: {
 				en: "You may discard all Energy from this Pokémon. If you do, this attack does 60 more damage.",
 				fr: "Vous pouvez défausser toute l’Énergie attachée à ce Pokémon. Dans ce cas, cette attaque inflige 60 dégâts supplémentaires.",
+				de: "Du kannst alle Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, fügt diese Attacke 60 Schadenspunkte mehr zu."
 			},
 			damage: 120,
 
@@ -61,10 +65,12 @@ const card: Card = {
 			name: {
 				en: "Tapu Wilderness-GX",
 				fr: "Toko Nature-GX",
+				de: "Kapu-Wildnis GX"
 			},
 			effect: {
 				en: "Heal all damage from this Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Soignez tous les dégâts de ce Pokémon. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Heile allen Schaden bei diesem Pokémon. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 150,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV92.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV92.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tapu Fini-GX",
 		fr: "Tokopisco-GX",
+		de: "Kapu-Kime-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
@@ -30,10 +31,12 @@ const card: Card = {
 			name: {
 				en: "Aqua Ring",
 				fr: "Anneau Hydro",
+				de: "Wasserring"
 			},
 			effect: {
 				en: "You may switch this Pokémon with 1 of your Benched Pokémon.",
 				fr: "Vous pouvez échanger ce Pokémon avec l’un de vos Pokémon de Banc.",
+				de: "Du kannst dieses Pokémon gegen 1 Pokémon auf deiner Bank austauschen."
 			},
 			damage: 20,
 
@@ -47,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Hydro Shot",
 				fr: "Hydro-Coup",
+				de: "Hydroschuss"
 			},
 			effect: {
 				en: "Discard 2 Water Energy from this Pokémon. This attack does 120 damage to 1 of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Défaussez 2 Énergies Water de ce Pokémon. Cette attaque inflige 120 dégâts à l’un des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Lege 2 {W}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 120 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -61,10 +66,12 @@ const card: Card = {
 			name: {
 				en: "Tapu Storm-GX",
 				fr: "Toko Tempête-GX",
+				de: "Kapu-Sturm-GX"
 			},
 			effect: {
 				en: "Shuffle your opponent's Active Pokémon and all cards attached to it into their deck. If your opponent has no Benched Pokémon, this attack does nothing. (You can't use more than 1 GX attack in a game.)",
 				fr: "Mélangez le Pokémon Actif de votre adversaire et toutes les cartes qui lui sont attachées dans son deck. Si votre adversaire n’a aucun Pokémon de Banc, cette attaque ne fait rien. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Mische das Aktive Pokémon deines Gegners und alle an es angelegten Karten in sein Deck. Wenn dein Gegner keine Pokémon auf der Bank hat, hat diese Attacke keine Auswirkungen. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV93.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV93.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tapu Koko-GX",
 		fr: "Tokorico-GX",
+		de: "Kapu-Riki-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Aero Trail",
 				fr: "Sentier Aérien",
+				de: "Luftspur"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand onto your Bench during your turn, you may move any number of Lightning Energy from your other Pokémon to this Pokémon. If you do, switch this Pokémon with your Active Pokémon.",
 				fr: "Lorsque vous jouez ce Pokémon de votre main sur votre Banc pendant votre tour, vous pouvez déplacer autant d’Énergie Lightning que vous voulez de vos autres Pokémon vers ce Pokémon. Dans ce cas, échangez ce Pokémon avec votre Pokémon Actif.",
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du beliebig viele {L}-Energien von deinen anderen Pokémon auf dieses Pokémon verschieben. Wenn du das machst, tausche dieses Pokémon gegen dein Aktives Pokémon aus."
 			},
 		},
 	],
@@ -44,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Sky-High Claws",
 				fr: "Griffes Gratte-Ciel",
+				de: "Himmelhohe Klauen"
 			},
 
 			damage: 130,
@@ -58,10 +62,12 @@ const card: Card = {
 			name: {
 				en: "Tapu Thunder-GX",
 				fr: "Toko Tonnerre-GX",
+				de: "Kapu-Donner GX"
 			},
 			effect: {
 				en: "This attack does 50 damage times the amount of Energy attached to all of your opponent's Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 50 dégâts multipliés par le nombre d’Énergies attachées aux Pokémon de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt 50 Schadenspunkte mal der Anzahl der an alle Pokémon deines Gegners angelegten Energien zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 50,
 

--- a/data/Sun & Moon/Hidden Fates Shiny Vault/SV94.ts
+++ b/data/Sun & Moon/Hidden Fates Shiny Vault/SV94.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Tapu Lele-GX",
 		fr: "Tokopiyon-GX",
+		de: "Kapu-Fala-GX"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Secret Rare",
@@ -27,10 +28,12 @@ const card: Card = {
 			name: {
 				en: "Wonder Tag",
 				fr: "Relais Miracle",
+				de: "Wunderfang"
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand onto your Bench during your turn, you may search your deck for a Supporter card, reveal it, and put it into your hand. Then, shuffle your deck.",
 				fr: "Lorsque vous jouez ce Pokémon de votre main sur votre Banc pendant votre tour, vous pouvez chercher une carte Supporter dans votre deck, la montrer et l’ajouter à votre main. Mélangez ensuite votre deck.",
+				de: "Wenn du dieses Pokémon während deines Zuges aus deiner Hand auf deine Bank spielst, kannst du dein Deck nach 1 Unterstützerkarte durchsuchen, sie deinem Gegner zeigen und sie auf deine Hand nehmen. Mische anschließend dein Deck."
 			},
 		},
 	],
@@ -43,10 +46,12 @@ const card: Card = {
 			name: {
 				en: "Energy Drive",
 				fr: "Propulsion d’Énergie",
+				de: "Energieantrieb"
 			},
 			effect: {
 				en: "This attack does 20 damage times the amount of Energy attached to both Active Pokémon. This damage isn't affected by Weakness or Resistance.",
 				fr: "Cette attaque inflige 20 dégâts multipliés par le nombre d’Énergies attachées aux deux Pokémon Actifs. Ces dégâts ne sont pas affectés par la Faiblesse ou la Résistance.",
+				de: "Diese Attacke fügt 20 Schadenspunkte mal der Anzahl der an beide Aktiven Pokémon angelegten Energien zu. Der Schaden dieser Attacke wird durch Schwäche und Resistenz nicht verändert."
 			},
 			damage: 20,
 
@@ -58,10 +63,12 @@ const card: Card = {
 			name: {
 				en: "Tapu Cure-GX",
 				fr: "Toko Soins-GX",
+				de: "Kapu-Heilung-GX"
 			},
 			effect: {
 				en: "Heal all damage from 2 of your Benched Pokémon. (You can't use more than 1 GX attack in a game.)",
 				fr: "Soignez tous les dégâts de 2 de vos Pokémon de Banc. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Heile allen Schaden bei 2 Pokémon auf deiner Bank. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},


### PR DESCRIPTION
## Add missing German translations for sma

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
