### PR TITLE
Add missing German translations for swsh2

### DIFF
--- a/data/Sword & Shield/Rebel Clash/1.ts
+++ b/data/Sword & Shield/Rebel Clash/1.ts
@@ -73,7 +73,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "For protection, it releases a horrible stench from the antenna on its head to drive away enemies."
+		en: "For protection, it releases a horrible stench from the antenna on its head to drive away enemies.",
+		de: "Als Schutz vor Feinden sondert es einen übel riechenden Gestank mit seinen Antennen ab."
 	},
 
 	dexId: [10],

--- a/data/Sword & Shield/Rebel Clash/10.ts
+++ b/data/Sword & Shield/Rebel Clash/10.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It lives in ponds and marshes that feature lots of plant life. It often fights with Dewpider, whose habitat and diet are similar."
+		en: "It lives in ponds and marshes that feature lots of plant life. It often fights with Dewpider, whose habitat and diet are similar.",
+		de: "Es lebt in pflanzenreichen Teichen und Sümpfen und streitet sich oft mit Araqua, da sie ähnliche Habitate haben und ähnliches Futter fressen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/100.ts
+++ b/data/Sword & Shield/Rebel Clash/100.ts
@@ -44,7 +44,7 @@ const card: Card = {
 				es: "Mientras este Pokémon esté en tu Banca, evita todo el daño infligido a este Pokémon por ataques (tanto tuyos como de tu rival).",
 				it: "Fintanto che questo Pokémon è nella tua panchina, previeni tutti i danni inflitti a questo Pokémon dagli attacchi, sia tuoi che del tuo avversario.",
 				pt: "Desde que este Pokémon esteja em seu Banco, previne todos os danos causados a este Pokémon por ataques (seus e do seu oponente).",
-				de: "Solang sich dieses Pokémon auf deiner Bank befindet, verhindere allen Schaden, der diesem Pokémon durch Angriffe (deine und die deines Gegners) zugefügt wird."
+				de: "Solange sich dieses Pokémon auf deiner Bank befindet, verhindere allen Schaden, der diesem Pokémon durch Attacken (deine und die deines Gegners) zugefügt wird."
 			},
 		},
 	],
@@ -92,7 +92,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It makes its nest at the bottom of swamps. It will eat anything—if it is alive, Whiscash will eat it."
+		en: "It makes its nest at the bottom of swamps. It will eat anything—if it is alive, Whiscash will eat it.",
+		de: "Dieses Pokémon baut sein Nest am Grund von Sümpfen. Es ist ein Vielfraß und verspeist Lebewesen aller Art."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/101.ts
+++ b/data/Sword & Shield/Rebel Clash/101.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "A clay slab with cursed engravings took possession of a Yamask. The slab is said to be absorbing the Yamask's dark power."
+		en: "A clay slab with cursed engravings took possession of a Yamask. The slab is said to be absorbing the Yamask's dark power.",
+		de: "Eine Tontafel, auf der ein Fluch eingeritzt wurde, hat Besitz von diesem Makabaja ergriffen. Man sagt, es ziehe seine Kraft aus dem Groll anderer."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/102.ts
+++ b/data/Sword & Shield/Rebel Clash/102.ts
@@ -93,7 +93,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "A powerful curse was woven into an ancient painting. After absorbing the spirit of a Yamask, the painting began to move."
+		en: "A powerful curse was woven into an ancient painting. After absorbing the spirit of a Yamask, the painting began to move.",
+		de: "Eine antike Malerei, die mit einem mächtigen Fluch versehen wurde, nahm die Seele eines Makabaja auf und erwachte zum Leben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/103.ts
+++ b/data/Sword & Shield/Rebel Clash/103.ts
@@ -62,7 +62,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "After two Binacle find a suitably sized rock, they adhere themselves to it and live together. They cooperate to gather food during high tide."
+		en: "After two Binacle find a suitably sized rock, they adhere themselves to it and live together. They cooperate to gather food during high tide.",
+		de: "Zwei Exemplare hängen sich an einen passenden Felsen in Küstennähe, um dort zu leben. Bei Flut sammeln sie gemeinsam Nahrung."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/104.ts
+++ b/data/Sword & Shield/Rebel Clash/104.ts
@@ -95,7 +95,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Seven Binacle come together to form one Barbaracle. The Binacle that serves as the head gives orders to those serving as the limbs."
+		en: "Seven Binacle come together to form one Barbaracle. The Binacle that serves as the head gives orders to those serving as the limbs.",
+		de: "Sein Körper besteht aus sieben verschiedenen Bithora, wobei der Kopf das Sagen über die anderen Gliedmaßen hat."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/105.ts
+++ b/data/Sword & Shield/Rebel Clash/105.ts
@@ -52,7 +52,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Most of its body has the same composition as coal. Fittingly, this Pokémon was first discovered in coal mines about 400 years ago."
+		en: "Most of its body has the same composition as coal. Fittingly, this Pokémon was first discovered in coal mines about 400 years ago.",
+		de: "Es wurde vor circa 400 Jahren in einer Kohlemine entdeckt. Sein Körper besteht fast aus denselben Komponenten wie Steinkohle."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/106.ts
+++ b/data/Sword & Shield/Rebel Clash/106.ts
@@ -80,7 +80,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It forms coal inside its body. Coal dropped by this Pokémon once helped fuel the lives of people in the Galar region."
+		en: "It forms coal inside its body. Coal dropped by this Pokémon once helped fuel the lives of people in the Galar region.",
+		de: "Es produziert Steinkohle in seinem Körper. Die von ihm abfallende Kohle wurde früher in der Galar-Region fürs tägliche Leben genutzt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/107.ts
+++ b/data/Sword & Shield/Rebel Clash/107.ts
@@ -44,7 +44,7 @@ const card: Card = {
 				es: "Una vez durante tu turno, puedes unir 1 carta de Energía Fire, 1 carta de Energía Fighting o 1 de cada una de tu pila de descartes a tus Pokémon de la manera que desees.",
 				it: "Una sola volta durante il tuo turno, puoi assegnare ai tuoi Pokémon una carta Energia Fire, una carta Energia Fighting o entrambe dalla tua pila degli scarti nel modo che preferisci.",
 				pt: "Uma vez durante o seu turno, você poderá ligar 1 carta de Energia Fire, 1 carta de Energia Fighting, ou 1 de cada da sua pilha de descarte aos seus Pokémon como desejar.",
-				de: "Einmal während deines Zuges kannst du 1 Fire-Energiekarte, 1 Fighting-Energiekarte oder von beiden 1 aus deinem Ablagestapel beliebig an deine Pokémon anlegen."
+				de: "Einmal während deines Zuges kannst du 1 {R}-Energiekarte, 1 {F}-Energiekarte oder von beiden 1 aus deinem Ablagestapel beliebig an deine Pokémon anlegen."
 			},
 		},
 	],
@@ -87,7 +87,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It's usually peaceful, but the vandalism of mines enrages it. Offenders will be incinerated with flames that reach 2,700 degrees Fahrenheit."
+		en: "It's usually peaceful, but the vandalism of mines enrages it. Offenders will be incinerated with flames that reach 2,700 degrees Fahrenheit.",
+		de: "Meist ist es friedfertig, aber wenn Menschen eine Mine zugrunde richten, sieht es rot und verbrennt sie mit 1 500 ºC heißen Flammen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/108.ts
+++ b/data/Sword & Shield/Rebel Clash/108.ts
@@ -36,7 +36,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Fighting de tu pila de descartes a este Pokémon.",
 				it: "Assegna a questo Pokémon una carta Energia Fighting dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia Fighting da sua pilha de descarte a este Pokémon.",
-				de: "Lege 1 Fighting-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
+				de: "Lege 1 {F}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 			},
 			damage: 30,
 

--- a/data/Sword & Shield/Rebel Clash/109.ts
+++ b/data/Sword & Shield/Rebel Clash/109.ts
@@ -82,7 +82,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Five of them are troopers, and one is the brass. The brass's orders are absolute."
+		en: "Five of them are troopers, and one is the brass. The brass's orders are absolute.",
+		de: "Dieses Pokémon besteht aus fünf Untergebenen und einem Anführer. Die Befehle des Anführers werden nie in Frage gestellt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/11.ts
+++ b/data/Sword & Shield/Rebel Clash/11.ts
@@ -93,7 +93,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Its thin, winglike antennae are highly absorbent. It waits out rainy days in tree hollows."
+		en: "Its thin, winglike antennae are highly absorbent. It waits out rainy days in tree hollows.",
+		de: "Seine Antennen erinnern an dünne Flügel und saugen leicht Flüssigkeit auf. Regentage verbringt es regungslos in Baumhöhlen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/110.ts
+++ b/data/Sword & Shield/Rebel Clash/110.ts
@@ -26,7 +26,7 @@ const card: Card = {
 				es: "",
 				it: "",
 				pt: "",
-				de: ""
+				de: "Eiserne Abwehrformation"
 			},
 			effect: {
 				en: "All of your Pokémon that have \"Falinks\" in their name take 20 less damage from your opponent's attacks (after applying Weakness and Resistance).",
@@ -34,7 +34,7 @@ const card: Card = {
 				es: "",
 				it: "",
 				pt: "",
-				de: ""
+				de: "Allen deinen Pokémon, bei denen „Legios“ zum Namen gehört, werden durch Attacken deines Gegners 20 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],

--- a/data/Sword & Shield/Rebel Clash/111.ts
+++ b/data/Sword & Shield/Rebel Clash/111.ts
@@ -81,7 +81,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It stands in grasslands, watching the sun's descent from zenith to horizon. This Pokémon has a talent for delivering dynamic kicks."
+		en: "It stands in grasslands, watching the sun's descent from zenith to horizon. This Pokémon has a talent for delivering dynamic kicks.",
+		de: "Es verweilt auf weitläufigen Wiesen und beobachtet den Lauf der Sonne. Dynamische Trittangriffe sind sein Spezialgebiet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/112.ts
+++ b/data/Sword & Shield/Rebel Clash/112.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its body is full of poisonous gas. It floats into garbage dumps, seeking out the fumes of raw, rotting trash."
+		en: "Its body is full of poisonous gas. It floats into garbage dumps, seeking out the fumes of raw, rotting trash.",
+		de: "Sein Körper ist zum Bersten voll mit Giftgas. Angelockt vom fauligen Geruch verrottender Abfälle, lungert es auf Müllhalden herum."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/113.ts
+++ b/data/Sword & Shield/Rebel Clash/113.ts
@@ -89,7 +89,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon consumes particles that contaminate the air. Instead of leaving droppings, it expels clean air."
+		en: "This Pokémon consumes particles that contaminate the air. Instead of leaving droppings, it expels clean air.",
+		de: "Es saugt Schmutzpartikel aus der Atmosphäre und scheidet sie dann anstelle von Exkrementen in Form von sauberer Luft wieder aus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/114.ts
+++ b/data/Sword & Shield/Rebel Clash/114.ts
@@ -61,7 +61,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "From its rear, it sprays a foul-smelling liquid at opponents. It aims for their faces, and it can hit them from over 16 feet away."
+		en: "From its rear, it sprays a foul-smelling liquid at opponents. It aims for their faces, and it can hit them from over 16 feet away.",
+		de: "Aus seinem Hinterleib sprüht es Gegnern eine fürchterlich stinkende Flüssigkeit ins Gesicht. Dabei hat es eine Reichweite von bis zu 5 m."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/115.ts
+++ b/data/Sword & Shield/Rebel Clash/115.ts
@@ -88,7 +88,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "In its belly, it reserves stinky fluid that it shoots from its tail during battle. As this Pokémon's diet varies, so does the stench of its fluid."
+		en: "In its belly, it reserves stinky fluid that it shoots from its tail during battle. As this Pokémon's diet varies, so does the stench of its fluid.",
+		de: "In seinem Magen speichert es eine stinkende Flüssigkeit, die es im Kampf aus seinem Schweif sprüht. Ihr Geruch hängt von seiner Nahrung ab."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/116.ts
+++ b/data/Sword & Shield/Rebel Clash/116.ts
@@ -82,7 +82,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It was bound to a fissure in an Odd Keystone as punishment for misdeeds 500 years ago."
+		en: "It was bound to a fissure in an Odd Keystone as punishment for misdeeds 500 years ago.",
+		de: "Es wurde in einen Spalt eines Steins gebannt, als Sühne für Untaten, die es vor 500 Jahren begangen hatte."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/117.ts
+++ b/data/Sword & Shield/Rebel Clash/117.ts
@@ -61,7 +61,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its favorite places are unsanitary ones. If you leave trash lying around, you could even find one of these Pokémon living in your room."
+		en: "Its favorite places are unsanitary ones. If you leave trash lying around, you could even find one of these Pokémon living in your room.",
+		de: "Es liebt schmutzige Orte. Angeblich zieht es auch in menschliche Behausungen ein, wenn man zu viel Müll herumliegen lässt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/118.ts
+++ b/data/Sword & Shield/Rebel Clash/118.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon eats trash, which turns into poison inside its body. The main component of the poison depends on what sort of trash was eaten."
+		en: "This Pokémon eats trash, which turns into poison inside its body. The main component of the poison depends on what sort of trash was eaten.",
+		de: "Es frisst Müll und verdaut ihn in seinem Inneren zu Gift. Je nach Art des Mülls, den es verzehrt, ändern sich die Hauptbestandteile des Giftes."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/119.ts
+++ b/data/Sword & Shield/Rebel Clash/119.ts
@@ -67,7 +67,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It wears a bone to protect its rear. It often squabbles with others of its kind over particularly comfy bones."
+		en: "It wears a bone to protect its rear. It often squabbles with others of its kind over particularly comfy bones.",
+		de: "Sie schützen ihren Bürzel mit einer Schädelwindel. Untereinander streiten sie sich um den Schädel mit dem höchsten Tragekomfort."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/12.ts
+++ b/data/Sword & Shield/Rebel Clash/12.ts
@@ -72,7 +72,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It lives on snowy mountains. It sinks its legs into the snow to absorb water and keep its own temperature down."
+		en: "It lives on snowy mountains. It sinks its legs into the snow to absorb water and keep its own temperature down.",
+		de: "Es lebt auf verschneiten Bergen und steckt seine Füße in den Schnee, um über sie Wasser und Kälte zu absorbieren."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/120.ts
+++ b/data/Sword & Shield/Rebel Clash/120.ts
@@ -99,7 +99,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Although it's a bit of a ruffian, this Pokémon will take lost Vullaby under its wing and care for them till they're ready to leave the nest."
+		en: "Although it's a bit of a ruffian, this Pokémon will take lost Vullaby under its wing and care for them till they're ready to leave the nest.",
+		de: "Grypheldis sind ziemliche Grobiane. Begegnet ihnen ein verirrtes Skallyk, kümmern sie sich aber liebevoll um es, bis es das Nest verlassen kann."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/123.ts
+++ b/data/Sword & Shield/Rebel Clash/123.ts
@@ -69,7 +69,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Through its nose, it sucks in the emanations produced by people and Pokémon when they feel annoyed. It thrives off this negative energy."
+		en: "Through its nose, it sucks in the emanations produced by people and Pokémon when they feel annoyed. It thrives off this negative energy.",
+		de: "Es wird kräftiger, indem es die von unzufriedenen Menschen und Pokémon ausgestoßene negative Energie einatmet."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/124.ts
+++ b/data/Sword & Shield/Rebel Clash/124.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "When it gets down on all fours as if to beg for forgiveness, it's trying to lure opponents in so that it can stab them with its spear-like hair."
+		en: "When it gets down on all fours as if to beg for forgiveness, it's trying to lure opponents in so that it can stab them with its spear-like hair.",
+		de: "Es nutzt eine Taktik, bei der es sich niederwirft und vorgibt, sich zu entschuldigen, nur um dann mit seinem speerartigen Haar zuzustoßen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/125.ts
+++ b/data/Sword & Shield/Rebel Clash/125.ts
@@ -43,7 +43,7 @@ const card: Card = {
 				es: "Mientras este Pokémon esté en el Puesto Activo, los ataques del Pokémon Activo de tu rival cuestan Colorless más.",
 				it: "Fintanto che questo Pokémon è in posizione attiva, il costo degli attacchi del Pokémon attivo del tuo avversario aumenta di Colorless.",
 				pt: "Enquanto este Pokémon estiver no Campo Ativo, os ataques do Pokémon Ativo do seu oponente custam Colorless a mais.",
-				de: "Solange dieses Pokémon in der Aktiven Position ist, erhöhen sich die Kosten der Attacken des Aktiven Pokémon deines Gegners um Colorless."
+				de: "Solange dieses Pokémon in der Aktiven Position ist, erhöhen sich die Kosten der Attacken des Aktiven Pokémon deines Gegners um {C}."
 			},
 		},
 	],
@@ -92,7 +92,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "With the hair wrapped around its body helping to enhance its muscles, this Pokémon can overwhelm even Machamp."
+		en: "With the hair wrapped around its body helping to enhance its muscles, this Pokémon can overwhelm even Machamp.",
+		de: "Wickelt es seine Haare um den ganzen Körper, verstärkt dies seine Muskelkraft. Das macht es so stark, dass es sogar Machomei bezwingen könnte."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/126.ts
+++ b/data/Sword & Shield/Rebel Clash/126.ts
@@ -83,7 +83,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Living with a savage, seafaring people has toughened this Pokémon's body so much that parts of it have turned to iron."
+		en: "Living with a savage, seafaring people has toughened this Pokémon's body so much that parts of it have turned to iron.",
+		de: "Das Leben bei einem kriegerischen Seefahrervolk hat es stärker gemacht. Manche Stellen an seinem Körper wandelten sich dabei zu Eisen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/127.ts
+++ b/data/Sword & Shield/Rebel Clash/127.ts
@@ -95,7 +95,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "What appears to be an iron helmet is actually hardened hair. This Pokémon lives for the thrill of battle."
+		en: "What appears to be an iron helmet is actually hardened hair. This Pokémon lives for the thrill of battle.",
+		de: "Die Haare auf seinem Kopf haben sich zu etwas verhärtet, das an einen eisernen Helm erinnert. Es ist von Natur aus kriegerisch veranlagt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/128.ts
+++ b/data/Sword & Shield/Rebel Clash/128.ts
@@ -101,7 +101,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Once it has identified something as an enemy, it will continue beating them with its steel-hard pincers until there's nothing left but scraps."
+		en: "Once it has identified something as an enemy, it will continue beating them with its steel-hard pincers until there's nothing left but scraps.",
+		de: "Sobald es ein anderes Pokémon als Feind erkennt, schlägt es dieses mit seinen stahlharten Scheren gnadenlos in Stücke."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/129.ts
+++ b/data/Sword & Shield/Rebel Clash/129.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It appears in ancient ruins. The pattern on its body doesn't come from any culture in the Galar region, so it remains shrouded in mystery."
+		en: "It appears in ancient ruins. The pattern on its body doesn't come from any culture in the Galar region, so it remains shrouded in mystery.",
+		de: "Es erscheint in alten Ruinen. Sein Muster ist ein Rätsel, da es nicht aus einer in Galar beheimateten Kultur stammt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/13.ts
+++ b/data/Sword & Shield/Rebel Clash/13.ts
@@ -90,7 +90,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "If it sees any packs of Darumaka going after Snover, it chases them off, swinging its sizable arms like hammers."
+		en: "If it sees any packs of Darumaka going after Snover, it chases them off, swinging its sizable arms like hammers.",
+		de: "Es schwingt seine großen Arme wie Hämmer und vertreibt damit Gruppen von Flampion, die es auf Shnebedeck abgesehen haben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/130.ts
+++ b/data/Sword & Shield/Rebel Clash/130.ts
@@ -94,7 +94,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Some believe it to be a deity that summons rain clouds. When angered, it lets out a warning cry that rings out like the tolling of a bell."
+		en: "Some believe it to be a deity that summons rain clouds. When angered, it lets out a warning cry that rings out like the tolling of a bell.",
+		de: "Man verehrt es als Regenmacher. Wird es wütend, droht es mit einer unheimlichen Stimme, die wie der Ton einer Glocke klingt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/131.ts
+++ b/data/Sword & Shield/Rebel Clash/131.ts
@@ -46,7 +46,7 @@ const card: Card = {
 				es: "Este ataque hace 30 puntos de daño más por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 30 danni in più per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Este ataque causa 30 pontos de dano a mais para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-				de: "Diese Attacke fügt für jedes Colorless in den Rückzugskosten des Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu."
+				de: "Diese Attacke fügt für jedes {C} in den Rückzugskosten des Aktiven Pokémon deines Gegners 30 Schadenspunkte mehr zu."
 			},
 			damage: "10+",
 
@@ -94,7 +94,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It uses three small units to catch prey and battle enemies. The main body mostly just gives orders."
+		en: "It uses three small units to catch prey and battle enemies. The main body mostly just gives orders.",
+		de: "Sein Körper selbst befehligt meist nur die drei kleinen Einheiten, die an seiner Stelle kämpfen und für die Nahrungssuche zuständig sind."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/132.ts
+++ b/data/Sword & Shield/Rebel Clash/132.ts
@@ -84,7 +84,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "They lay their eggs deep inside their nests. When attacked by Heatmor, they retaliate using their massive mandibles."
+		en: "They lay their eggs deep inside their nests. When attacked by Heatmor, they retaliate using their massive mandibles.",
+		de: "Es legt seine Eier im hintersten Winkel des Nests. Wenn es von Furnifraß bedroht wird, wehrt es sich mit seinen kräftigen Kiefern."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/133.ts
+++ b/data/Sword & Shield/Rebel Clash/133.ts
@@ -61,7 +61,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Honedge's soul once belonged to a person who was killed a long time ago by the sword that makes up Honedge's body."
+		en: "Honedge's soul once belonged to a person who was killed a long time ago by the sword that makes up Honedge's body.",
+		de: "Seine Seele ist die eines Menschen, der vor langer Zeit durch dieses Schwert getötet wurde."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/134.ts
+++ b/data/Sword & Shield/Rebel Clash/134.ts
@@ -95,7 +95,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Honedge evolves into twins. The two blades rub together to emit a metallic sound that unnerves opponents."
+		en: "Honedge evolves into twins. The two blades rub together to emit a metallic sound that unnerves opponents.",
+		de: "Bei der Entwicklung hat es sich verdoppelt. Es reibt seine Klingen aneinander, um Gegner mit einem metallenen Geräusch einzuschüchtern."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/135.ts
+++ b/data/Sword & Shield/Rebel Clash/135.ts
@@ -93,7 +93,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "In this defensive stance, Aegislash uses its steel body and a force field of spectral power to reduce the damage of any attack."
+		en: "In this defensive stance, Aegislash uses its steel body and a force field of spectral power to reduce the damage of any attack.",
+		de: "Mit seinem stählernen Körper und der Barriere, die es durch eine mysteriöse Kraft erzeugt, vermag es jegliche Angriffe abzuschwächen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/138.ts
+++ b/data/Sword & Shield/Rebel Clash/138.ts
@@ -37,7 +37,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Metal de tu pila de descartes a 1 de tus Pokémon.",
 				it: "Assegna a uno dei tuoi Pokémon una carta Energia Metal dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia Metal da sua pilha de descarte a 1 dos seus Pokémon.",
-				de: "Lege 1 Metal-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon an."
+				de: "Lege 1 {M}-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon an."
 			},
 			damage: 30,
 
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its body resembles polished metal, and it's both lightweight and strong. The only drawback is that it rusts easily."
+		en: "Its body resembles polished metal, and it's both lightweight and strong. The only drawback is that it rusts easily.",
+		de: "Sein an aufpoliertes Metall erinnernder Körper ist nicht nur leicht, sondern auch robust. Er hat jedoch den Nachteil, schnell zu rosten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/139.ts
+++ b/data/Sword & Shield/Rebel Clash/139.ts
@@ -38,7 +38,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Metal de tu pila de descartes a este Pokémon.",
 				it: "Assegna a questo Pokémon una carta Energia Metal dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia Metal da sua pilha de descarte a este Pokémon.",
-				de: "Lege 1 Metal-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
+				de: "Lege 1 {M}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 			},
 			damage: 30,
 
@@ -93,7 +93,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Now armed with a weapon it used in ancient times, this Pokémon needs only a single strike to fell even Gigantamax Pokémon."
+		en: "Now armed with a weapon it used in ancient times, this Pokémon needs only a single strike to fell even Gigantamax Pokémon.",
+		de: "Es trägt nun eine Waffe, die es vor langer Zeit einmal führte. Selbst Gigadynamax-Pokémon bezwingt es damit auf einen Streich."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/14.ts
+++ b/data/Sword & Shield/Rebel Clash/14.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "After a lost child perished in the forest, their spirit possessed a tree stump, causing the spirit's rebirth as this Pokémon."
+		en: "After a lost child perished in the forest, their spirit possessed a tree stump, causing the spirit's rebirth as this Pokémon.",
+		de: "Die Seele eines Kindes, das sich im Wald verlief und dabei ums Leben kam, nistete sich in einem Baumstumpf ein und wurde zu diesem Pokémon."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/140.ts
+++ b/data/Sword & Shield/Rebel Clash/140.ts
@@ -93,7 +93,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its ability to deflect any attack led to it being known as the Fighting Master's Shield. It was feared and respected by all."
+		en: "Its ability to deflect any attack led to it being known as the Fighting Master's Shield. It was feared and respected by all.",
+		de: "Weil es alles und jeden abwehren konnte, trug es einst den Namen „Kämpferkönigsschild“ und wurde gleichermaßen gefürchtet und verehrt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/141.ts
+++ b/data/Sword & Shield/Rebel Clash/141.ts
@@ -84,7 +84,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It is not satisfied unless it eats over 880 pounds of food every day. When it is done eating, it goes promptly to sleep."
+		en: "It is not satisfied unless it eats over 880 pounds of food every day. When it is done eating, it goes promptly to sleep.",
+		de: "Es muss über 400 kg Nahrung am Tag fressen, um satt zu werden. Ist es mit dem Essen fertig, schläft es sofort ein."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/142.ts
+++ b/data/Sword & Shield/Rebel Clash/142.ts
@@ -83,7 +83,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It can learn and speak human words. If they gather, they all learn the same saying."
+		en: "It can learn and speak human words. If they gather, they all learn the same saying.",
+		de: "Es kann die menschliche Sprache nachahmen. Versammeln sie sich, bringen sich alle dasselbe bei."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/143.ts
+++ b/data/Sword & Shield/Rebel Clash/143.ts
@@ -37,7 +37,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 2 Pokémon con Resistencia a Fighting, enséñalos y ponlos en tu mano. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a due Pokémon con resistenza al tipo Fighting, mostrali e aggiungili alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 2 Pokémon com Resistência Fighting no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 2 Pokémon mit Fighting-Resistenz, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 2 Pokémon mit {F}-Resistenz, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -83,7 +83,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Where people go, these Pokémon follow. If you're scattering food for them, be careful—several hundred of them can gather at once."
+		en: "Where people go, these Pokémon follow. If you're scattering food for them, be careful—several hundred of them can gather at once.",
+		de: "Es taucht dort auf, wo Menschen leben. Beim Füttern muss man vorsichtig sein, da sich sonst schnell hunderte von ihnen versammeln können."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/144.ts
+++ b/data/Sword & Shield/Rebel Clash/144.ts
@@ -88,7 +88,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It can fly moderately quickly. No matter how far it travels, it can always find its way back to its master and its nest."
+		en: "It can fly moderately quickly. No matter how far it travels, it can always find its way back to its master and its nest.",
+		de: "Navitaub kann einigermaßen schnell fliegen. Es findet immer zu seinem Trainer und seinem Nest zurück, egal, wie weit entfernt es von ihnen ist."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/145.ts
+++ b/data/Sword & Shield/Rebel Clash/145.ts
@@ -102,7 +102,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "Unfezant are exceptional fliers. The females are known for their stamina, while the males outclass them in terms of speed."
+		en: "Unfezant are exceptional fliers. The females are known for their stamina, while the males outclass them in terms of speed.",
+		de: "Sie verfügen über exzellente Flugfertigkeiten. Weibchen können länger fliegen, aber dafür erreichen Männchen ein höheres Flugtempo."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/146.ts
+++ b/data/Sword & Shield/Rebel Clash/146.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It excels at digging holes. Using its ears, it can dig a nest 33 feet deep in one night."
+		en: "It excels at digging holes. Using its ears, it can dig a nest 33 feet deep in one night.",
+		de: "Mit den Ohren schaufelt es Löcher. Es braucht nur eine Nacht, um einen 10 m tiefen Bau zu graben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/147.ts
+++ b/data/Sword & Shield/Rebel Clash/147.ts
@@ -90,7 +90,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "With power equal to an excavator, it can dig through dense bedrock. It's a huge help during tunnel construction."
+		en: "With power equal to an excavator, it can dig through dense bedrock. It's a huge help during tunnel construction.",
+		de: "Seine Stärke gleicht der eines Baggers, sodass es sich durch harte Gesteinsschichten graben kann. Es leistet großartige Arbeit beim Tunnelbau."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/148.ts
+++ b/data/Sword & Shield/Rebel Clash/148.ts
@@ -82,7 +82,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It drives its opponents to exhaustion with its agile maneuvers, then ends the fight with a flashy finishing move."
+		en: "It drives its opponents to exhaustion with its agile maneuvers, then ends the fight with a flashy finishing move.",
+		de: "Durch flinke Angriffsmanöver raubt es seinen Gegnern ihre Kraft, um sie dann mit prachtvollen Spezialtechniken niederzuringen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/149.ts
+++ b/data/Sword & Shield/Rebel Clash/149.ts
@@ -78,7 +78,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its fluffy fur is a delight to pet, but carelessly reaching out to touch this Pokémon could result in painful retaliation."
+		en: "Its fluffy fur is a delight to pet, but carelessly reaching out to touch this Pokémon could result in painful retaliation.",
+		de: "Sein Pelz ist wunderbar flauschig. Wagt man es jedoch, diesen zu berühren, setzt es sich ohne Rücksicht auf Verluste zur Wehr."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/15.ts
+++ b/data/Sword & Shield/Rebel Clash/15.ts
@@ -87,7 +87,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "People fear it due to a belief that it devours any who try to cut down trees in its forest, but to the Pokémon it shares its woods with, it's kind."
+		en: "People fear it due to a belief that it devours any who try to cut down trees in its forest, but to the Pokémon it shares its woods with, it's kind.",
+		de: "Es wird dafür gefürchtet, Menschen zu fressen, die Bäume im Wald fällen. Zu den Pokémon, die den Wald bewohnen, ist es aber stets nett."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/150.ts
+++ b/data/Sword & Shield/Rebel Clash/150.ts
@@ -96,7 +96,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Once it accepts you as a friend, it tries to show its affection with a hug. Letting it do that is dangerous—it could easily shatter your bones."
+		en: "Once it accepts you as a friend, it tries to show its affection with a hug. Letting it do that is dangerous—it could easily shatter your bones.",
+		de: "Es drückt seine Zuneigung durch Umarmungen aus. Das ist ebenso sympathisch wie gefährlich, da diese zu Knochenbrüchen führen können."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/151.ts
+++ b/data/Sword & Shield/Rebel Clash/151.ts
@@ -69,7 +69,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Found throughout the Galar region, this Pokémon becomes uneasy if its cheeks are ever completely empty of berries."
+		en: "Found throughout the Galar region, this Pokémon becomes uneasy if its cheeks are ever completely empty of berries.",
+		de: "Es ist überall in der Galar-Region anzutreffen. Hat es keine Beeren, die es in seinen beiden Backen horten kann, wird es unruhig."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/152.ts
+++ b/data/Sword & Shield/Rebel Clash/152.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It stashes berries in its tail—so many berries that they fall out constantly. But this Pokémon is a bit slow-witted, so it doesn't notice the loss."
+		en: "It stashes berries in its tail—so many berries that they fall out constantly. But this Pokémon is a bit slow-witted, so it doesn't notice the loss.",
+		de: "Es hortet in seinem Schweif Beeren. Versucht es, zu viele unterzubringen, fallen sie heraus. Da es jedoch nicht allzu clever ist, bemerkt es das nicht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/154.ts
+++ b/data/Sword & Shield/Rebel Clash/154.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/155.ts
+++ b/data/Sword & Shield/Rebel Clash/155.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon Fire al que está unida esta carta está en el Puesto Activo y resulta dañado por un ataque de tu rival (incluso si queda Fuera de Combate), el Pokémon Atacante pasa a estar Quemado.",
 		it: "Se il Pokémon Fire a cui è assegnata questa carta è in posizione attiva e viene danneggiato da un attacco dell'avversario, anche se viene messo KO, il Pokémon attaccante viene bruciato.",
 		pt: "Se o Pokémon Fire ao qual esta carta está ligada estiver no Campo Ativo e for danificado por um ataque do seu oponente (mesmo que ele seja Nocauteado), o Pokémon Atacante ficará Queimado.",
-		de: "Wenn das Fire-Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist und durch eine Attacke deines Gegners Schaden erhält (auch wenn es dadurch kampfunfähig wird), ist das Angreifende Pokémon jetzt verbrannt."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das {R}-Pokémon, an das diese Karte angelegt ist, in der Aktiven Position ist und durch eine Attacke deines Gegners Schaden erhält (auch wenn es dadurch kampfunfähig wird), ist das Angreifende Pokémon jetzt verbrannt. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Rebel Clash/156.ts
+++ b/data/Sword & Shield/Rebel Clash/156.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Energía Water, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due carte Energia Water, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 cartas de Energia Water no seu baralho, revele-as e coloque-as na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Water-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 {W}-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Rebel Clash/157.ts
+++ b/data/Sword & Shield/Rebel Clash/157.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Si el Pokémon al que está unida esta carta queda Fuera de Combate por el daño de un ataque de tu rival, descarta las 2 primeras cartas de la baraja de tu rival.",
 		it: "Se il Pokémon a cui è assegnata questa carta viene messo KO dai danni inflitti da un attacco dell'avversario, scarta le prime due carte del mazzo del tuo avversario.",
 		pt: "Se o Pokémon ao qual esta carta está ligada for Nocauteado pelo dano de um ataque do seu oponente, descarte as 2 cartas de cima do baralho do seu oponente.",
-		de: "Wenn das Pokémon, an das diese Karte angelegt ist, durch Schaden einer Attacke deines Gegners kampfunfähig wird, lege die obersten 2 Karten des Decks deines Gegners auf seinen Ablagestapel."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Wenn das Pokémon, an das diese Karte angelegt ist, durch Schaden einer Attacke deines Gegners kampfunfähig wird, lege die obersten 2 Karten des Decks deines Gegners auf seinen Ablagestapel. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Rebel Clash/158.ts
+++ b/data/Sword & Shield/Rebel Clash/158.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Roba 2 cartas. Tu rival y tú jugáis a piedra, papel, tijeras hasta que gane uno de los dos. Si ganas tú, roba 2 cartas más.",
 		it: "Pesca due carte. Tu e il tuo avversario giocate a morra cinese finché uno dei due non vince. Se vinci, pesca altre due carte.",
 		pt: "Compre 2 cartas. Você e seu oponente jogam \"pedra, papel e tesoura\" até alguém vencer. Se você vencer, compre 2 cartas a mais.",
-		de: "Ziehe 2 Karten. Du und dein Gegner spielt Schere/Stein/Papier, bis jemand gewinnt. Wenn du gewinnst, ziehe 2 Karten mehr."
+		de: "Ziehe 2 Karten. Du und dein Gegner spielt Schere/Stein/Papier, bis jemand gewinnt. Wenn du gewinnst, ziehe 2 Karten mehr. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/159.ts
+++ b/data/Sword & Shield/Rebel Clash/159.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Tu Pokémon Activo se recupera de todas las Condiciones Especiales.",
 		it: "Il tuo Pokémon attivo guarisce da tutte le condizioni speciali.",
 		pt: "O seu Pokémon Ativo se recupera de todas as Condições Especiais.",
-		de: "Dein Aktives Pokémon erholt sich von allen Speziellen Zuständen."
+		de: "Dein Aktives Pokémon erholt sich von allen Speziellen Zuständen. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Rebel Clash/16.ts
+++ b/data/Sword & Shield/Rebel Clash/16.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its natural enemies, like Rookidee, may flee rather than risk getting caught in its large mandibles that can snap thick tree branches."
+		en: "Its natural enemies, like Rookidee, may flee rather than risk getting caught in its large mandibles that can snap thick tree branches.",
+		de: "Sein großer Kiefer ist stark genug, um selbst dicke Äste zu zerbrechen. Damit treibt es auch seinen natürlichen Feind Meikro in die Flucht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/160.ts
+++ b/data/Sword & Shield/Rebel Clash/160.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "El Coste de Retirada de ambos Pokémon Activos es de ColorlessColorless más.",
 		it: "Il costo di ritirata di entrambi i Pokémon attivi aumenta di ColorlessColorless.",
 		pt: "O custo de Recuo de ambos os Pokémon Ativos é ColorlessColorless a mais.",
-		de: "Die Rückzugskosten beider Aktiven Pokémon erhöhen sich um ColorlessColorless."
+		de: "Die Rückzugskosten beider Aktiven Pokémon erhöhen sich um {C}{C}. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte auf den Ablagestapel, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit demselben Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sword & Shield/Rebel Clash/161.ts
+++ b/data/Sword & Shield/Rebel Clash/161.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta hasta 2 cartas de tu mano y roba 2 cartas por cada carta que hayas descartado de esta manera.",
 		it: "Scarta fino a due carte che hai in mano e pesca due carte per ogni carta che hai scartato in questo modo.",
 		pt: "Descarte até 2 cartas da sua mão e compre 2 cartas para cada carta descartada desta forma.",
-		de: "Lege bis zu 2 Karten aus deiner Hand auf deinen Ablagestapel und ziehe 2 Karten für jede auf diese Weise auf deinen Ablagestapel gelegte Karte."
+		de: "Lege bis zu 2 Karten aus deiner Hand auf deinen Ablagestapel und ziehe 2 Karten für jede auf diese Weise auf deinen Ablagestapel gelegte Karte. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/162.ts
+++ b/data/Sword & Shield/Rebel Clash/162.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si la has robado de tu baraja al principio de tu turno, antes de ponerla en tu mano.\n\nRoba 3 cartas.",
 		it: "Puoi giocare questa carta solo se l'hai pescata dal tuo mazzo all'inizio del tuo turno, prima di aggiungerla alle carte che hai in mano.\n\nPesca tre carte.",
 		pt: "Você só pode jogar esta carta se a tiver comprado do seu baralho no começo do seu turno, antes de colocá-la na sua mão.\n\nCompre 3 cartas.",
-		de: "Du kannst diese Karte nur spielen, wenn du sie zu Beginn deines Zuges von deinem Deck gezogen hast und bevor du sie auf deine Hand nimmst.\n\nZiehe 3 Karten."
+		de: "Du kannst diese Karte nur spielen, wenn du sie zu Beginn deines Zuges von deinem Deck gezogen hast und bevor du sie auf deine Hand nimmst. Ziehe 3 Karten. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Rebel Clash/163.ts
+++ b/data/Sword & Shield/Rebel Clash/163.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si descartas otras 2 cartas de tu mano.\n\nTu rival enseña las cartas de su mano. Pon 1 carta de Entrenador que encuentres entre ellas en la parte inferior de su baraja.",
 		it: "Puoi giocare questa carta solo se scarti altre due carte che hai in mano.\n\nIl tuo avversario mostra le carte che ha in mano. Prendi una carta Allenatore presente tra esse e mettila in fondo al suo mazzo.",
 		pt: "Você só pode jogar esta carta se descartar outras 2 cartas da sua mão.\n\nSeu oponente revela a própria mão. Coloque 1 carta de Treinador que encontrar lá como a carta de baixo do baralho dele(a).",
-		de: "Du kannst diese Karte nur spielen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst.\n\nDein Gegner zeigt dir seine Handkarten. Lege 1 Trainerkarte, die du dort findest, unter sein Deck."
+		de: "Du kannst diese Karte nur spielen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst. Dein Gegner zeigt dir seine Handkarten. Lege 1 Trainerkarte, die du dort findest, unter sein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/164.ts
+++ b/data/Sword & Shield/Rebel Clash/164.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Lanza 1 moneda. Si sale cara, busca en tu baraja 1 Pokémon, enséñalo y ponlo en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Lancia una moneta. Se esce testa, cerca nel tuo mazzo un Pokémon, mostralo e aggiungilo alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Jogue 1 moeda. Se sair cara, procure por 1 Pokémon no seu baralho, revele-o e coloque-o na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck."
+		de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Pokémon, zeige es deinem Gegner und nimm es auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Rebel Clash/165.ts
+++ b/data/Sword & Shield/Rebel Clash/165.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Pon 1 de tus Pokémon que no sea un Pokémon V o un Pokémon-GX en tu mano. (Descarta todas las cartas unidas a él).",
 		it: "Prendi uno dei tuoi Pokémon che non è Pokémon-V o un Pokémon-GX e aggiungilo alle carte che hai in mano. Scarta tutte le carte assegnate.",
 		pt: "Coloque 1 dos seus Pokémon que não seja um Pokémon V ou um Pokémon-GX na sua mão (descarte todas as cartas ligadas a ele).",
-		de: "Nimm 1 deiner Pokémon, das kein Pokémon-V oder Pokémon-GX ist, auf deine Hand. (Lege alle angelegten Karten auf deinen Ablagestapel.)"
+		de: "Nimm 1 deiner Pokémon, das kein Pokémon-V oder Pokémon-GX ist, auf deine Hand. (Lege alle angelegten Karten auf deinen Ablagestapel.) Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Rebel Clash/166.ts
+++ b/data/Sword & Shield/Rebel Clash/166.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja una carta de Entrenador, enséñala y ponla en tu mano. Baraja las cartas de tu baraja después.",
 		it: "Cerca nel tuo mazzo una carta Allenatore, mostrala e aggiungila alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure um card de Treinador em seu baralho, revele-o e coloque-o em sua mão. Em seguida, embaralhe seus cards.",
-		de: "Durchsuche dein Deck nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach 1 Trainerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/167.ts
+++ b/data/Sword & Shield/Rebel Clash/167.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Pokémon Básico o hasta 2 cartas de Energía Básica, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due Pokémon Base o due carte Energia base, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 Pokémon Básicos ou até 2 cartas de Energia básica no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon oder bis zu 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon oder bis zu 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/168.ts
+++ b/data/Sword & Shield/Rebel Clash/168.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Elige hasta 2 Herramientas Pokémon unidas a Pokémon (tuyos o de tu rival) y descártalas.",
 		it: "Scegli fino a due carte Oggetto Pokémon assegnate ai Pokémon, tuoi o del tuo avversario, e scartale.",
 		pt: "Escolha até 2 Ferramentas Pokémon ligadas a Pokémon (seus ou do seu oponente) e descarte-as.",
-		de: "Wähle bis zu 2 an Pokémon (deine oder die deines Gegners) angelegte Pokémon-Ausrüstungen und lege sie auf den Ablagestapel."
+		de: "Wähle bis zu 2 an Pokémon (deine oder die deines Gegners) angelegte Pokémon-Ausrüstungen und lege sie auf den Ablagestapel. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Rebel Clash/169.ts
+++ b/data/Sword & Shield/Rebel Clash/169.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Una vez durante el turno de cada jugador, ese jugador puede poner 1 carta de Energía Básica de su pila de descartes en su mano.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può prendere una carta Energia base dalla propria pila degli scarti e aggiungerla alle carte che ha in mano.",
 		pt: "Uma vez durante o turno de cada jogador, aquele jogador poderá colocar 1 carta de Energia básica da própria pilha de descarte na própria mão.",
-		de: "Einmal während des Zuges jedes Spielers kann jener Spieler 1 Basis-Energiekarte aus seinem Ablagestapel auf seine Hand nehmen."
+		de: "Einmal während des Zuges jedes Spielers kann jener Spieler 1 Basis-Energiekarte aus seinem Ablagestapel auf seine Hand nehmen. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte auf den Ablagestapel, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit demselben Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sword & Shield/Rebel Clash/17.ts
+++ b/data/Sword & Shield/Rebel Clash/17.ts
@@ -37,7 +37,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 2 Pokémon Grass Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a due Pokémon Base Grass e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 2 Pokémon Grass Básicos no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 2 Basis-Grass-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 2 Basis-{G}-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},

--- a/data/Sword & Shield/Rebel Clash/170.ts
+++ b/data/Sword & Shield/Rebel Clash/170.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Una vez durante el turno de cada jugador, ese jugador puede buscar en su baraja 1 Pokémon Grass Evolución, enseñarlo y ponerlo en su mano. Después, ese jugador baraja las cartas de su baraja.",
 		it: "Una sola volta durante il turno di ciascun giocatore, quel giocatore può cercare nel suo mazzo un Pokémon Evoluzione Grass, mostrarlo e aggiungerlo alle carte che ha in mano. Poi quel giocatore rimischia le carte del suo mazzo.",
 		pt: "Uma vez durante o turno de cada jogador, aquele jogador poderá procurar por 1 Pokémon Grass de Evolução no próprio baralho, revelá-lo e colocá-lo na própria mão. Em seguida, aquele jogador embaralha o próprio baralho.",
-		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach 1 Entwicklungs-Grass-Pokémon durchsuchen, es seinem Gegner zeigen und auf seine Hand nehmen. Anschließend mischt jener Spieler sein Deck."
+		de: "Einmal während des Zuges jedes Spielers kann jener Spieler sein Deck nach 1 Entwicklungs-{G}-Pokémon durchsuchen, es seinem Gegner zeigen und auf seine Hand nehmen. Anschließend mischt jener Spieler sein Deck. Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte auf den Ablagestapel, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit demselben Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 
 	trainerType: "Stadium",

--- a/data/Sword & Shield/Rebel Clash/171.ts
+++ b/data/Sword & Shield/Rebel Clash/171.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mientras esta carta esté unida a 1 Pokémon, proporciona 1 Energía Colorless.\n\nCuando unes esta carta de tu mano a 1 Pokémon, busca en tu baraja 1 Pokémon Básico y ponlo en tu Banca. Después, baraja las cartas de tu baraja.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon, fornisce Energia Colorless.\n\nQuando assegni questa carta dalla tua mano a un Pokémon, cerca nel tuo mazzo un Pokémon Base e mettilo nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon, ela fornecerá Energia Colorless.\n\nQuando você ligar esta carta da sua mão a 1 Pokémon, procure por 1 Pokémon Básico no seu baralho e coloque-o no seu Banco. Em seguida, embaralhe o seu baralho.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie Colorless-Energie.\n\nWenn du diese Karte aus deiner Hand an ein Pokémon anlegst, durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, liefert sie {C}-Energie. Wenn du diese Karte aus deiner Hand an ein Pokémon anlegst, durchsuche dein Deck nach 1 Basis-Pokémon und lege es auf deine Bank. Mische anschließend dein Deck."
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Rebel Clash/174.ts
+++ b/data/Sword & Shield/Rebel Clash/174.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mientras esta carta esté unida a 1 Pokémon que no sea un Pokémon V o un Pokémon-GX, proporciona 2 Energías Colorless.\n\nSi esta carta está unida a un Pokémon V o a un Pokémon-GX, proporciona 1 Energía Colorless en vez de 2.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon che non è un Pokémon-V o un Pokémon-GX, fornisce Energia ColorlessColorless.\n\nSe questa carta è assegnata a un Pokémon-V o a un Pokémon-GX, invece fornisce Energia Colorless.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon que não seja um Pokémon V ou um Pokémon-GX, ela fornecerá Energia ColorlessColorless.\n\nSe esta carta estiver ligada a um Pokémon V ou um Pokémon-GX, ela fornecerá Energia Colorless.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, das kein Pokémon-V oder Pokémon-GX ist, liefert diese Karte ColorlessColorless-Energie.\n\nWenn diese Karte an ein Pokémon-V oder Pokémon-GX angelegt ist, liefert sie stattdessen Colorless-Energie."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, das kein Pokémon-V oder Pokémon-GX ist, liefert diese Karte {C}{C}-Energie. Wenn diese Karte an ein Pokémon-V oder Pokémon-GX angelegt ist, liefert sie stattdessen {C}-Energie."
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Rebel Clash/175.ts
+++ b/data/Sword & Shield/Rebel Clash/175.ts
@@ -37,7 +37,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 2 Pokémon Grass Básicos y ponlos en tu Banca. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a due Pokémon Base Grass e mettili nella tua panchina. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 2 Pokémon Grass Básicos no seu baralho e coloque-os no seu Banco. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 2 Basis-Grass-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 2 Basis-{G}-Pokémon und lege sie auf deine Bank. Mische anschließend dein Deck."
 			},
 
 		},

--- a/data/Sword & Shield/Rebel Clash/178.ts
+++ b/data/Sword & Shield/Rebel Clash/178.ts
@@ -27,7 +27,7 @@ const card: Card = {
 				es: "",
 				it: "",
 				pt: "",
-				de: ""
+				de: "Feldspieler"
 			},
 			effect: {
 				en: "If a Stadium is in play, this Pokémon has no Retreat Cost.",

--- a/data/Sword & Shield/Rebel Clash/179.ts
+++ b/data/Sword & Shield/Rebel Clash/179.ts
@@ -38,7 +38,7 @@ const card: Card = {
 				es: "Este ataque hace 50 puntos de daño más por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 50 danni in più per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Este ataque causa 50 pontos de dano a mais para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-				de: "Diese Attacke fügt für jedes Colorless in den Rückzugskosten des Aktiven Pokémon deines Gegners 50 Schadenspunkte mehr zu."
+				de: "Diese Attacke fügt für jedes {C} in den Rückzugskosten des Aktiven Pokémon deines Gegners 50 Schadenspunkte mehr zu."
 			},
 			damage: "10+",
 

--- a/data/Sword & Shield/Rebel Clash/18.ts
+++ b/data/Sword & Shield/Rebel Clash/18.ts
@@ -64,7 +64,7 @@ const card: Card = {
 				es: "Puedes descartar hasta 3 Energías Grass de este Pokémon. Si lo haces, este ataque hace 50 puntos de daño más por cada carta que hayas descartado de esta manera.",
 				it: "Puoi scartare fino a tre Energie Grass da questo Pokémon. Se lo fai, questo attacco infligge 50 danni in più per ogni carta che hai scartato in questo modo.",
 				pt: "Você pode descartar até 3 Energias Grass deste Pokémon. Se fizer isto, este ataque causará 50 pontos de dano a mais para cada carta descartada desta forma.",
-				de: "Du kannst bis zu 3 Grass-Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, fügt diese Attacke für jede auf diese Weise abgelegte Karte 50 Schadenspunkte mehr zu."
+				de: "Du kannst bis zu 3 {G}-Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, fügt diese Attacke für jede auf diese Weise abgelegte Karte 50 Schadenspunkte mehr zu."
 			},
 			damage: "130+",
 

--- a/data/Sword & Shield/Rebel Clash/181.ts
+++ b/data/Sword & Shield/Rebel Clash/181.ts
@@ -37,7 +37,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 2 cartas de Energía Lightning y únelas a tus Pokémon en Banca de la manera que desees. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a due carte Energia Lightning e assegnale ai tuoi Pokémon in panchina nel modo che preferisci. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 2 cartas de Energia Lightning no seu baralho e ligue-as aos seus Pokémon no Banco como desejar. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 2 Lightning-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 2 {L}-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -60,7 +60,7 @@ const card: Card = {
 				es: "Este ataque hace 30 puntos de daño más por cada Energía Lightning unida a todos tus Pokémon.",
 				it: "Questo attacco infligge 30 danni in più per ogni Energia Lightning assegnata ai tuoi Pokémon.",
 				pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Lightning ligada a todos os seus Pokémon.",
-				de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte Lightning-Energie 30 Schadenspunkte mehr zu."
+				de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte {L}-Energie 30 Schadenspunkte mehr zu."
 			},
 			damage: "10+",
 

--- a/data/Sword & Shield/Rebel Clash/184.ts
+++ b/data/Sword & Shield/Rebel Clash/184.ts
@@ -36,7 +36,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Fighting de tu pila de descartes a este Pokémon.",
 				it: "Assegna a questo Pokémon una carta Energia Fighting dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia Fighting da sua pilha de descarte a este Pokémon.",
-				de: "Lege 1 Fighting-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
+				de: "Lege 1 {F}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 			},
 			damage: 30,
 

--- a/data/Sword & Shield/Rebel Clash/185.ts
+++ b/data/Sword & Shield/Rebel Clash/185.ts
@@ -26,7 +26,7 @@ const card: Card = {
 				es: "",
 				it: "",
 				pt: "",
-				de: ""
+				de: "Eiserne Abwehrformation"
 			},
 			effect: {
 				en: "All of your Pokémon that have \"Falinks\" in their name take 20 less damage from your opponent's attacks (after applying Weakness and Resistance).",
@@ -34,7 +34,7 @@ const card: Card = {
 				es: "",
 				it: "",
 				pt: "",
-				de: ""
+				de: "Allen deinen Pokémon, bei denen „Legios“ zum Namen gehört, werden durch Attacken deines Gegners 20 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},
 	],

--- a/data/Sword & Shield/Rebel Clash/189.ts
+++ b/data/Sword & Shield/Rebel Clash/189.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/190.ts
+++ b/data/Sword & Shield/Rebel Clash/190.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Descarta hasta 2 cartas de tu mano y roba 2 cartas por cada carta que hayas descartado de esta manera.",
 		it: "Scarta fino a due carte che hai in mano e pesca due carte per ogni carta che hai scartato in questo modo.",
 		pt: "Descarte até 2 cartas da sua mão e compre 2 cartas para cada carta descartada desta forma.",
-		de: "Lege bis zu 2 Karten aus deiner Hand auf deinen Ablagestapel und ziehe 2 Karten für jede auf diese Weise auf deinen Ablagestapel gelegte Karte."
+		de: "Lege bis zu 2 Karten aus deiner Hand auf deinen Ablagestapel und ziehe 2 Karten für jede auf diese Weise auf deinen Ablagestapel gelegte Karte. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/191.ts
+++ b/data/Sword & Shield/Rebel Clash/191.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si descartas otras 2 cartas de tu mano.\n\nTu rival enseña las cartas de su mano. Pon 1 carta de Entrenador que encuentres entre ellas en la parte inferior de su baraja.",
 		it: "Puoi giocare questa carta solo se scarti altre due carte che hai in mano.\n\nIl tuo avversario mostra le carte che ha in mano. Prendi una carta Allenatore presente tra esse e mettila in fondo al suo mazzo.",
 		pt: "Você só pode jogar esta carta se descartar outras 2 cartas da sua mão.\n\nSeu oponente revela a própria mão. Coloque 1 carta de Treinador que encontrar lá como a carta de baixo do baralho dele(a).",
-		de: "Du kannst diese Karte nur spielen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst.\n\nDein Gegner zeigt dir seine Handkarten. Lege 1 Trainerkarte, die du dort findest, unter sein Deck."
+		de: "Du kannst diese Karte nur spielen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst. Dein Gegner zeigt dir seine Handkarten. Lege 1 Trainerkarte, die du dort findest, unter sein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/192.ts
+++ b/data/Sword & Shield/Rebel Clash/192.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Pokémon Básico o hasta 2 cartas de Energía Básica, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due Pokémon Base o due carte Energia base, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 Pokémon Básicos ou até 2 cartas de Energia básica no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon oder bis zu 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon oder bis zu 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/193.ts
+++ b/data/Sword & Shield/Rebel Clash/193.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			es: "Puedes descartar hasta 3 Energías Grass de este Pokémon. Si lo haces, este ataque hace 50 puntos de daño más por cada carta que hayas descartado de esta manera.",
 			it: "Puoi scartare fino a tre Energie Grass da questo Pokémon. Se lo fai, questo attacco infligge 50 danni in più per ogni carta che hai scartato in questo modo.",
 			pt: "Você pode descartar até 3 Energias Grass deste Pokémon. Se fizer isto, este ataque causará 50 pontos de dano a mais para cada carta descartada desta forma.",
-			de: "Du kannst bis zu 3 Grass-Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, fügt diese Attacke für jede auf diese Weise abgelegte Karte 50 Schadenspunkte mehr zu."
+			de: "Du kannst bis zu 3 {G}-Energien von diesem Pokémon auf deinen Ablagestapel legen. Wenn du das machst, fügt diese Attacke für jede auf diese Weise abgelegte Karte 50 Schadenspunkte mehr zu."
 		},
 
 		damage: "130+",

--- a/data/Sword & Shield/Rebel Clash/196.ts
+++ b/data/Sword & Shield/Rebel Clash/196.ts
@@ -26,7 +26,7 @@ const card: Card = {
 		es: "Toxtricity V",
 		it: "Toxtricity-V",
 		pt: "Toxtricity V",
-		de: "Riffex-V"
+		de: "Riffex VMAX"
 	},
 
 	attacks: [{

--- a/data/Sword & Shield/Rebel Clash/2.ts
+++ b/data/Sword & Shield/Rebel Clash/2.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It is waiting for the moment to evolve. At this stage, it can only harden, so it remains motionless to avoid attack."
+		en: "It is waiting for the moment to evolve. At this stage, it can only harden, so it remains motionless to avoid attack.",
+		de: "In diesem Zustand wartet es auf die Entwicklung. Es kann nur seinen Panzer erhärten, daher bewegt es sich nicht, um nicht angegriffen zu werden."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/20.ts
+++ b/data/Sword & Shield/Rebel Clash/20.ts
@@ -61,7 +61,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It spends its entire life inside an apple. It hides from its natural enemies, bird Pokémon, by pretending it's just an apple and nothing more."
+		en: "It spends its entire life inside an apple. It hides from its natural enemies, bird Pokémon, by pretending it's just an apple and nothing more.",
+		de: "Es verbringt sein ganzes Leben im Inneren eines Apfels. Um sich vor Vogel-Pokémon, seinen Fressfeinden, zu schützen, imitiert es einen Apfel."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/200.ts
+++ b/data/Sword & Shield/Rebel Clash/200.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Cambia 1 de los Pokémon en Banca de tu rival por su Pokémon Activo.",
 		it: "Scambia uno dei Pokémon nella panchina del tuo avversario con il suo Pokémon attivo.",
 		pt: "Troque 1 dos Pokémon no Banco do seu oponente pelo Pokémon Ativo dele(a).",
-		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus."
+		de: "Tausche 1 Pokémon auf der Bank deines Gegners gegen sein Aktives Pokémon aus. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/201.ts
+++ b/data/Sword & Shield/Rebel Clash/201.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Descarta hasta 2 cartas de tu mano y roba 2 cartas por cada carta que hayas descartado de esta manera.",
 		it: "Scarta fino a due carte che hai in mano e pesca due carte per ogni carta che hai scartato in questo modo.",
 		pt: "Descarte até 2 cartas da sua mão e compre 2 cartas para cada carta descartada desta forma.",
-		de: "Lege bis zu 2 Karten aus deiner Hand auf deinen Ablagestapel und ziehe 2 Karten für jede auf diese Weise auf deinen Ablagestapel gelegte Karte."
+		de: "Lege bis zu 2 Karten aus deiner Hand auf deinen Ablagestapel und ziehe 2 Karten für jede auf diese Weise auf deinen Ablagestapel gelegte Karte. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/202.ts
+++ b/data/Sword & Shield/Rebel Clash/202.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Puedes jugar esta carta solo si descartas otras 2 cartas de tu mano.\n\nTu rival enseña las cartas de su mano. Pon 1 carta de Entrenador que encuentres entre ellas en la parte inferior de su baraja.",
 		it: "Puoi giocare questa carta solo se scarti altre due carte che hai in mano.\n\nIl tuo avversario mostra le carte che ha in mano. Prendi una carta Allenatore presente tra esse e mettila in fondo al suo mazzo.",
 		pt: "Você só pode jogar esta carta se descartar outras 2 cartas da sua mão.\n\nSeu oponente revela a própria mão. Coloque 1 carta de Treinador que encontrar lá como a carta de baixo do baralho dele(a).",
-		de: "Du kannst diese Karte nur spielen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst.\n\nDein Gegner zeigt dir seine Handkarten. Lege 1 Trainerkarte, die du dort findest, unter sein Deck."
+		de: "Du kannst diese Karte nur spielen, wenn du 2 andere Karten aus deiner Hand auf deinen Ablagestapel legst. Dein Gegner zeigt dir seine Handkarten. Lege 1 Trainerkarte, die du dort findest, unter sein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/203.ts
+++ b/data/Sword & Shield/Rebel Clash/203.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Busca en tu baraja hasta 2 cartas de Pokémon Básico o hasta 2 cartas de Energía Básica, enséñalas y ponlas en tu mano. Después, baraja las cartas de tu baraja.",
 		it: "Cerca nel tuo mazzo fino a due Pokémon Base o due carte Energia base, mostrale e aggiungile alle carte che hai in mano. Poi rimischia le carte del tuo mazzo.",
 		pt: "Procure por até 2 Pokémon Básicos ou até 2 cartas de Energia básica no seu baralho, revele-os e coloque-os na sua mão. Em seguida, embaralhe o seu baralho.",
-		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon oder bis zu 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
+		de: "Durchsuche dein Deck nach bis zu 2 Basis-Pokémon oder bis zu 2 Basis-Energiekarten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck. Du kannst während deines Zuges nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sword & Shield/Rebel Clash/204.ts
+++ b/data/Sword & Shield/Rebel Clash/204.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			es: "Todas las veces que quieras durante tu turno, puedes unir 1 carta de Energía Water de tu mano a 1 de tus Pokémon Water en Banca.",
 			it: "Durante il tuo turno, puoi assegnare a uno dei tuoi Pokémon Water in panchina una carta Energia Water dalla tua mano tutte le volte che vuoi.",
 			pt: "Quantas vezes desejar durante o seu turno, você poderá ligar 1 carta de Energia Water da sua mão a 1 dos seus Pokémon Water no Banco.",
-			de: "Beliebig oft während deines Zuges kannst du 1 Water-Energiekarte aus deiner Hand an 1 Water-Pokémon auf deiner Bank anlegen."
+			de: "Beliebig oft während deines Zuges kannst du 1 {W}-Energiekarte aus deiner Hand an 1 {W}-Pokémon auf deiner Bank anlegen."
 		}
 	}],
 
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It shows no mercy to any who desecrate fields and mountains. It will fly around on its icy wings, causing a blizzard to chase offenders away."
+		en: "It shows no mercy to any who desecrate fields and mountains. It will fly around on its icy wings, causing a blizzard to chase offenders away.",
+		de: "Verwüstet jemand Felder und Berge, vergibt es ihm niemals. Es bestraft den Täter, indem es mit seinen kalten Flügeln einen Schneesturm erzeugt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/205.ts
+++ b/data/Sword & Shield/Rebel Clash/205.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			es: "Los ataques de tus Pokémon Metal hacen 20 puntos de daño más al Pokémon Activo de tu rival (antes de aplicar Debilidad y Resistencia).",
 			it: "Gli attacchi dei tuoi Pokémon Metal infliggono 20 danni in più al Pokémon attivo del tuo avversario, prima di aver applicato debolezza e resistenza.",
 			pt: "Os ataques dos seus Pokémon Metal causam 20 pontos de dano a mais ao Pokémon Ativo do seu oponente (antes de aplicar Fraqueza e Resistência).",
-			de: "Die Attacken deiner Metal-Pokémon fügen dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
+			de: "Die Attacken deiner {M}-Pokémon fügen dem Aktiven Pokémon deines Gegners 20 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden)."
 		}
 	}],
 
@@ -82,7 +82,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "What appears to be an iron helmet is actually hardened hair. This Pokémon lives for the thrill of battle."
+		en: "What appears to be an iron helmet is actually hardened hair. This Pokémon lives for the thrill of battle.",
+		de: "Die Haare auf seinem Kopf haben sich zu etwas verhärtet, das an einen eisernen Helm erinnert. Es ist von Natur aus kriegerisch veranlagt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/206.ts
+++ b/data/Sword & Shield/Rebel Clash/206.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "El Pokémon al que está unida esta carta obtiene 30 PS más.",
 		it: "Il Pokémon a cui è assegnata questa carta ha 30 PS in più.",
 		pt: "O Pokémon ao qual esta carta está ligada recebe 30 PS a mais.",
-		de: "Das Pokémon, an das diese Karte angelegt ist, erhält +30 KP."
+		de: "Lege 1 Pokémon-Ausrüstung an 1 deiner Pokémon an, an das noch keine Pokémon-Ausrüstung angelegt ist. Das Pokémon, an das diese Karte angelegt ist, erhält +30 KP. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Tool",

--- a/data/Sword & Shield/Rebel Clash/207.ts
+++ b/data/Sword & Shield/Rebel Clash/207.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Pon 1 de tus Pokémon que no sea un Pokémon V o un Pokémon-GX en tu mano. (Descarta todas las cartas unidas a él).",
 		it: "Prendi uno dei tuoi Pokémon che non è Pokémon-V o un Pokémon-GX e aggiungilo alle carte che hai in mano. Scarta tutte le carte assegnate.",
 		pt: "Coloque 1 dos seus Pokémon que não seja um Pokémon V ou um Pokémon-GX na sua mão (descarte todas as cartas ligadas a ele).",
-		de: "Nimm 1 deiner Pokémon, das kein Pokémon-V oder Pokémon-GX ist, auf deine Hand. (Lege alle angelegten Karten auf deinen Ablagestapel.)"
+		de: "Nimm 1 deiner Pokémon, das kein Pokémon-V oder Pokémon-GX ist, auf deine Hand. (Lege alle angelegten Karten auf deinen Ablagestapel.) Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Rebel Clash/208.ts
+++ b/data/Sword & Shield/Rebel Clash/208.ts
@@ -23,7 +23,7 @@ const card: Card = {
 		es: "Elige hasta 2 Herramientas Pokémon unidas a Pokémon (tuyos o de tu rival) y descártalas.",
 		it: "Scegli fino a due carte Oggetto Pokémon assegnate ai Pokémon, tuoi o del tuo avversario, e scartale.",
 		pt: "Escolha até 2 Ferramentas Pokémon ligadas a Pokémon (seus ou do seu oponente) e descarte-as.",
-		de: "Wähle bis zu 2 an Pokémon (deine oder die deines Gegners) angelegte Pokémon-Ausrüstungen und lege sie auf den Ablagestapel."
+		de: "Wähle bis zu 2 an Pokémon (deine oder die deines Gegners) angelegte Pokémon-Ausrüstungen und lege sie auf den Ablagestapel. Du kannst während deines Zuges beliebig viele Itemkarten spielen."
 	},
 
 	trainerType: "Item",

--- a/data/Sword & Shield/Rebel Clash/209.ts
+++ b/data/Sword & Shield/Rebel Clash/209.ts
@@ -22,7 +22,7 @@ const card: Card = {
 		es: "Mientras esta carta esté unida a 1 Pokémon que no sea un Pokémon V o un Pokémon-GX, proporciona 2 Energías Colorless.\n\nSi esta carta está unida a un Pokémon V o a un Pokémon-GX, proporciona 1 Energía Colorless en vez de 2.",
 		it: "Fintanto che questa carta è assegnata a un Pokémon che non è un Pokémon-V o un Pokémon-GX, fornisce Energia ColorlessColorless.\n\nSe questa carta è assegnata a un Pokémon-V o a un Pokémon-GX, invece fornisce Energia Colorless.",
 		pt: "Enquanto esta carta estiver ligada a um Pokémon que não seja um Pokémon V ou um Pokémon-GX, ela fornecerá Energia ColorlessColorless.\n\nSe esta carta estiver ligada a um Pokémon V ou um Pokémon-GX, ela fornecerá Energia Colorless.",
-		de: "Solange diese Karte an ein Pokémon angelegt ist, das kein Pokémon-V oder Pokémon-GX ist, liefert diese Karte ColorlessColorless-Energie.\n\nWenn diese Karte an ein Pokémon-V oder Pokémon-GX angelegt ist, liefert sie stattdessen Colorless-Energie."
+		de: "Solange diese Karte an ein Pokémon angelegt ist, das kein Pokémon-V oder Pokémon-GX ist, liefert diese Karte {C}{C}-Energie. Wenn diese Karte an ein Pokémon-V oder Pokémon-GX angelegt ist, liefert sie stattdessen {C}-Energie."
 	},
 
 	energyType: "Special",

--- a/data/Sword & Shield/Rebel Clash/21.ts
+++ b/data/Sword & Shield/Rebel Clash/21.ts
@@ -59,7 +59,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It spends its entire life inside an apple. It hides from its natural enemies, bird Pokémon, by pretending it's just an apple and nothing more."
+		en: "It spends its entire life inside an apple. It hides from its natural enemies, bird Pokémon, by pretending it's just an apple and nothing more.",
+		de: "Es verbringt sein ganzes Leben im Inneren eines Apfels. Um sich vor Vogel-Pokémon, seinen Fressfeinden, zu schützen, imitiert es einen Apfel."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/22.ts
+++ b/data/Sword & Shield/Rebel Clash/22.ts
@@ -92,7 +92,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It ate a sour apple, and that induced its evolution. In its cheeks, it stores an acid capable of causing chemical burns."
+		en: "It ate a sour apple, and that induced its evolution. In its cheeks, it stores an acid capable of causing chemical burns.",
+		de: "Nach dem Verzehr eines sauren Apfels hat es sich entwickelt. In den Backentaschen speichert es eine saure Substanz, die zu Verbrennungen führt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/23.ts
+++ b/data/Sword & Shield/Rebel Clash/23.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Eating a sweet apple caused its evolution. A nectarous scent wafts from its body, luring in the bug Pokémon it preys on."
+		en: "Eating a sweet apple caused its evolution. A nectarous scent wafts from its body, luring in the bug Pokémon it preys on.",
+		de: "Nach dem Verzehr eines süßen Apfels hat es sich entwickelt. Es verströmt einen süßen Duft und lockt damit sein Futter an: Käfer-Pokémon."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/24.ts
+++ b/data/Sword & Shield/Rebel Clash/24.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "While young, it has six gorgeous tails. When it grows, several new tails are sprouted."
+		en: "While young, it has six gorgeous tails. When it grows, several new tails are sprouted.",
+		de: "In seiner Jugend hat es sechs hinreißende Schweife. Während es wächst, kommen noch weitere neue Schweife hinzu."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/25.ts
+++ b/data/Sword & Shield/Rebel Clash/25.ts
@@ -94,7 +94,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It is said to live 1,000 years, and each of its tails is loaded with supernatural powers."
+		en: "It is said to live 1,000 years, and each of its tails is loaded with supernatural powers.",
+		de: "Man sagt, es lebe 1 000 Jahre und jedem seiner Schweife wohnen übernatürliche Kräfte inne."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/27.ts
+++ b/data/Sword & Shield/Rebel Clash/27.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It has a brave and trustworthy nature. It fearlessly stands up to bigger and stronger foes."
+		en: "It has a brave and trustworthy nature. It fearlessly stands up to bigger and stronger foes.",
+		de: "Es ist von Natur aus tapfer und vertrauenswürdig und scheut auch vor Gegnern nicht zurück, die größer und stärker sind als es selbst."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/28.ts
+++ b/data/Sword & Shield/Rebel Clash/28.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "The sight of it running over 6,200 miles in a single day and night has captivated many people."
+		en: "The sight of it running over 6,200 miles in a single day and night has captivated many people.",
+		de: "Viele Trainer sind davon fasziniert, dass dieses Pokémon innerhalb eines Tages 10 000 km zurücklegen kann."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/29.ts
+++ b/data/Sword & Shield/Rebel Clash/29.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its entire body is burning. When it breathes, the temperature rises. When it sneezes, flames shoot out!"
+		en: "Its entire body is burning. When it breathes, the temperature rises. When it sneezes, flames shoot out!",
+		de: "Mit seinem brennenden Körper und glühenden Atem heizt es seine Umgebung auf. Beim Niesen stößt es Flammen aus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/3.ts
+++ b/data/Sword & Shield/Rebel Clash/3.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "In battle, it flaps its wings at great speed to release highly toxic dust into the air."
+		en: "In battle, it flaps its wings at great speed to release highly toxic dust into the air.",
+		de: "Wenn es sehr schnell mit den Flügeln schlägt, setzt es hochgiftigen Flügelstaub frei."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/30.ts
+++ b/data/Sword & Shield/Rebel Clash/30.ts
@@ -95,7 +95,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Magmortar takes down its enemies by shooting fireballs, which burn them to a blackened crisp. It avoids this method when hunting prey."
+		en: "Magmortar takes down its enemies by shooting fireballs, which burn them to a blackened crisp. It avoids this method when hunting prey.",
+		de: "Es schießt Feuerbälle auf seine Gegner. Da alles, was es damit trifft, verkohlt wird, sieht es auf der Jagd nach Beute von dieser Methode ab."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/31.ts
+++ b/data/Sword & Shield/Rebel Clash/31.ts
@@ -59,7 +59,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The flame on its head keeps its body slightly warm. This Pokémon takes lost children by the hand to guide them to the spirit world."
+		en: "The flame on its head keeps its body slightly warm. This Pokémon takes lost children by the hand to guide them to the spirit world.",
+		de: "Seine Flamme wärmt seinen Körper leicht. Wer vom Weg abkommt, wird von ihm an der Hand genommen und ins Jenseits gelockt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/32.ts
+++ b/data/Sword & Shield/Rebel Clash/32.ts
@@ -68,7 +68,7 @@ const card: Card = {
 				es: "Une 1 carta de Energía Fire de tu pila de descartes a 1 de tus Pokémon.",
 				it: "Assegna a uno dei tuoi Pokémon una carta Energia Fire dalla tua pila degli scarti.",
 				pt: "Ligue 1 carta de Energia Fire da sua pilha de descarte a 1 dos seus Pokémon.",
-				de: "Lege 1 Fire-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon an."
+				de: "Lege 1 {R}-Energiekarte aus deinem Ablagestapel an 1 deiner Pokémon an."
 			},
 			damage: 20,
 
@@ -91,7 +91,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon appears just before someone passes away, so it's feared as an emissary of death."
+		en: "This Pokémon appears just before someone passes away, so it's feared as an emissary of death.",
+		de: "Es wird als Todesbote gefürchtet, da es oft in der Nähe von Menschen auftaucht, deren Ende kurz bevorsteht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/33.ts
+++ b/data/Sword & Shield/Rebel Clash/33.ts
@@ -92,7 +92,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "This Pokémon haunts dilapidated mansions. It sways its arms to hypnotize opponents with the ominous dancing of its flames."
+		en: "This Pokémon haunts dilapidated mansions. It sways its arms to hypnotize opponents with the ominous dancing of its flames.",
+		de: "Dieses Pokémon bewohnt gerne alte Anwesen. Es hypnotisiert seine Opfer, indem es die Flammen an seinen Armen auf unheimliche Weise schwenkt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/34.ts
+++ b/data/Sword & Shield/Rebel Clash/34.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "There's a hole in its tail that allows it to draw in the air it needs to keep its fire burning. If the hole gets blocked, this Pokémon will fall ill."
+		en: "There's a hole in its tail that allows it to draw in the air it needs to keep its fire burning. If the hole gets blocked, this Pokémon will fall ill.",
+		de: "Es saugt über das Loch in seinem Schweif Luft für seine Flammen ein. Eine Verstopfung des Lochs schlägt Furnifraß sofort auf die Gesundheit."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/35.ts
+++ b/data/Sword & Shield/Rebel Clash/35.ts
@@ -27,7 +27,7 @@ const card: Card = {
 				es: "",
 				it: "",
 				pt: "",
-				de: ""
+				de: "Feldspieler"
 			},
 			effect: {
 				en: "If a Stadium is in play, this Pokémon has no Retreat Cost.",

--- a/data/Sword & Shield/Rebel Clash/37.ts
+++ b/data/Sword & Shield/Rebel Clash/37.ts
@@ -83,7 +83,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its talent is tap-dancing. It can also manipulate temperatures to create a floor of ice, which this Pokémon can kick up to use as a barrier."
+		en: "Its talent is tap-dancing. It can also manipulate temperatures to create a floor of ice, which this Pokémon can kick up to use as a barrier.",
+		de: "Dieser begabte Stepptänzer erzeugt am Boden mit kalter Luft eine Barriere aus Eis und richtet sie zu seinem Schutz mit den Füßen auf."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/38.ts
+++ b/data/Sword & Shield/Rebel Clash/38.ts
@@ -91,7 +91,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It's highly skilled at tap-dancing. It waves its cane of ice in time with its graceful movements."
+		en: "It's highly skilled at tap-dancing. It waves its cane of ice in time with its graceful movements.",
+		de: "Dieser begnadete Stepptänzer schwingt einen aus Eis geformten Gehstock und gibt mit leichtem Fuß seinen Tanz zum Besten."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/39.ts
+++ b/data/Sword & Shield/Rebel Clash/39.ts
@@ -59,7 +59,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It is virtually worthless in terms of both power and speed. It is the most weak and pathetic Pokémon in the world."
+		en: "It is virtually worthless in terms of both power and speed. It is the most weak and pathetic Pokémon in the world.",
+		de: "Es ist nutzlos, was Kraft und Geschwindigkeit angeht. Dieses Pokémon ist das schwächste und erbärmlichste der Welt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/4.ts
+++ b/data/Sword & Shield/Rebel Clash/4.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its two sharp scythes are more than just weapons. It uses them with dexterity to dress its prey before eating."
+		en: "Its two sharp scythes are more than just weapons. It uses them with dexterity to dress its prey before eating.",
+		de: "Seine scharfen Sicheln sind nicht nur Waffen. Vor einer Mahlzeit filetiert es damit auch geschickt seine Beute."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/40.ts
+++ b/data/Sword & Shield/Rebel Clash/40.ts
@@ -91,7 +91,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It has an extremely aggressive nature. The Hyper Beam it shoots from its mouth totally incinerates all targets."
+		en: "It has an extremely aggressive nature. The Hyper Beam it shoots from its mouth totally incinerates all targets.",
+		de: "Es ist von Natur aus sehr aggressiv. Der Hyperstrahl, den es aus seinem Maul verschießt, äschert seine Gegner ein."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/41.ts
+++ b/data/Sword & Shield/Rebel Clash/41.ts
@@ -52,7 +52,7 @@ const card: Card = {
 				es: "Chapoteo Ondulante",
 				it: "Schizzi d'Onda",
 				pt: "Onda Borrifante",
-				de: "Wellenplatscher"
+				de: "Platscher"
 			},
 
 			damage: 20,
@@ -83,7 +83,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It makes its nest on sheer cliffs. Riding the sea breeze, it glides up into the expansive skies."
+		en: "It makes its nest on sheer cliffs. Riding the sea breeze, it glides up into the expansive skies.",
+		de: "Es baut sein Nest an Steilhängen und nutzt die Seebrise, um beim Gleiten am weiten Himmel an Höhe zu gewinnen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/42.ts
+++ b/data/Sword & Shield/Rebel Clash/42.ts
@@ -95,7 +95,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It is a messenger of the skies, carrying small Pokémon and eggs to safety in its bill."
+		en: "It is a messenger of the skies, carrying small Pokémon and eggs to safety in its bill.",
+		de: "Ein Bote der Lüfte. Es bringt Eier und kleine Pokémon in seinem Schnabel in Sicherheit."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/43.ts
+++ b/data/Sword & Shield/Rebel Clash/43.ts
@@ -38,7 +38,7 @@ const card: Card = {
 				es: "Este ataque hace 50 puntos de daño más por cada Colorless en el Coste de Retirada del Pokémon Activo de tu rival.",
 				it: "Questo attacco infligge 50 danni in più per ogni Colorless nel costo di ritirata del Pokémon attivo del tuo avversario.",
 				pt: "Este ataque causa 50 pontos de dano a mais para cada Colorless no custo de Recuo do Pokémon Ativo do seu oponente.",
-				de: "Diese Attacke fügt für jedes Colorless in den Rückzugskosten des Aktiven Pokémon deines Gegners 50 Schadenspunkte mehr zu."
+				de: "Diese Attacke fügt für jedes {C} in den Rückzugskosten des Aktiven Pokémon deines Gegners 50 Schadenspunkte mehr zu."
 			},
 			damage: "10+",
 

--- a/data/Sword & Shield/Rebel Clash/44.ts
+++ b/data/Sword & Shield/Rebel Clash/44.ts
@@ -59,7 +59,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Graceful ripples running across the water's surface are a sure sign that Tympole are singing in high-pitched voices below."
+		en: "Graceful ripples running across the water's surface are a sure sign that Tympole are singing in high-pitched voices below.",
+		de: "Man sagt, wenn auf Wasseroberflächen schöne Kräuselwellen zu sehen sind, liege das an Schallquap, die unter Wasser schrill rufen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/45.ts
+++ b/data/Sword & Shield/Rebel Clash/45.ts
@@ -70,7 +70,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It weakens its prey with sound waves intense enough to cause headaches, then entangles them with its sticky tongue."
+		en: "It weakens its prey with sound waves intense enough to cause headaches, then entangles them with its sticky tongue.",
+		de: "Es schwächt seine Beute mit Kopfschmerzen erregenden Schallwellen und umschlingt sie anschließend mit seiner klebrigen Zunge."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/46.ts
+++ b/data/Sword & Shield/Rebel Clash/46.ts
@@ -95,7 +95,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "The vibrating of the bumps all over its body causes earthquake-like tremors. Seismitoad and Croagunk are similar species."
+		en: "The vibrating of the bumps all over its body causes earthquake-like tremors. Seismitoad and Croagunk are similar species.",
+		de: "Die Beulen, die seinen ganzen Körper bedecken, können Erschütterungen auf Erdbebenstärke erzeugen. Es ist artverwandt mit Glibunkel."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/47.ts
+++ b/data/Sword & Shield/Rebel Clash/47.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It lived in snowy areas for so long that its fire sac cooled off and atrophied. It now has an organ that generates cold instead."
+		en: "It lived in snowy areas for so long that its fire sac cooled off and atrophied. It now has an organ that generates cold instead.",
+		de: "Seit es in kälteren Gefilden lebt, hat sich sein innerer Flammensack zurückgebildet. Stattdessen wuchs ein Organ heran, das eiskalte Luft erzeugt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/48.ts
+++ b/data/Sword & Shield/Rebel Clash/48.ts
@@ -96,7 +96,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "On days when blizzards blow through, it comes down to where people live. It stashes food in the snowball on its head, taking it home for later."
+		en: "On days when blizzards blow through, it comes down to where people live. It stashes food in the snowball on its head, taking it home for later.",
+		de: "Es lagert Futter in dem Schneeball auf seinem Kopf und trägt es nach Hause. Bei Schneestürmen steigt es zu den Siedlungen der Menschen hinab."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/5.ts
+++ b/data/Sword & Shield/Rebel Clash/5.ts
@@ -84,7 +84,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It stores berries inside its shell. To avoid attacks, it hides beneath rocks and remains completely still."
+		en: "It stores berries inside its shell. To avoid attacks, it hides beneath rocks and remains completely still.",
+		de: "Es sammelt Beeren in seiner Schale. Um sich vor Attacken zu schützen, versteckt es sich unter Steinen und verharrt dort regungslos."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/51.ts
+++ b/data/Sword & Shield/Rebel Clash/51.ts
@@ -62,7 +62,7 @@ const card: Card = {
 				es: "Este ataque hace 20 puntos de daño más por cada Energía Water unida a este Pokémon.",
 				it: "Questo attacco infligge 20 danni in più per ogni Energia Water assegnata a questo Pokémon.",
 				pt: "Este ataque causa 20 pontos de dano a mais para cada Energia Water ligada a este Pokémon.",
-				de: "Diese Attacke fügt für jede an dieses Pokémon angelegte Water-Energie 20 Schadenspunkte mehr zu."
+				de: "Diese Attacke fügt für jede an dieses Pokémon angelegte {W}-Energie 20 Schadenspunkte mehr zu."
 			},
 			damage: "50+",
 
@@ -92,7 +92,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It's so strong that it can knock out some opponents in a single hit, but it also may forget what it's battling midfight."
+		en: "It's so strong that it can knock out some opponents in a single hit, but it also may forget what it's battling midfight.",
+		de: "Es ist so stark, dass es seine Gegner mit einem Angriff vernichten könnte, aber zerstreut wie es ist, vergisst es öfters, wen es gerade bekämpft."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/52.ts
+++ b/data/Sword & Shield/Rebel Clash/52.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "If it sees any movement around it, this Pokémon charges for it straightaway, leading with its sharply pointed jaw. It's very proud of that jaw."
+		en: "If it sees any movement around it, this Pokémon charges for it straightaway, leading with its sharply pointed jaw. It's very proud of that jaw.",
+		de: "Sein spitz zulaufender Kiefer ist sein ganzer Stolz. Erblickt es etwas, das sich auch nur ein bisschen bewegt, setzt es geradewegs zum Stoßangriff an."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/53.ts
+++ b/data/Sword & Shield/Rebel Clash/53.ts
@@ -61,7 +61,7 @@ const card: Card = {
 				es: "Descarta 2 cartas de Energía Water de tu mano. Si no lo haces, este ataque no hace nada.",
 				it: "Scarta due carte Energia Water che hai in mano. Se non lo fai, questo attacco non ha effetto.",
 				pt: "Descarte 2 cartas de Energia Water da sua mão. Se não fizer isto, este ataque não fará nada.",
-				de: "Lege 2 Water-Energiekarten aus deiner Hand auf deinen Ablagestapel. Wenn du das nicht machst, hat diese Attacke keine Auswirkungen."
+				de: "Lege 2 {W}-Energiekarten aus deiner Hand auf deinen Ablagestapel. Wenn du das nicht machst, hat diese Attacke keine Auswirkungen."
 			},
 			damage: 130,
 
@@ -84,7 +84,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "This Pokémon has a jaw that's as sharp as a spear and as strong as steel. Apparently Barraskewda's flesh is surprisingly tasty, too."
+		en: "This Pokémon has a jaw that's as sharp as a spear and as strong as steel. Apparently Barraskewda's flesh is surprisingly tasty, too.",
+		de: "Sein Kiefer ist spitz wie ein Speer und hart wie Stahl. Außerdem soll Barrakiefa überraschend deliziös sein."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/54.ts
+++ b/data/Sword & Shield/Rebel Clash/54.ts
@@ -84,7 +84,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It drifted in on the flow of ocean waters from a frigid place. It keeps its head iced constantly to make sure it stays nice and cold."
+		en: "It drifted in on the flow of ocean waters from a frigid place. It keeps its head iced constantly to make sure it stays nice and cold.",
+		de: "Es kam von einem extrem kalten Ort, indem es sich treiben ließ und schließlich angespült wurde. Es kühlt unablässig sein Gesicht mit Eis."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/55.ts
+++ b/data/Sword & Shield/Rebel Clash/55.ts
@@ -34,7 +34,7 @@ const card: Card = {
 				es: "Cada vez que unas 1 carta de Energía Water de tu mano a este Pokémon durante tu turno, cúrale 30 puntos de daño.",
 				it: "Ogni volta che assegni una carta Energia Water a questo Pokémon dalla tua mano durante il tuo turno, curalo da 30 danni.",
 				pt: "Sempre que ligar 1 carta de Energia Water da sua mão a este Pokémon durante o seu turno, cure 30 pontos de dano dele.",
-				de: "Jedes Mal, wenn du während deines Zuges 1 Water-Energiekarte aus deiner Hand an dieses Pokémon anlegst, heile 30 Schadenspunkte bei diesem Pokémon."
+				de: "Jedes Mal, wenn du während deines Zuges 1 {W}-Energiekarte aus deiner Hand an dieses Pokémon anlegst, heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 		},
 	],

--- a/data/Sword & Shield/Rebel Clash/56.ts
+++ b/data/Sword & Shield/Rebel Clash/56.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Usually found in power plants. Easily mistaken for a Poké Ball, it has zapped many people."
+		en: "Usually found in power plants. Easily mistaken for a Poké Ball, it has zapped many people.",
+		de: "Dieses Pokémon wird oftmals mit einem Pokéball verwechselt. Es lebt vorwiegend in Kraftwerken."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/57.ts
+++ b/data/Sword & Shield/Rebel Clash/57.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It stores an overflowing amount of electric energy inside its body. Even a small shock makes it explode."
+		en: "It stores an overflowing amount of electric energy inside its body. Even a small shock makes it explode.",
+		de: "Es speichert eine riesige Menge Elektrizität in seinem Körper. Es explodiert beim kleinsten Ruck."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/58.ts
+++ b/data/Sword & Shield/Rebel Clash/58.ts
@@ -71,7 +71,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "While it's often blamed for power outages, the truth is the cause of outages is more often an error on the part of the electric company."
+		en: "While it's often blamed for power outages, the truth is the cause of outages is more often an error on the part of the electric company.",
+		de: "Es wird oft für Stromausfälle verantwortlich gemacht, doch viel häufiger handelt es sich um eine Folge menschlichen Fehlverhaltens."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/59.ts
+++ b/data/Sword & Shield/Rebel Clash/59.ts
@@ -95,7 +95,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "A single Electivire can provide enough electricity for all the buildings in a big city for a year."
+		en: "A single Electivire can provide enough electricity for all the buildings in a big city for a year.",
+		de: "Ein einzelnes Elevoltek erzeugt genügend Elektrizität, um eine Großstadt ein ganzes Jahr lang mit Strom zu versorgen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/6.ts
+++ b/data/Sword & Shield/Rebel Clash/6.ts
@@ -79,7 +79,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It roams through forests searching for sweet nectar. Although it boasts fantastic physical strength, it's not that good at flying."
+		en: "It roams through forests searching for sweet nectar. Although it boasts fantastic physical strength, it's not that good at flying.",
+		de: "Auf der Suche nach süßem Honig durchstreift es die Wälder. Es ist stolz auf seine Stärke, aber fliegen kann es nicht besonders gut."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/60.ts
+++ b/data/Sword & Shield/Rebel Clash/60.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "All of its fur dazzles if danger is sensed. It flees while the foe is momentarily blinded."
+		en: "All of its fur dazzles if danger is sensed. It flees while the foe is momentarily blinded.",
+		de: "In Gefahr blendet es seinen Gegner mit seinem Fell und flieht, während der Gegner einen Moment blind ist."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/61.ts
+++ b/data/Sword & Shield/Rebel Clash/61.ts
@@ -84,7 +84,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes."
+		en: "Strong electricity courses through the tips of its sharp claws. A light scratch causes fainting in foes.",
+		de: "Durch die Spitzen seiner scharfen Krallen strömt Elektrizität. Selbst kleine Kratzer verursachen Ohnmacht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/62.ts
+++ b/data/Sword & Shield/Rebel Clash/62.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "Luxray's ability to see through objects comes in handy when it's scouting for danger."
+		en: "Luxray's ability to see through objects comes in handy when it's scouting for danger.",
+		de: "Beim Aufspüren von Gefahren sind Luxtras hellseherische Fähigkeiten äußerst hilfreich."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/63.ts
+++ b/data/Sword & Shield/Rebel Clash/63.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "When spread, the frills on its head act like solar panels, generating the power behind this Pokémon's electric moves."
+		en: "When spread, the frills on its head act like solar panels, generating the power behind this Pokémon's electric moves.",
+		de: "Es breitet die Hautlappen an seinem Kopf aus, um mithilfe des Sonnenlichts Strom zu erzeugen und mächtige Elektro-Attacken einzusetzen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/64.ts
+++ b/data/Sword & Shield/Rebel Clash/64.ts
@@ -92,7 +92,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "A now-vanished desert culture treasured these Pokémon. Appropriately, when Heliolisk came to the Galar region, treasure came with them."
+		en: "A now-vanished desert culture treasured these Pokémon. Appropriately, when Heliolisk came to the Galar region, treasure came with them.",
+		de: "Es wurde in einem Wüstenreich, das vor langer Zeit unterging, sehr respektiert. Zusammen mit dessen Schätzen gelangte es in die Galar-Region."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/65.ts
+++ b/data/Sword & Shield/Rebel Clash/65.ts
@@ -46,7 +46,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 2 cartas de Energía Lightning y únelas a este Pokémon. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a due carte Energia Lightning e assegnale a questo Pokémon. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 2 cartas de Energia Lightning no seu baralho e ligue-as a este Pokémon. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 2 Lightning-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 2 {L}-Energiekarten und lege sie an dieses Pokémon an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "While its durable shell protects it from attacks, Charjabug strikes at enemies with jolts of electricity discharged from the tips of its jaws."
+		en: "While its durable shell protects it from attacks, Charjabug strikes at enemies with jolts of electricity discharged from the tips of its jaws.",
+		de: "Es schützt sich mithilfe seines robusten Panzers. Durch die Spitzen an seinem Kiefer leitet es Strom, mit dem es sich gegen Angreifer wehrt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/66.ts
+++ b/data/Sword & Shield/Rebel Clash/66.ts
@@ -97,7 +97,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It builds up electricity in its abdomen, focuses it through its jaws, and then fires the electricity off in concentrated beams."
+		en: "It builds up electricity in its abdomen, focuses it through its jaws, and then fires the electricity off in concentrated beams.",
+		de: "In seinem Bauch erzeugt es Elektrizität, die es in seinem großen Kiefer sammelt und dann als Hochleistungsstrahlen abfeuern kann."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/67.ts
+++ b/data/Sword & Shield/Rebel Clash/67.ts
@@ -37,7 +37,7 @@ const card: Card = {
 				es: "Busca en tu baraja hasta 2 cartas de Energía Lightning y únelas a tus Pokémon en Banca de la manera que desees. Después, baraja las cartas de tu baraja.",
 				it: "Cerca nel tuo mazzo fino a due carte Energia Lightning e assegnale ai tuoi Pokémon in panchina nel modo che preferisci. Poi rimischia le carte del tuo mazzo.",
 				pt: "Procure por até 2 cartas de Energia Lightning no seu baralho e ligue-as aos seus Pokémon no Banco como desejar. Em seguida, embaralhe o seu baralho.",
-				de: "Durchsuche dein Deck nach bis zu 2 Lightning-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
+				de: "Durchsuche dein Deck nach bis zu 2 {L}-Energiekarten und lege sie beliebig an die Pokémon auf deiner Bank an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -60,7 +60,7 @@ const card: Card = {
 				es: "Este ataque hace 30 puntos de daño más por cada Energía Lightning unida a todos tus Pokémon.",
 				it: "Questo attacco infligge 30 danni in più per ogni Energia Lightning assegnata ai tuoi Pokémon.",
 				pt: "Este ataque causa 30 pontos de dano a mais para cada Energia Lightning ligada a todos os seus Pokémon.",
-				de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte Lightning-Energie 30 Schadenspunkte mehr zu."
+				de: "Diese Attacke fügt für jede an alle deine Pokémon angelegte {L}-Energie 30 Schadenspunkte mehr zu."
 			},
 			damage: "10+",
 

--- a/data/Sword & Shield/Rebel Clash/68.ts
+++ b/data/Sword & Shield/Rebel Clash/68.ts
@@ -59,7 +59,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It stores poison in an internal poison sac and secretes that poison through its skin. If you touch this Pokémon, a tingling sensation follows."
+		en: "It stores poison in an internal poison sac and secretes that poison through its skin. If you touch this Pokémon, a tingling sensation follows.",
+		de: "Das Gift aus dem Giftsack in seinem Körper sondert es über die Haut ab. Berührt man es, bekommt man einen lähmenden Schock verpasst."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/69.ts
+++ b/data/Sword & Shield/Rebel Clash/69.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "When this Pokémon sounds as if it's strumming a guitar, it's actually clawing at the protrusions on its chest to generate electricity."
+		en: "When this Pokémon sounds as if it's strumming a guitar, it's actually clawing at the protrusions on its chest to generate electricity.",
+		de: "Wenn es am Fortsatz an seiner Brust kratzt und dadurch Strom erzeugt, dann erklingt in der Umgebung ein Ton wie von einer Gitarre."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/7.ts
+++ b/data/Sword & Shield/Rebel Clash/7.ts
@@ -77,7 +77,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It searches about for clean water. If it does not drink water for too long, the leaf on its head wilts."
+		en: "It searches about for clean water. If it does not drink water for too long, the leaf on its head wilts.",
+		de: "Es sucht nach reinem Wasser. Wenn es für längere Zeit kein Wasser trinkt, verwelkt das Blatt auf seinem Kopf."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/71.ts
+++ b/data/Sword & Shield/Rebel Clash/71.ts
@@ -24,7 +24,7 @@ const card: Card = {
 		es: "Toxtricity V",
 		it: "Toxtricity-V",
 		pt: "Toxtricity V",
-		de: "Riffex-V"
+		de: "Riffex VMAX"
 	},
 
 	attacks: [

--- a/data/Sword & Shield/Rebel Clash/73.ts
+++ b/data/Sword & Shield/Rebel Clash/73.ts
@@ -84,7 +84,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "As it eats the seeds stored up in its pocket-like pouches, this Pokémon is not just satisfying its constant hunger. It's also generating electricity."
+		en: "As it eats the seeds stored up in its pocket-like pouches, this Pokémon is not just satisfying its constant hunger. It's also generating electricity.",
+		de: "Dieses immerzu hungrige Pokémon frisst Samen, die es in seinen beutelartigen Taschen verwahrt, und produziert so Elektrizität."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/74.ts
+++ b/data/Sword & Shield/Rebel Clash/74.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It is said that happiness will come to those who see a gathering of Clefairy dancing under a full moon."
+		en: "It is said that happiness will come to those who see a gathering of Clefairy dancing under a full moon.",
+		de: "Eine Ansammlung von Piepi bei Vollmond tanzen zu sehen, soll Freude verheißen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/75.ts
+++ b/data/Sword & Shield/Rebel Clash/75.ts
@@ -85,7 +85,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "A timid fairy Pokémon that is rarely seen, it will run and hide the moment it senses people."
+		en: "A timid fairy Pokémon that is rarely seen, it will run and hide the moment it senses people.",
+		de: "Ein feenhaftes und scheues Pokémon, das sofort die Flucht ergreift, wenn es Menschen wahrnimmt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/76.ts
+++ b/data/Sword & Shield/Rebel Clash/76.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It is extremely good at climbing tree trunks and likes to eat the new sprouts on the trees."
+		en: "It is extremely good at climbing tree trunks and likes to eat the new sprouts on the trees.",
+		de: "Es ist ein hervorragender Kletterer. Besonders gern steigt es auf Bäume und frisst die jungen Triebe ab."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/77.ts
+++ b/data/Sword & Shield/Rebel Clash/77.ts
@@ -98,7 +98,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "They say that it stays still and quiet because it is seeing both the past and future at the same time."
+		en: "They say that it stays still and quiet because it is seeing both the past and future at the same time.",
+		de: "Man sagt, es sei so still und in sich gekehrt, weil es die Zukunft und die Vergangenheit parallel sieht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/78.ts
+++ b/data/Sword & Shield/Rebel Clash/78.ts
@@ -65,7 +65,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Watch your step when wandering areas oceans once covered. What looks like a stone could be this Pokémon, and it will curse you if you kick it."
+		en: "Watch your step when wandering areas oceans once covered. What looks like a stone could be this Pokémon, and it will curse you if you kick it.",
+		de: "Man findet es oft an Orten, die vor langer Zeit vom Meer bedeckt waren. Wer es mit einem Stein verwechselt und herumkickt, wird verflucht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/79.ts
+++ b/data/Sword & Shield/Rebel Clash/79.ts
@@ -98,7 +98,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Its shell is overflowing with its heightened otherworldly energy. The ectoplasm serves as protection for this Pokémon's core spirit."
+		en: "Its shell is overflowing with its heightened otherworldly energy. The ectoplasm serves as protection for this Pokémon's core spirit.",
+		de: "In ihm wuchs eine mysteriöse Kraft und so löste es sich von seinem Panzer los. Sein geisterhaftes Ektoplasma schützt die Seele im Kern."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/8.ts
+++ b/data/Sword & Shield/Rebel Clash/8.ts
@@ -93,7 +93,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It is nocturnal and becomes active at nightfall. It feeds on aquatic mosses that grow in the riverbed."
+		en: "It is nocturnal and becomes active at nightfall. It feeds on aquatic mosses that grow in the riverbed.",
+		de: "Lombrero wird erst in der Abenddämmerung aktiv. Es ernährt sich von Moos, das am Boden von Flüssen gedeiht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/80.ts
+++ b/data/Sword & Shield/Rebel Clash/80.ts
@@ -35,7 +35,7 @@ const card: Card = {
 				es: "Si este Pokémon es tu Pokémon Activo y resulta dañado por un ataque de tu rival (incluso si este Pokémon queda Fuera de Combate), pon 3 contadores de daño en el Pokémon Atacante.",
 				it: "Se questo Pokémon è il tuo Pokémon attivo e viene danneggiato da un attacco del tuo avversario, anche se viene messo KO, metti tre segnalini danno sul Pokémon attaccante.",
 				pt: "Se este Pokémon for seu Pokémon Ativo e for danificado pelo ataque de um oponente (mesmo se esse Pokémon for Nocauteado), coloque 3 contadores de danos no Pokémon Atacante.",
-				de: "Wenn dieses Pokémon dein Aktives Pokémon ist und durch einen gegnerischen Angriff Schaden erhält (auch wenn dieses Pokémon dadurch kampfunfähig wird), lege 3 Schadensmarken auf das Angreifende Pokémon."
+				de: "Wenn dieses Pokémon in der Aktiven Position ist und durch eine Attacke deines Gegners Schaden erhält (auch wenn es dadurch kampfunfähig wird), lege 3 Schadensmarken auf das Angreifende Pokémon."
 			},
 		},
 	],
@@ -90,7 +90,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Psychic power allows these Pokémon to fly. Some say they were the guardians of an ancient city. Others say they were the guardians' emissaries."
+		en: "Psychic power allows these Pokémon to fly. Some say they were the guardians of an ancient city. Others say they were the guardians' emissaries.",
+		de: "Es fliegt mithilfe seiner Psycho-Kräfte. Einige sagen, es war einst der Wächter einer Stadt aus uralten Zeiten. Andere sagen, es war sein Bote."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/81.ts
+++ b/data/Sword & Shield/Rebel Clash/81.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "If you build sand mounds when you're playing, destroy them before you go home, or they may get possessed and become Sandygast."
+		en: "If you build sand mounds when you're playing, destroy them before you go home, or they may get possessed and become Sandygast.",
+		de: "Lässt man beim Spielen gebaute Sandhaufen zurück, kann es vorkommen, dass sich eine Seele dort einnistet und ein Sankabuh entsteht."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/82.ts
+++ b/data/Sword & Shield/Rebel Clash/82.ts
@@ -101,7 +101,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Once it has whipped up a sandstorm to halt its opponents in their tracks, this terrifying Pokémon snatches away their vitality."
+		en: "Once it has whipped up a sandstorm to halt its opponents in their tracks, this terrifying Pokémon snatches away their vitality.",
+		de: "Ein grauenvolles Pokémon, das seine Feinde in einen Sandsturm einschließt, um sie dann ihrer Lebensenergie zu berauben."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/83.ts
+++ b/data/Sword & Shield/Rebel Clash/83.ts
@@ -83,7 +83,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Via the protrusion on its head, it senses other creatures' emotions. If you don't have a calm disposition, it will never warm up to you."
+		en: "Via the protrusion on its head, it senses other creatures' emotions. If you don't have a calm disposition, it will never warm up to you.",
+		de: "Mit dem Fortsatz an seinem Kopf kann es die Gefühle von Lebewesen wahrnehmen. Es öffnet nur geruhsam veranlagten Leuten sein Herz."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/84.ts
+++ b/data/Sword & Shield/Rebel Clash/84.ts
@@ -98,7 +98,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "No matter who you are, if you bring strong emotions near this Pokémon, it will silence you violently."
+		en: "No matter who you are, if you bring strong emotions near this Pokémon, it will silence you violently.",
+		de: "Empfindet jemand starke Emotionen, bringt es ihn auf gewaltsame Art zum Schweigen, egal, um wen es sich dabei handelt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/85.ts
+++ b/data/Sword & Shield/Rebel Clash/85.ts
@@ -96,7 +96,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "It emits psychic power strong enough to cause headaches as a deterrent to the approach of others."
+		en: "It emits psychic power strong enough to cause headaches as a deterrent to the approach of others.",
+		de: "Die starken Psycho-Kräfte, die es ausstrahlt, rufen Kopfschmerzen hervor. So hält es andere Lebewesen von sich fern."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/86.ts
+++ b/data/Sword & Shield/Rebel Clash/86.ts
@@ -75,7 +75,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "This Pokémon was born from sweet-smelling particles in the air. Its body is made of cream."
+		en: "This Pokémon was born from sweet-smelling particles in the air. Its body is made of cream.",
+		de: "Sein Körper besteht aus Sahne. Es entstand aus einer Ansammlung süßer Geruchspartikel in der Luft."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/87.ts
+++ b/data/Sword & Shield/Rebel Clash/87.ts
@@ -92,7 +92,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "When it trusts a Trainer, it will treat them to berries it's decorated with cream."
+		en: "When it trusts a Trainer, it will treat them to berries it's decorated with cream.",
+		de: "Es macht einem Trainer, dem es vertraut, mit Beeren samt Sahnedekoration eine Freude."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/88.ts
+++ b/data/Sword & Shield/Rebel Clash/88.ts
@@ -89,7 +89,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "These intelligent Pokémon touch horns with each other to share information between them."
+		en: "These intelligent Pokémon touch horns with each other to share information between them.",
+		de: "Ein äußerst intelligentes Pokémon, das mit seinen Artgenossen kommuniziert, indem es die Hörner eines anderen Exemplars mit seinen berührt."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/89.ts
+++ b/data/Sword & Shield/Rebel Clash/89.ts
@@ -66,7 +66,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "After being reborn as a ghost Pokémon, Dreepy wanders the areas it used to inhabit back when it was alive in prehistoric seas."
+		en: "After being reborn as a ghost Pokémon, Dreepy wanders the areas it used to inhabit back when it was alive in prehistoric seas.",
+		de: "In der Urzeit lebte es im Meer. Nun ist es als Geister-Pokémon wiedererwacht und irrt rastlos durch seinen früheren Lebensraum."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/9.ts
+++ b/data/Sword & Shield/Rebel Clash/9.ts
@@ -95,7 +95,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "The rhythm of bright, festive music activates Ludicolo's cells, making it more powerful."
+		en: "The rhythm of bright, festive music activates Ludicolo's cells, making it more powerful.",
+		de: "Der Rhythmus von fröhlicher Musik aktiviert die Zellen von Kappalores und macht es so stärker."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/90.ts
+++ b/data/Sword & Shield/Rebel Clash/90.ts
@@ -91,7 +91,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "It's capable of flying faster than 120 mph. It battles alongside Dreepy and dotes on them until they successfully evolve."
+		en: "It's capable of flying faster than 120 mph. It battles alongside Dreepy and dotes on them until they successfully evolve.",
+		de: "Beim Fliegen ist es bis zu 200 km/h schnell. Es kämpft gemeinsam mit Grolldra und kümmert sich bis zu dessen Entwicklung um es."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/91.ts
+++ b/data/Sword & Shield/Rebel Clash/91.ts
@@ -98,7 +98,8 @@ const card: Card = {
 	stage: "Stage2",
 
 	description: {
-		en: "When it isn't battling, it keeps Dreepy in the holes on its horns. Once a fight starts, it launches the Dreepy like supersonic missiles."
+		en: "When it isn't battling, it keeps Dreepy in the holes on its horns. Once a fight starts, it launches the Dreepy like supersonic missiles.",
+		de: "Es transportiert Grolldra in den Löchern an seinen Hörnern. Kommt es zum Kampf, schießt es diese mit Mach-Geschwindigkeit ab."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/94.ts
+++ b/data/Sword & Shield/Rebel Clash/94.ts
@@ -76,7 +76,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "The Farfetch'd of the Galar region are brave warriors, and they wield thick, tough leeks in battle."
+		en: "The Farfetch'd of the Galar region are brave warriors, and they wield thick, tough leeks in battle.",
+		de: "Dies ist die in Galar ansässige Form von Porenta. Dieser tapfere Krieger schwingt im Kampf eine dicke, robuste Lauchstange."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/95.ts
+++ b/data/Sword & Shield/Rebel Clash/95.ts
@@ -86,7 +86,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Only Farfetch'd that have survived many battles can attain this evolution. When this Pokémon's leek withers, it will retire from combat."
+		en: "Only Farfetch'd that have survived many battles can attain this evolution. When this Pokémon's leek withers, it will retire from combat.",
+		de: "Porenta, die viele Schlachten überstanden haben, entwickeln sich zu Lauchzelot. Verwelkt seine Lauchstange, zieht es sich vom Kämpfen zurück."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/96.ts
+++ b/data/Sword & Shield/Rebel Clash/96.ts
@@ -71,7 +71,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It hunts without twitching a muscle by pulling in its prey with powerful magnetism. But sometimes it pulls natural enemies in close."
+		en: "It hunts without twitching a muscle by pulling in its prey with powerful magnetism. But sometimes it pulls natural enemies in close.",
+		de: "Es nutzt sein starkes Magnetfeld, um Beute zu sich heranzuziehen. Ebenso zieht es Objekte aus Eisen an, um sich mit ihnen zu schützen."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/97.ts
+++ b/data/Sword & Shield/Rebel Clash/97.ts
@@ -60,7 +60,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "It eats just one berry a day. By enduring hunger, its spirit is tempered and made sharper."
+		en: "It eats just one berry a day. By enduring hunger, its spirit is tempered and made sharper.",
+		de: "Es isst gerade mal eine Beere am Tag. Durch Hunger wird sein Geist ruhiger und schärfer."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/98.ts
+++ b/data/Sword & Shield/Rebel Clash/98.ts
@@ -94,7 +94,8 @@ const card: Card = {
 	stage: "Stage1",
 
 	description: {
-		en: "Through yoga training, it gained the psychic power to predict its foe's next move."
+		en: "Through yoga training, it gained the psychic power to predict its foe's next move.",
+		de: "Mit Yoga-Training hat es seine Psycho-Kräfte geschärft und ahnt so die Attacken seiner Gegner voraus."
 	},
 
 	variants: [

--- a/data/Sword & Shield/Rebel Clash/99.ts
+++ b/data/Sword & Shield/Rebel Clash/99.ts
@@ -53,7 +53,8 @@ const card: Card = {
 	stage: "Basic",
 
 	description: {
-		en: "Its slimy body is hard to grasp. In one region, it is said to have been born from hardened mud."
+		en: "Its slimy body is hard to grasp. In one region, it is said to have been born from hardened mud.",
+		de: "Sein schleimiger Körper ist schwer zu greifen. In einer Region sagt man, es sei aus gehärtetem Schlamm entstanden."
 	},
 
 	variants: [


### PR DESCRIPTION
## Add missing German translations for swsh2

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
