### PR TITLE
Add missing German translations for 2022swsh

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2022/1.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/1.ts
@@ -29,15 +29,18 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Collect",
+				de: "Sammeln"
 			},
 			effect: {
 				en: "Draw a card.",
+				de: "Ziehe 1 Karte."
 			},
 		},
 		{
 			cost: ["Colorless", "Colorless"],
 			name: {
 				en: "Punch",
+				de: "Boxhieb"
 			},
 			damage: 20,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/10.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/10.ts
@@ -28,10 +28,12 @@ const card: Card = {
 		{
 			type: "Ability",
 			name: {
-				en: "Levitate"
+				en: "Levitate",
+				de: "Schwebe"
 			},
 			effect: {
-				en: "If this Pokémon has any Energy attached, it has no Retreat Cost."
+				en: "If this Pokémon has any Energy attached, it has no Retreat Cost.",
+				de: "Wenn an dieses Pokémon mindestens 1 Energie angelegt ist, hat es keine Rückzugskosten."
 			}
 		}
 	],
@@ -41,6 +43,7 @@ const card: Card = {
 			cost: ["Lightning"],
 			name: {
 				en: "Tiny Charge",
+				de: "Mini-Stromstoß"
 			},
 			damage: 10
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/11.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/11.ts
@@ -29,6 +29,7 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Flap",
+				de: "Flattern"
 			},
 			damage: 10,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/12.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/12.ts
@@ -38,16 +38,19 @@ const card: Card = {
 			cost: ["Fighting", "Colorless"],
 			name: {
 				en: "Split Spiral Punch",
+				de: "Spiralhieb"
 			},
 			damage: 40,
 			effect: {
 				en: "Your opponent's Active Pokémon is now Confused.",
+				de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
 			},
 		},
 		{
 			cost: ["Fighting", "Fighting", "Colorless"],
 			name: {
 				en: "Strength",
+				de: "Stärke"
 			},
 			damage: 130,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/13.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/13.ts
@@ -38,9 +38,11 @@ const card: Card = {
 			cost: ["Darkness", "Darkness", "Colorless"],
 			name: {
 				en: "Knocking Hammer",
+				de: "Klopfender Hammer"
 			},
 			effect: {
-				en: "Discard the top card of your opponent's deck."
+				en: "Discard the top card of your opponent's deck.",
+				de: "Lege die oberste Karte des Decks deines Gegners auf seinen Ablagestapel."
 			},
 			damage: 90,
 		},
@@ -48,9 +50,11 @@ const card: Card = {
 			cost: ["Darkness", "Darkness", "Darkness", "Colorless"],
 			name: {
 				en: "Shakedown",
+				de: "Abschütteln"
 			},
 			effect: {
-				en: "Discard a random card from your opponent's hand."
+				en: "Discard a random card from your opponent's hand.",
+				de: "Lege 1 zufällige Karte aus der Hand deines Gegners auf seinen Ablagestapel."
 			},
 			damage: 150,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/14.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/14.ts
@@ -29,6 +29,7 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Corkscrew Punch",
+				de: "Korkenzieherhieb"
 			},
 			damage: 30,
 		},
@@ -36,9 +37,11 @@ const card: Card = {
 			cost: ["Water", "Fighting"],
 			name: {
 				en: "Berkshire",
+				de: "Wutausbruch"
 			},
 			effect: {
 				en: "If your Benched Pokémon have any damage counters on them, this attack does 90 more damage.",
+				de: "Wenn auf den Pokémon auf deiner Bank mindestens 1 Schadensmarke liegt, fügt diese Attacke 90 Schadenspunkte mehr zu."
 			},
 			damage: "70+",
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/15.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/15.ts
@@ -29,9 +29,11 @@ const card: Card = {
 			cost: ["Colorless", "Colorless"],
 			name: {
 				en: "Live Painting",
+				de: "Live-Malerei"
 			},
 			effect: {
 				en: "Reveal any number of basic Energy cards from your hand. This attack does 30 more damage for each type of basic Energy you revealed in this way.",
+				de: "Zeige deinem Gegner beliebig viele Basis-Energiekarten auf deiner Hand. Diese Attacke fügt für jeden auf diese Weise gezeigten Basis-Energietyp 30 Schadenspunkte mehr zu."
 			},
 			damage: "30+"
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/2.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/2.ts
@@ -28,10 +28,12 @@ const card: Card = {
 		{
 			type: "Ability",
 			name: {
-				en: "Sky Circus"
+				en: "Sky Circus",
+				de: "Himmelszirkus"
 			},
 			effect: {
-				en: "If you played Bird Keeper from your hand during this turn, ignore all Energy in this Pokémon's attack costs"
+				en: "If you played Bird Keeper from your hand during this turn, ignore all Energy in this Pokémon's attack costs",
+				de: "Wenn du Vogel-Profi während dieses Zuges aus deiner Hand gespielt hast, ignoriere alle Energien in den Attackenkosten dieses Pokémon."
 			}
 		}
 	],
@@ -41,9 +43,11 @@ const card: Card = {
 			cost: ["Colorless", "Colorless", "Colorless"],
 			name: {
 				en: "Wind Shard",
+				de: "Windscherbe"
 			},
 			effect: {
-				en: "This attack does 60 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
+				en: "This attack does 60 damage to 1 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				de: "Diese Attacke fügt 1 Pokémon auf der Bank deines Gegners 60 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			}
 		},
 	],

--- a/data/McDonald's Collection/McDonald's Collection 2022/3.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/3.ts
@@ -29,9 +29,11 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Blot",
+				de: "Klecks"
 			},
 			effect: {
 				en: "Heal 10 damage from this Pokémon.",
+				de: "Heile 10 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 10
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/4.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/4.ts
@@ -29,15 +29,18 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Warm Up",
+				de: "Aufwärmen"
 			},
 			effect: {
-				en: "Search your deck for a Fire Energy card and attach it to 1 of your Pokémon. Then, shuffle your deck."
+				en: "Search your deck for a Fire Energy card and attach it to 1 of your Pokémon. Then, shuffle your deck.",
+				de: "Durchsuche dein Deck nach 1 {R}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische anschließend dein Deck."
 			}
 		},
 		{
 			cost: ["Fire", "Colorless", "Colorless"],
 			name: {
 				en: "Combustion",
+				de: "Glühen"
 			},
 			damage: 30,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/5.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/5.ts
@@ -29,9 +29,11 @@ const card: Card = {
 			cost: ["Fire"],
 			name: {
 				en: "Victory Dive",
+				de: "Triumphzug"
 			},
 			effect: {
-				en: "You may search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck."
+				en: "You may search your deck for up to 2 cards and put them into your hand. Then, shuffle your deck.",
+				de: "Du kannst dein Deck nach bis zu 2 Karten durchsuchen und sie auf deine Hand nehmen. Mische anschließend dein Deck."
 			},
 			damage: 30,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/6.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/6.ts
@@ -29,18 +29,22 @@ const card: Card = {
 			cost: ["Colorless"],
 			name: {
 				en: "Wintry Call",
+				de: "Winterlicher Ruf"
 			},
 			effect: {
-				en: "Search your deck for up to 2 Melony cards, reveal them, and put them into your hand. Then, shuffle your deck."
+				en: "Search your deck for up to 2 Melony cards, reveal them, and put them into your hand. Then, shuffle your deck.",
+				de: "Durchsuche dein Deck nach bis zu 2 Mel-Karten, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			}
 		},
 		{
 			cost: ["Water", "Colorless"],
 			name: {
 				en: "Icy Wind",
+				de: "Eissturm"
 			},
 			effect: {
-				en: "Your opponent's Active Pokémon is now Asleep."
+				en: "Your opponent's Active Pokémon is now Asleep.",
+				de: "Das Aktive Pokémon deines Gegners schläft jetzt."
 			},
 			damage: 50,
 		},

--- a/data/McDonald's Collection/McDonald's Collection 2022/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2022/7.ts
@@ -29,9 +29,11 @@ const card: Card = {
 			cost: ["Lightning"],
 			name: {
 				en: "Energize",
+				de: "Energiezufuhr"
 			},
 			effect: {
-				en: "Attach a Lightning Energy card from your discard pile to this Pokémon."
+				en: "Attach a Lightning Energy card from your discard pile to this Pokémon.",
+				de: "Lege 1 {L}-Energiekarte aus deinem Ablagestapel an dieses Pokémon an."
 			}
 		},
 		{


### PR DESCRIPTION
## Add missing German translations for 2022swsh

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
