### PR TITLE
fix(data): Phantasmal Flames variant and marketplace id fixes

### DIFF
--- a/data/Mega Evolution/Phantasmal Flames/001.ts
+++ b/data/Mega Evolution/Phantasmal Flames/001.ts
@@ -70,6 +70,14 @@ const card: Card = {
 				cardtrader: 356785
 			}
 		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 884285,
+				tcgplayer: 684041
+			}
+		},
 	],
 }
 

--- a/data/Mega Evolution/Phantasmal Flames/002.ts
+++ b/data/Mega Evolution/Phantasmal Flames/002.ts
@@ -90,6 +90,14 @@ const card: Card = {
 				cardtrader: 356786
 			}
 		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 884286,
+				tcgplayer: 684042
+			}
+		},
 	],
 }
 

--- a/data/Mega Evolution/Phantasmal Flames/003.ts
+++ b/data/Mega Evolution/Phantasmal Flames/003.ts
@@ -114,6 +114,14 @@ const card: Card = {
 				cardtrader: 356787
 			}
 		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 884287,
+				tcgplayer: 684043
+			}
+		},
 	],
 }
 

--- a/data/Mega Evolution/Phantasmal Flames/008.ts
+++ b/data/Mega Evolution/Phantasmal Flames/008.ts
@@ -94,9 +94,11 @@ const card: Card = {
 		},
 		{
 			type: 'holo',
+			foil: 'cosmos',
 			stamp: ['set-logo'],
 			thirdParty: {
-				cardmarket: 858502
+				cardmarket: 858502,
+				tcgplayer: 664012
 			}
 		},
 	],

--- a/data/Mega Evolution/Phantasmal Flames/014.ts
+++ b/data/Mega Evolution/Phantasmal Flames/014.ts
@@ -67,7 +67,8 @@ const card: Card = {
 		{
 			type: 'holo',
 			thirdParty: {
-				cardmarket: 858503,
+				cardmarket: 857589,
+				tcgplayer: 662201,
 				cardtrader: 356797
 			}
 		},
@@ -82,8 +83,8 @@ const card: Card = {
 		{
 			type: 'normal',
 			thirdParty: {
-				cardmarket: 857589,
-				tcgplayer: 662201
+				cardmarket: 858503,
+				tcgplayer: 664004
 			}
 		},
 	],

--- a/data/Mega Evolution/Phantasmal Flames/017.ts
+++ b/data/Mega Evolution/Phantasmal Flames/017.ts
@@ -98,7 +98,16 @@ const card: Card = {
 			type: 'holo',
 			stamp: ['set-logo'],
 			thirdParty: {
-				cardmarket: 858504
+				cardmarket: 858504,
+				tcgplayer: 664098
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 889721,
+				tcgplayer: 696441
 			}
 		},
 	],

--- a/data/Mega Evolution/Phantasmal Flames/026.ts
+++ b/data/Mega Evolution/Phantasmal Flames/026.ts
@@ -73,13 +73,6 @@ const card: Card = {
 			}
 		},
 		{
-			type: 'holo',
-			foil: 'cosmos',
-			thirdParty: {
-				cardmarket: 867791
-			}
-		},
-		{
 			type: 'reverse',
 			thirdParty: {
 				cardmarket: 857601,
@@ -89,16 +82,27 @@ const card: Card = {
 		},
 		{
 			type: 'holo',
-			stamp: ['eb-games'],
+			foil: 'cosmos',
 			thirdParty: {
-				cardmarket: 858506
+				cardmarket: 867791,
+				tcgplayer: 670788
 			}
 		},
 		{
 			type: 'holo',
+			stamp: ['eb-games'],
+			thirdParty: {
+				cardmarket: 858506,
+				tcgplayer: 671234
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
 			stamp: ['gamestop'],
 			thirdParty: {
-				cardmarket: 858505
+				cardmarket: 858505,
+				tcgplayer: 666533
 			}
 		},
 	],

--- a/data/Mega Evolution/Phantasmal Flames/034.ts
+++ b/data/Mega Evolution/Phantasmal Flames/034.ts
@@ -90,6 +90,14 @@ const card: Card = {
 				cardtrader: 356817
 			}
 		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 891252,
+				tcgplayer: 696233
+			}
+		},
 	],	
 }
 

--- a/data/Mega Evolution/Phantasmal Flames/045.ts
+++ b/data/Mega Evolution/Phantasmal Flames/045.ts
@@ -65,9 +65,11 @@ const card: Card = {
 	illustrator: "kawayoo",
 	variants: [
 		{
-			type: 'normal',
+			type: 'holo',
 			thirdParty: {
-				cardmarket: 858507
+				cardmarket: 857620,
+				tcgplayer: 662244,
+				cardtrader: 356828
 			}
 		},
 		{
@@ -79,11 +81,18 @@ const card: Card = {
 			}
 		},
 		{
-			type: 'holo',
+			type: 'normal',
 			thirdParty: {
-				cardmarket: 857620,
-				tcgplayer: 662244,
-				cardtrader: 356828
+				cardmarket: 858507,
+				tcgplayer: 664005
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 891734,
+				tcgplayer: 696145
 			}
 		},
 	],	

--- a/data/Mega Evolution/Phantasmal Flames/053.ts
+++ b/data/Mega Evolution/Phantasmal Flames/053.ts
@@ -97,17 +97,26 @@ const card: Card = {
 			}
 		},
 		{
-			type: 'normal',
-			thirdParty: {
-				cardmarket: 858508
-			}
-		},
-		{
 			type: 'reverse',
 			thirdParty: {
 				cardmarket: 857628,
 				tcgplayer: 662159,
 				cardtrader: 356836
+			}
+		},
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 858508,
+				tcgplayer: 664006
+			}
+		},
+		{
+			type: 'holo',
+			foil: 'cosmos',
+			thirdParty: {
+				cardmarket: 891754,
+				tcgplayer: 696232
 			}
 		},
 	],

--- a/data/Mega Evolution/Phantasmal Flames/068.ts
+++ b/data/Mega Evolution/Phantasmal Flames/068.ts
@@ -96,16 +96,17 @@ const card: Card = {
 			}
 		},
 		{
-			type: "normal",
-			thirdParty: {
-				cardmarket: 858509
-			}
-		},
-		{
 			type: "reverse",
 			thirdParty: {
 				cardmarket: 857643,
 				tcgplayer: 660409
+			}
+		},
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 858509,
+				tcgplayer: 663937
 			}
 		}
 	],	

--- a/data/Mega Evolution/Phantasmal Flames/079.ts
+++ b/data/Mega Evolution/Phantasmal Flames/079.ts
@@ -87,7 +87,7 @@ const card: Card = {
 	illustrator: "hncl",
 	variants: [
 		{
-			type: 'normal',
+			type: 'holo',
 			thirdParty: {
 				cardmarket: 857654,
 				tcgplayer: 662127


### PR DESCRIPTION
014 Moltres had the Build & Battle product on its holo and the main-set product on its normal, now swapped back, and 079 Ambipom is a holo, not a normal. The cosmos holo prints on 001, 002, 003, 017, 034, 045 and 053 were added with their Cardmarket and TCGplayer ids (008 and 026's GameStop print are cosmos holos as well), and the Build & Battle non-holos (014, 045, 053, 068) and the stamped prints (008, 017, 026) got their missing TCGplayer ids. All ids checked against the Cardmarket product list / price guide and the TCGplayer API.
