### PR TITLE
Add missing German translations for sm115

### DIFF
--- a/data/Sun & Moon/Hidden Fates/1.ts
+++ b/data/Sun & Moon/Hidden Fates/1.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Caterpie",
 		fr: "Chenipan",
+		de: "Raupy"
 	},
 
 	illustrator: "tetsuya koizumi",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -50,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "Perhaps because it would like to grow up quickly, it has a voracious appetite, eating a hundred leaves a day.",
+		de: "Das nimmersatte Raupy verschlingt 100 Blätter am Tag. Vermutlich strebt es so ein schnelleres Wachstum an."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/10.ts
+++ b/data/Sun & Moon/Hidden Fates/10.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Magmar",
 		fr: "Magmar",
+		de: "Magmar"
 	},
 
 	illustrator: "Satoshi Shirai",
@@ -33,6 +34,7 @@ const card: Card = {
 			name: {
 				en: "Fire Punch",
 				fr: "Poing de Feu",
+				de: "Feuerschlag"
 			},
 
 			damage: 50,
@@ -51,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "Its entire body is burning. When it breathes, the temperature rises. When it sneezes, flames shoot out!",
+		de: "Mit seinem brennenden Körper und glühenden Atem heizt es seine Umgebung auf. Beim Niesen stößt es Flammen aus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/11.ts
+++ b/data/Sun & Moon/Hidden Fates/11.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Psyduck",
 		fr: "Psykokwak",
+		de: "Enton"
 	},
 
 	illustrator: "nagimiso",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Headache",
 				fr: "Migraine",
+				de: "Kopfweh"
 			},
 
 			damage: 20,
@@ -50,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "Using psychokinesis gives it a headache, so it normally passes the time spacing out and doing as little as possible.",
+		de: "Wenn es seine Psycho-Kräfte einsetzt, bekommt es Kopfschmerzen. Deshalb steht es lieber untätig und geistesabwesend herum."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/12.ts
+++ b/data/Sun & Moon/Hidden Fates/12.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Slowpoke",
 		fr: "Ramoloss",
+		de: "Flegmon"
 	},
 
 	illustrator: "Misa Tsutsui",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Yawn",
 				fr: "Bâillement",
+				de: "Gähner"
 			},
 			effect: {
 				en: "Your opponent’s Active Pokémon is now Asleep.",
 				fr: "Le Pokémon Actif de votre adversaire est maintenant Endormi.",
+				de: "Das Aktive Pokémon deines Gegners schläft jetzt."
 			},
 
 		},
@@ -52,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "Alolan home cooking involves drying Slowpoke tails and then simmering them into a salty stew.",
+		de: "In Alola bereiten viele Familien Flegmon-Ruten zu, indem sie diese zuerst trocknen und dann in Salzwasser kochen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/13.ts
+++ b/data/Sun & Moon/Hidden Fates/13.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Staryu",
 		fr: "Stari",
+		de: "Sterndu"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Numbing Water",
 				fr: "Eau Paralysante",
+				de: "Betäubendes Wasser"
 			},
 			effect: {
 				en: "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei Kopf ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 10,
 
@@ -53,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "In many places, there are folktales of stardust falling into the ocean and becoming Staryu.",
+		de: "Einer weitverbreiteten Volkssage zufolge ist Sterndu aus Sternennebel entstanden, der ins Meer gefallen war."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/14.ts
+++ b/data/Sun & Moon/Hidden Fates/14.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Starmie GX",
 		fr: "Staross-GX",
+		de: "Starmie-GX"
 	},
 
 	illustrator: "PLANETA Otani",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Staryu",
 		fr: "Stari",
+		de: "Sterndu"
 	},
 
 	suffix: "GX",
@@ -37,10 +39,12 @@ const card: Card = {
 			name: {
 				en: "Star Stream",
 				fr: "Flot Stellaire",
+				de: "Sternenfluss"
 			},
 			effect: {
 				en: "Attach 2 Water Energy cards from your discard pile to 1 of your Pokémon.",
 				fr: "Attachez 2 cartes Énergie Water de votre pile de défausse à l’un de vos Pokémon.",
+				de: "Lege 2 {W}-Energiekarten aus deinem Ablagestapel an 1 deiner Pokémon an."
 			},
 			damage: 40,
 
@@ -54,6 +58,7 @@ const card: Card = {
 			name: {
 				en: "Spinning Attack",
 				fr: "Attaque Tournante",
+				de: "Rundumangriff"
 			},
 
 			damage: 100,
@@ -66,10 +71,12 @@ const card: Card = {
 			name: {
 				en: "Hydro Pump GX",
 				fr: "Hydrocanon-GX",
+				de: "Hydropumpe-GX"
 			},
 			effect: {
 				en: "This attack does 40 more damage times the amount of Water Energy attached to this Pokémon. (You can’t use more than 1 GX attack in a game.)",
 				fr: "Cette attaque inflige 40 dégâts supplémentaires multipliés par le nombre d’Énergies Water attachées à ce Pokémon. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Diese Attacke fügt 40 Schadenspunkte mehr mal der Anzahl der an dieses Pokémon angelegten {W}-Energien zu. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: "40+",
 

--- a/data/Sun & Moon/Hidden Fates/15.ts
+++ b/data/Sun & Moon/Hidden Fates/15.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Magikarp",
 		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	illustrator: "Shigenori Negishi",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Splash",
 				fr: "Trempette",
+				de: "Platscher"
 			},
 
 			damage: 10,
@@ -50,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "In the distant past, they were fairly strong, but they have become gradually weaker over time.",
+		de: "Vor langer, langer Zeit war es anscheinend ziemlich stark, doch es wurde zusehends schwächer und schwächer."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/16.ts
+++ b/data/Sun & Moon/Hidden Fates/16.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Gyarados GX",
 		fr: "Léviator-GX",
+		de: "Garados-GX"
 	},
 
 	illustrator: "5ban Graphics",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Magikarp",
 		fr: "Magicarpe",
+		de: "Karpador"
 	},
 
 	suffix: "GX",
@@ -40,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Dragon Rage",
 				fr: "Draco-Rage",
+				de: "Drachenwut"
 			},
 
 			damage: 130,
@@ -55,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Hyper Beam GX",
 				fr: "Ultralaser-GX",
+				de: "Hyperstrahl-GX"
 			},
 			effect: {
 				en: "(You can’t use more than 1 GX attack in a game.)",
 				fr: "(Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "(Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 240,
 

--- a/data/Sun & Moon/Hidden Fates/17.ts
+++ b/data/Sun & Moon/Hidden Fates/17.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lapras",
 		fr: "Lokhlass",
+		de: "Lapras"
 	},
 
 	illustrator: "kodama",
@@ -34,6 +35,7 @@ const card: Card = {
 			name: {
 				en: "Aqua Wave",
 				fr: "Aqua-Vague",
+				de: "Aquawoge"
 			},
 
 			damage: 80,
@@ -52,6 +54,7 @@ const card: Card = {
 
 	description: {
 		en: "It likes swimming around with people on its back. In the Alola region, it's an important means of transportation over water.",
+		de: "Da es liebend gerne beim Schwimmen Menschen auf seinem Rücken trägt, gilt es in Alola als bedeutendes Transportmittel."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/18.ts
+++ b/data/Sun & Moon/Hidden Fates/18.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Vaporeon",
 		fr: "Aquali",
+		de: "Aquana"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -38,6 +40,7 @@ const card: Card = {
 			name: {
 				en: "Water Gun",
 				fr: "Pistolet à O",
+				de: "Aquaknarre"
 			},
 
 			damage: 30,
@@ -52,10 +55,12 @@ const card: Card = {
 			name: {
 				en: "Bubble Drain",
 				fr: "Vide Bulle",
+				de: "Blasengully"
 			},
 			effect: {
 				en: "Heal 30 damage from this Pokémon.",
 				fr: "Soignez 30 dégâts à ce Pokémon.",
+				de: "Heile 30 Schadenspunkte bei diesem Pokémon."
 			},
 			damage: 80,
 
@@ -73,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "Clean, clear waters are its usual habitat. When it's about to be attacked by an invading enemy, it dives into the water to hide.",
+		de: "Es lebt meist an klaren Gewässern. Wittert es einen feindlichen Angriff, verschwindet es ins Wasser und macht sich unsichtbar."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/19.ts
+++ b/data/Sun & Moon/Hidden Fates/19.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pikachu",
 		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Quick Attack",
 				fr: "Vive-Attaque",
+				de: "Ruckzuckhieb"
 			},
 
 			damage: 10,
@@ -46,6 +48,7 @@ const card: Card = {
 			name: {
 				en: "Electro Ball",
 				fr: "Boule Élek",
+				de: "Elektroball"
 			},
 
 			damage: 60,
@@ -71,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "Its nature is to store up electricity. Forests where nests of Pikachu live are dangerous, since the trees are so often struck by lightning.",
+		de: "Es liegt in seiner Natur, konstant Elektrizität zu speichern. Die Wälder, in denen Pikachu leben, bergen stets die Gefahr eines Blitzgewitters."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/2.ts
+++ b/data/Sun & Moon/Hidden Fates/2.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Metapod",
 		fr: "Chrysacier",
+		de: "Safcon"
 	},
 
 	illustrator: "Shibuzoh.",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Caterpie",
 		fr: "Chenipan",
+		de: "Raupy"
 	},
 
 	stage: "Stage1",
@@ -38,6 +40,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 30,
@@ -56,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Its shell is filled with a thick liquid. All of the cells throughout its body are being rebuilt in preparation for evolution.",
+		de: "Sein Panzer birgt ein dickflüssiges Inneres. In Vorbereitung auf seine Entwicklung wird seine Zellstruktur vollständig umgestaltet."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/20.ts
+++ b/data/Sun & Moon/Hidden Fates/20.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Raichu GX",
 		fr: "Raichu-GX",
+		de: "Raichu-GX"
 	},
 
 	illustrator: "5ban Graphics",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Pikachu",
 		fr: "Pikachu",
+		de: "Pikachu"
 	},
 
 	suffix: "GX",
@@ -39,6 +41,7 @@ const card: Card = {
 			name: {
 				en: "Thunderbolt",
 				fr: "Tonnerre",
+				de: "Donnerblitz"
 			},
 
 			damage: 120,
@@ -53,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Spark Ball GX",
 				fr: "Boule Étincelles-GX",
+				de: "Zündball-GX"
 			},
 			effect: {
 				en: "(You can’t use more than 1 GX attack in a game.)",
 				fr: "(Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "(Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 200,
 

--- a/data/Sun & Moon/Hidden Fates/21.ts
+++ b/data/Sun & Moon/Hidden Fates/21.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Voltorb",
 		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	illustrator: "SATOSHI NAKAI",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Lightning Ball",
 				fr: "Boule Éclair",
+				de: "Kugelblitz"
 			},
 
 			damage: 20,
@@ -57,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "It was discovered when Poké Balls were introduced. It is said that there is some connection.",
+		de: "Es wurde entdeckt, als man Pokébälle einführte. Es scheint, als gäbe es da einen Zusammenhang."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/22.ts
+++ b/data/Sun & Moon/Hidden Fates/22.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Electrode",
 		fr: "Électrode",
+		de: "Lektrobal"
 	},
 
 	illustrator: "Anesaki Dynamic",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Voltorb",
 		fr: "Voltorbe",
+		de: "Voltobal"
 	},
 
 	stage: "Stage1",
@@ -37,6 +39,7 @@ const card: Card = {
 			name: {
 				en: "Lightning Ball",
 				fr: "Boule Éclair",
+				de: "Kugelblitz"
 			},
 
 			damage: 30,
@@ -51,10 +54,12 @@ const card: Card = {
 			name: {
 				en: "Electroblast",
 				fr: "Électro-Explosion",
+				de: "Elektrokracher"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 30 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 30 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf 2 Münzen. Diese Attacke fügt 30 Schadenspunkte mehr pro Kopf zu."
 			},
 			damage: "60+",
 
@@ -79,6 +84,7 @@ const card: Card = {
 
 	description: {
 		en: "It explodes in response to even minor stimuli. It is feared, with the nickname of \"The Bomb Ball.\"",
+		de: "Es explodiert schon bei kleinsten Reizen. Sein Spitzname „Die Bombenkugel“ spiegelt die Furcht der Menschen wider."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/23.ts
+++ b/data/Sun & Moon/Hidden Fates/23.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Jolteon",
 		fr: "Voltali",
+		de: "Blitza"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	stage: "Stage1",
@@ -35,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Electromagnetic Wall",
 				fr: "Mur Électromagnétique",
+				de: "Elektromagnetischer Wall"
 			},
 			effect: {
 				en: "As long as this Pokémon is your Active Pokémon, whenever your opponent attaches an Energy card from their hand to 1 of their Pokémon, put 2 damage counters on that Pokémon.",
 				fr: "Tant que ce Pokémon est votre Pokémon Actif, chaque fois que votre adversaire attache une carte Énergie de sa main à l’un de ses Pokémon, placez 2 marqueurs de dégâts sur ce Pokémon-là.",
+				de: "Solang dieses Pokémon dein Aktives Pokémon ist, lege jedes Mal, wenn dein Gegner 1 Energiekarte aus seiner Hand an 1 seiner Pokémon anlegt, 2 Schadensmarken auf jenes Pokémon."
 			},
 		},
 	],
@@ -52,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Thunderbolt",
 				fr: "Tonnerre",
+				de: "Donnerblitz"
 			},
 			effect: {
 				en: "Discard all Energy from this Pokémon.",
 				fr: "Défaussez toute l’Énergie de ce Pokémon.",
+				de: "Lege alle Energien von diesem Pokémon auf deinen Ablagestapel."
 			},
 			damage: 90,
 
@@ -80,6 +86,7 @@ const card: Card = {
 
 	description: {
 		en: "Its lungs contain an organ that creates electricity. The crackling sound of electricity can be heard when it exhales.",
+		de: "Blitza verfügt über ein Organ in der Lunge, das Elektrizität erzeugt. Wenn dieses Pokémon ausatmet, hört man ein elektrisches Knistern."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/24.ts
+++ b/data/Sun & Moon/Hidden Fates/24.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Zapdos",
 		fr: "Électhor",
+		de: "Zapdos"
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -33,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Hurricane Call",
 				fr: "Appel à l’Ouragan",
+				de: "Sturmruf"
 			},
 			effect: {
 				en: "Flip 4 coins. For each heads, search your deck for a Lightning Energy card and attach it to 1 of your Pokémon-GX or Pokémon-EX. Then, shuffle your deck.",
 				fr: "Lancez 4 pièces. Pour chaque côté face, cherchez une carte Énergie Lightning dans votre deck et attachez-la à l’un de vos Pokémon-GX ou Pokémon-EX. Mélangez ensuite votre deck.",
+				de: "Wirf 4 Münzen. Durchsuche pro Kopf dein Deck nach 1 {L}-Energiekarte und lege sie an 1 deiner Pokémon-GX oder Pokémon-EX an. Mische anschließend dein Deck."
 			},
 
 		},
@@ -49,6 +52,7 @@ const card: Card = {
 			name: {
 				en: "Sky-High Claws",
 				fr: "Griffes Gratte-Ciel",
+				de: "Himmelhohe Klauen"
 			},
 
 			damage: 100,
@@ -74,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "A legendary bird Pokémon that is said to appear from clouds while dropping enormous lightning bolts.",
+		de: "Ein Legendäres Vogel-Pokémon, das im Sturzflug aus den Wolken bricht und Blitze schleudert."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/25.ts
+++ b/data/Sun & Moon/Hidden Fates/25.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ekans",
 		fr: "Abo",
+		de: "Rettan"
 	},
 
 	illustrator: "MAHOU",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Wrap",
 				fr: "Ligotage",
+				de: "Wickel"
 			},
 			effect: {
 				en: "Flip a coin. If heads, discard an Energy from your opponent’s Active Pokémon.",
 				fr: "Lancez une pièce. Si c’est face, défaussez une Énergie du Pokémon Actif de votre adversaire.",
+				de: "Wirf 1 Münze. Lege bei Kopf 1 Energie vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel."
 			},
 			damage: 10,
 
@@ -53,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "By dislocating its jaw, it can swallow prey larger than itself. After a meal, it curls up and rests.",
+		de: "Es hängt seinen Kiefer aus und verschlingt so selbst größere Beute am Stück. Danach rollt es sich zusammen und ruht sich aus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/26.ts
+++ b/data/Sun & Moon/Hidden Fates/26.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Ekans",
 		fr: "Abo",
+		de: "Rettan"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -33,6 +34,7 @@ const card: Card = {
 			name: {
 				en: "Tail Whap",
 				fr: "Queue Battoir",
+				de: "Schweifvertrimmer"
 			},
 
 			damage: 30,
@@ -51,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "By dislocating its jaw, it can swallow prey larger than itself. After a meal, it curls up and rests.",
+		de: "Es hängt seinen Kiefer aus und verschlingt so selbst größere Beute am Stück. Danach rollt es sich zusammen und ruht sich aus."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/27.ts
+++ b/data/Sun & Moon/Hidden Fates/27.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Arbok",
 		fr: "Arbok",
+		de: "Arbok"
 	},
 
 	illustrator: "kirisAki",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Ekans",
 		fr: "Abo",
+		de: "Rettan"
 	},
 
 	stage: "Stage1",
@@ -35,10 +37,12 @@ const card: Card = {
 			name: {
 				en: "Last Pattern",
 				fr: "Dernier Motif",
+				de: "Letztes Muster"
 			},
 			effect: {
 				en: "If this Pokémon is Knocked Out by damage from an opponent’s attack, discard 2 random cards from your opponent’s hand.",
 				fr: "Si ce Pokémon est mis K.O. par les dégâts d’une attaque de votre adversaire, défaussez 2 cartes au hasard de la main de votre adversaire.",
+				de: "Wenn dieses Pokémon durch Schaden einer Attacke deines Gegners kampfunfähig wird, lege 2 zufällige Karten aus der Hand deines Gegners auf seinen Ablagestapel."
 			},
 		},
 	],
@@ -53,10 +57,12 @@ const card: Card = {
 			name: {
 				en: "Rocket Tail",
 				fr: "Queue Rocket",
+				de: "Rocket-Schweif"
 			},
 			effect: {
 				en: "If Jessie & James is in your discard pile, this attack does 80 more damage.",
 				fr: "Si la carte Jessie et James est dans votre pile de défausse, cette attaque inflige 80 dégâts supplémentaires.",
+				de: "Wenn sich Jessie & James in deinem Ablagestapel befindet, fügt diese Attacke 80 Schadenspunkte mehr zu."
 			},
 			damage: "50+",
 
@@ -74,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "The latest research has determined that there are over 20 possible arrangements of the patterns on its stomach.",
+		de: "Jüngsten Forschungsergebnissen zufolge gibt es mehr als 20 verschiedene Musterungen, die Arboks Bauch aufweisen kann."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/28.ts
+++ b/data/Sun & Moon/Hidden Fates/28.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Koffing",
 		fr: "Smogo",
+		de: "Smogon"
 	},
 
 	illustrator: "Saya Tsuruta",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 20,
@@ -50,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "Its thin, balloon-like body is inflated by horribly toxic gases. It reeks when it is nearby.",
+		de: "Sein dünner, ballonartiger Körper ist mit schrecklichem Giftgas gefüllt. Es verbreitet einen heftigen Gestank, wenn es in der Nähe ist."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/29.ts
+++ b/data/Sun & Moon/Hidden Fates/29.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Weezing",
 		fr: "Smogogo",
+		de: "Smogmog"
 	},
 
 	illustrator: "Hideki Ishikawa",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Koffing",
 		fr: "Smogo",
+		de: "Smogon"
 	},
 
 	stage: "Stage1",
@@ -34,11 +36,13 @@ const card: Card = {
 			type: "Ability",
 			name: {
 				en: "Surrender Now",
-				fr: "Rendez-Vous Tous"
+				fr: "Rendez-Vous Tous",
+				de: "Gib lieber auf"
 			},
 			effect: {
 				en: "Once during your turn, if this Pokémon is discarded with the effect of Jessie & James, you may have your opponent discard a card from their hand. (They discard that card after the effect of Jessie & James.)",
-				fr: "Une seule fois pendant votre tour, si ce Pokémon est défaussé du fait de l'effet de la carte Jessie et James, vous pouvez demander à votre adversaire de défausser une carte de sa main. (Cette carte est défaussée après l'effet de Jessie et James.)"
+				fr: "Une seule fois pendant votre tour, si ce Pokémon est défaussé du fait de l'effet de la carte Jessie et James, vous pouvez demander à votre adversaire de défausser une carte de sa main. (Cette carte est défaussée après l'effet de Jessie et James.)",
+				de: "Einmal während deines Zuges, wenn dieses Pokémon durch den Effekt von Jessie & James auf deinen Ablagestapel gelegt wird, kannst du deinen Gegner dazu veranlassen, 1 Karte aus seiner Hand auf seinen Ablagestapel zu legen. (Er legt jene Karte nach dem Effekt von Jessie & James auf seinen Ablagestapel.)"
 			},
 		},
 	],
@@ -51,6 +55,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 			damage: 40,
 
@@ -68,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "If one of the twin Koffing inflates, the other one deflates. It constantly mixes its poisonous gases.",
+		de: "Pumpt sich eines der zwei Smogon auf, lässt das andere Luft ab. So findet ein Giftgasaustausch statt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/3.ts
+++ b/data/Sun & Moon/Hidden Fates/3.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Butterfree",
 		fr: "Papilusion",
+		de: "Smettbo"
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Metapod",
 		fr: "Chrysacier",
+		de: "Safcon"
 	},
 
 	stage: "Stage2",
@@ -38,6 +40,7 @@ const card: Card = {
 			name: {
 				en: "Gust",
 				fr: "Tornade",
+				de: "Windstoß"
 			},
 
 			damage: 80,
@@ -56,6 +59,7 @@ const card: Card = {
 
 	description: {
 		en: "Its wings are covered in toxic scales. If it finds bird Pokémon going after Caterpie, Butterfree sprinkles its scales on them to drive them off.",
+		de: "Sieht es ein Raupy, das von Vogel-Pokémon angegriffen wird, schlägt es diese mit seinem hochgiftigen Flügelstaub in die Flucht."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/30.ts
+++ b/data/Sun & Moon/Hidden Fates/30.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Jynx",
 		fr: "Lippoutou",
+		de: "Rossana"
 	},
 
 	illustrator: "Kouki Saitou",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Slap",
 				fr: "Gifle",
+				de: "Hieb"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Lovely Kiss",
 				fr: "Grobisou",
+				de: "Todeskuss"
 			},
 
 			damage: 30,
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "It sways its hips to a rhythm all its own. The precise movements of Jynx living in Alola are truly wonderful.",
+		de: "Es bewegt seine Hüften in einem eigentümlichen Rhythmus. Rossana in Alola beherrschen einen besonders anmutigen Hüftschwung."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/31.ts
+++ b/data/Sun & Moon/Hidden Fates/31.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mewtwo GX",
 		fr: "Mewtwo-GX",
+		de: "Mewtu-GX"
 	},
 
 	illustrator: "aky CG Works",
@@ -34,6 +35,7 @@ const card: Card = {
 			name: {
 				en: "Super Psy Bolt",
 				fr: "Super Psy",
+				de: "Super-Psischlag"
 			},
 
 			damage: 110,
@@ -48,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Psycrush GX",
 				fr: "Écrasement Psy-GX",
+				de: "Psibrecher-GX"
 			},
 			effect: {
 				en: "Discard all Energy from your opponent’s Active Pokémon. (You can’t use more than 1 GX attack in a game.)",
 				fr: "Défaussez toute l’Énergie du Pokémon Actif de votre adversaire. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Lege alle Energien vom Aktiven Pokémon deines Gegners auf seinen Ablagestapel. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 120,
 

--- a/data/Sun & Moon/Hidden Fates/32.ts
+++ b/data/Sun & Moon/Hidden Fates/32.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mew",
 		fr: "Mew",
+		de: "Mew"
 	},
 
 	illustrator: "Atsuko Nishida",
@@ -33,6 +34,7 @@ const card: Card = {
 			name: {
 				en: "Psyshot",
 				fr: "Piqûre Psy",
+				de: "Psychoschuss"
 			},
 
 			damage: 50,
@@ -51,6 +53,7 @@ const card: Card = {
 
 	description: {
 		en: "Because it can use all kinds of moves, many scientists believe Mew to be the ancestor of Pokémon.",
+		de: "Es beherrscht alle möglichen Attacken, daher sieht man in ihm den Vorfahren aller Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/33.ts
+++ b/data/Sun & Moon/Hidden Fates/33.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Geodude",
 		fr: "Racaillou",
+		de: "Kleinstein"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 10,
@@ -50,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "Geodude that have lived a long life have had all their edges smoothed out until they're totally round. They also have a calm, quiet disposition.",
+		de: "Mit dem Alter verliert es zunehmend seine Kantigkeit, bis es vollkommen rund und auch charakterlich immer ausgeglichener wird."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/34.ts
+++ b/data/Sun & Moon/Hidden Fates/34.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Graveler",
 		fr: "Gravalanch",
+		de: "Georok"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Geodude",
 		fr: "Racaillou",
+		de: "Kleinstein"
 	},
 
 	stage: "Stage1",
@@ -38,6 +40,7 @@ const card: Card = {
 			name: {
 				en: "Tackle",
 				fr: "Charge",
+				de: "Tackle"
 			},
 
 			damage: 30,
@@ -53,10 +56,12 @@ const card: Card = {
 			name: {
 				en: "Mudslide",
 				fr: "Coulée de Boue",
+				de: "Schlammlawine"
 			},
 			effect: {
 				en: "Discard 2 Fighting Energy from this Pokémon. This attack does 80 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Défaussez 2 Énergies Fighting de ce Pokémon. Cette attaque inflige 80 dégâts à l’un des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Lege 2 {F}-Energien von diesem Pokémon auf deinen Ablagestapel. Diese Attacke fügt 1 Pokémon deines Gegners 80 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -73,6 +78,7 @@ const card: Card = {
 
 	description: {
 		en: "It climbs up cliffs as it heads toward the peak of a mountain. As soon as it reaches the summit, it rolls back down the way it came.",
+		de: "Es klettert Berghänge bis zum Gipfel empor. Einmal oben angekommen, rollt es über den Bergpfad sogleich wieder hinunter."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/35.ts
+++ b/data/Sun & Moon/Hidden Fates/35.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Golem",
 		fr: "Grolem",
+		de: "Geowaz"
 	},
 
 	illustrator: "Ken Sugimori",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Graveler",
 		fr: "Gravalanch",
+		de: "Georok"
 	},
 
 	stage: "Stage2",
@@ -39,10 +41,12 @@ const card: Card = {
 			name: {
 				en: "Rock Slide",
 				fr: "Éboulement",
+				de: "Steinhagel"
 			},
 			effect: {
 				en: "This attack does 20 damage to 3 of your opponent’s Benched Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à 3 des Pokémon de Banc de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Diese Attacke fügt 3 Pokémon auf der Bank deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 60,
 
@@ -57,6 +61,7 @@ const card: Card = {
 			name: {
 				en: "Land Crush",
 				fr: "Écras’Terre",
+				de: "Schollenbrecher"
 			},
 
 			damage: 140,
@@ -75,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "When Golem grow old, they stop shedding their shells. Those that have lived a long, long time have shells green with moss.",
+		de: "Im Alter hört es auf, sich zu häuten. Der Panzer betagter Geowaz ist mit dichtem, grünem Moos bewachsen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/36.ts
+++ b/data/Sun & Moon/Hidden Fates/36.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Onix GX",
 		fr: "Onix-GX",
+		de: "Onix-GX"
 	},
 
 	illustrator: "PLANETA Igarashi",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Bind",
 				fr: "Étreinte",
+				de: "Klammergriff"
 			},
 			effect: {
 				en: "Flip a coin. If heads, your opponent’s Active Pokémon is now Paralyzed.",
 				fr: "Lancez une pièce. Si c’est face, le Pokémon Actif de votre adversaire est maintenant Paralysé.",
+				de: "Wirf 1 Münze. Bei Kopf ist das Aktive Pokémon deines Gegners jetzt paralysiert."
 			},
 			damage: 30,
 
@@ -51,6 +54,7 @@ const card: Card = {
 			name: {
 				en: "Heavy Impact",
 				fr: "Gros Impact",
+				de: "Schwerer Einschlag"
 			},
 
 			damage: 150,
@@ -67,10 +71,12 @@ const card: Card = {
 			name: {
 				en: "Rocky Avalanche GX",
 				fr: "Avalanche Rocheuse-GX",
+				de: "Felslawine-GX"
 			},
 			effect: {
 				en: "During your opponent’s next turn, this Pokémon takes 100 less damage from attacks (after applying Weakness and Resistance). (You can’t use more than 1 GX attack in a game.)",
 				fr: "Pendant le prochain tour de votre adversaire, ce Pokémon subit 100 dégâts de moins provenant des attaques (après application de la Faiblesse et de la Résistance). (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Während des nächsten Zuges deines Gegners werden diesem Pokémon durch Attacken 100 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 200,
 

--- a/data/Sun & Moon/Hidden Fates/37.ts
+++ b/data/Sun & Moon/Hidden Fates/37.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Cubone",
 		fr: "Osselait",
+		de: "Tragosso"
 	},
 
 	illustrator: "Hasuno",
@@ -33,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Sharpshooting",
 				fr: "Tir de Précision",
+				de: "Scharfschuss"
 			},
 			effect: {
 				en: "This attack does 20 damage to 1 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.)",
 				fr: "Cette attaque inflige 20 dégâts à l’un des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				de: "Diese Attacke fügt 1 Pokémon deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 
 		},
@@ -53,6 +56,7 @@ const card: Card = {
 
 	description: {
 		en: "The skull it wears on its head is that of its dead mother. According to some, it will evolve when it comes to terms with the pain of her death.",
+		de: "Der Schädel auf seinem Kopf gehörte seiner verstorbenen Mutter. Überwindet es diesen Verlust, setzt angeblich die Entwicklung ein."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/38.ts
+++ b/data/Sun & Moon/Hidden Fates/38.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Clefairy",
 		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	illustrator: "Saya Tsuruta",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Lead",
 				fr: "Mentor",
+				de: "Führen"
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a Supporter card, reveal it, and put it into your hand. Then, shuffle your deck.",
 				fr: "Lancez une pièce. Si c’est face, cherchez une carte Supporter dans votre deck, montrez-la, puis ajoutez-la à votre main. Mélangez ensuite votre deck.",
+				de: "Wirf 1 Münze. Durchsuche bei Kopf dein Deck nach 1 Unterstützerkarte, zeige sie deinem Gegner und nimm sie auf deine Hand. Mische anschließend dein Deck."
 			},
 
 		},
@@ -46,6 +49,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras’Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -71,6 +75,7 @@ const card: Card = {
 
 	description: {
 		en: "They're popular, but they're rare. Trainers who show them off recklessly may be targeted by thieves.",
+		de: "Dieses beliebte Pokémon hat Seltenheitswert. Wer leichtsinnig damit prahlt, eins zu haben, könnte in das Visier von Dieben geraten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/39.ts
+++ b/data/Sun & Moon/Hidden Fates/39.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Clefairy",
 		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	illustrator: "kirisAki",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras’Face",
+				de: "Pfund"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Moon Dance",
 				fr: "Danse à la Lune",
+				de: "Mondtanz"
 			},
 
 			damage: 30,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "They're popular, but they're rare. Trainers who show them off recklessly may be targeted by thieves.",
+		de: "Dieses beliebte Pokémon hat Seltenheitswert. Wer leichtsinnig damit prahlt, eins zu haben, könnte in das Visier von Dieben geraten."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/4.ts
+++ b/data/Sun & Moon/Hidden Fates/4.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Paras",
 		fr: "Paras",
+		de: "Paras"
 	},
 
 	illustrator: "OOYAMA",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Scratch",
 				fr: "Griffe",
+				de: "Kratzer"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 20,
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Whether it's due to a lack of moisture or a lack of nutrients, in Alola the mushrooms on Paras don't grow up quite right.",
+		de: "In Alola sind Paras’ Pilze etwas unterentwickelt. Vielleicht mangelt es ihm hier an Feuchtigkeit oder Nährstoffen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/40.ts
+++ b/data/Sun & Moon/Hidden Fates/40.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Clefable",
 		fr: "Mélodelfe",
+		de: "Pixi"
 	},
 
 	illustrator: "sui",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Clefairy",
 		fr: "Mélofée",
+		de: "Piepi"
 	},
 
 	stage: "Stage1",
@@ -38,6 +40,7 @@ const card: Card = {
 			name: {
 				en: "Pound",
 				fr: "Écras’Face",
+				de: "Pfund"
 			},
 
 			damage: 40,
@@ -52,6 +55,7 @@ const card: Card = {
 			name: {
 				en: "Moon Impact",
 				fr: "Impact Lunaire",
+				de: "Mondeinschlag"
 			},
 
 			damage: 90,
@@ -77,6 +81,7 @@ const card: Card = {
 
 	description: {
 		en: "It can't help but hear a pin drop from over half a mile away, so it lives deep in the mountains where there aren't many people or Pokémon.",
+		de: "Es hört eine fallende Nadel aus 1 km Entfernung und lebt daher tief in den Bergen, weit weg vom Lärm der Menschen und anderer Pokémon."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/41.ts
+++ b/data/Sun & Moon/Hidden Fates/41.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Jigglypuff",
 		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	illustrator: "Mizue",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Singing Voice",
 				fr: "Voix Harmonieuse",
+				de: "Gesangsstimme"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Rollout",
 				fr: "Roulade",
+				de: "Walzer"
 			},
 
 			damage: 30,
@@ -70,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "Recordings of Jigglypuff's strange lullabies can be purchased from department stores. These CDs can be found near the bedding area.",
+		de: "In der Bettenabteilung von Kaufhäusern erhält man auch CDs mit Pummeluffs wundersam einlullendem Gesang."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/42.ts
+++ b/data/Sun & Moon/Hidden Fates/42.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Wigglytuff GX",
 		fr: "Grodoudou-GX",
+		de: "Knuddeluff-GX"
 	},
 
 	illustrator: "5ban Graphics",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Jigglypuff",
 		fr: "Rondoudou",
+		de: "Pummeluff"
 	},
 
 	suffix: "GX",
@@ -39,10 +41,12 @@ const card: Card = {
 			name: {
 				en: "Rolling Rush",
 				fr: "Ruée-Boulée",
+				de: "Rollender Ansturm"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 more damage for each heads.",
 				fr: "Lancez une pièce jusqu’à ce que vous obteniez un côté pile. Cette attaque inflige 30 dégâts supplémentaires pour chaque côté face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis Zahl kommt. Diese Attacke fügt 30 Schadenspunkte mehr pro Kopf zu."
 			},
 			damage: "100+",
 
@@ -56,10 +60,12 @@ const card: Card = {
 			name: {
 				en: "Lovely Star GX",
 				fr: "Belle Étoile-GX",
+				de: "Lieblicher Star GX"
 			},
 			effect: {
 				en: "Heal all damage from this Pokémon. (You can’t use more than 1 GX attack in a game.)",
 				fr: "Soignez tous les dégâts de ce Pokémon. (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Heile allen Schaden bei diesem Pokémon. (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 130,
 

--- a/data/Sun & Moon/Hidden Fates/43.ts
+++ b/data/Sun & Moon/Hidden Fates/43.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Mr. Mime",
 		fr: "M. Mime",
+		de: "Pantimos"
 	},
 
 	illustrator: "Hideki Ishikawa",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Happy Mime",
 				fr: "Mime Heureux",
+				de: "Fröhlicher Pantomime"
 			},
 			effect: {
 				en: "Each player draws a card.",
 				fr: "Chaque joueur pioche une carte.",
+				de: "Jeder Spieler zieht 1 Karte."
 			},
 
 		},
@@ -47,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Double Slap",
 				fr: "Torgnoles",
+				de: "Duplexhieb"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 40 damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 40 dégâts pour chaque côté face.",
+				de: "Wirf 2 Münzen. Diese Attacke fügt 40 Schadenspunkte pro Kopf zu."
 			},
 			damage: "40×",
 
@@ -75,6 +80,7 @@ const card: Card = {
 
 	description: {
 		en: "Its pantomime skills are wonderful. You may become enraptured while watching it, but next thing you know, Mr. Mime has made a real wall.",
+		de: "Sein Können als Pantomime ist verblüffend. Vor lauter Bewunderung merkt man gar nicht, wie plötzlich eine echte Wand vor einem erscheint."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/44.ts
+++ b/data/Sun & Moon/Hidden Fates/44.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Moltres & Zapdos & Articuno GX",
 		fr: "Sulfura, Électhor et Artikodin-GX",
+		de: "Lavados & Zapdos & Arktos-GX"
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Trinity Burn",
 				fr: "Triple Brûlure",
+				de: "Dreiheitsbrand"
 			},
 
 			damage: 210,
@@ -44,10 +46,12 @@ const card: Card = {
 			name: {
 				en: "Sky Legends GX",
 				fr: "Légendes Célestes GX",
+				de: "Legenden der Lüfte GX"
 			},
 			effect: {
 				en: "Shuffle this Pokémon and all cards attached to it into your deck. If this Pokémon has at least 1 extra Fire, Water, and Lightning Energy attached to it (in addition to this attack’s cost), this attack does 110 damage to 3 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",
-				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie Fire, Water et Lightning supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)"
+				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie Fire, Water et Lightning supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Mische dieses Pokémon und alle an es angelegten Karten in dein Deck. Wenn an dieses Pokémon mindestens 1 extra {R}-, {W}- und {L}-Energie angelegt ist (zusätzlich zu den Kosten dieser Attacke), fügt diese Attacke 3 Pokémon deines Gegners 110 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates/45.ts
+++ b/data/Sun & Moon/Hidden Fates/45.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Farfetch’d",
 		fr: "Canarticho",
+		de: "Porenta"
 	},
 	illustrator: "Eri Yamaki",
 	rarity: "Uncommon",
@@ -31,6 +32,7 @@ const card: Card = {
 			name: {
 				en: "Leek Slap",
 				fr: "Coup d’Oignon",
+				de: "Lauchschlag"
 			},
 
 			damage: 30,
@@ -56,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "The plant stalk it holds is its weapon. The stalk is used like a sword to cut all sorts of things.",
+		de: "Dieses Pokémon nutzt eine Lauchstange als Waffe. Es setzt sie wie ein Schwert ein."
 	},
 }
 

--- a/data/Sun & Moon/Hidden Fates/46.ts
+++ b/data/Sun & Moon/Hidden Fates/46.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Chansey",
 		fr: "Leveinard",
+		de: "Chaneira"
 	},
 
 	illustrator: "sowsow",
@@ -34,10 +35,12 @@ const card: Card = {
 			name: {
 				en: "Double-Edge",
 				fr: "Damoclès",
+				de: "Risikotackle"
 			},
 			effect: {
 				en: "This Pokémon does 20 damage to itself.",
 				fr: "Ce Pokémon s’inflige 20 dégâts.",
+				de: "Dieses Pokémon fügt sich selbst 20 Schadenspunkte zu."
 			},
 			damage: 80,
 
@@ -55,6 +58,7 @@ const card: Card = {
 
 	description: {
 		en: "It seems that other Pokémon's efforts to take its delicious, nutritious egg away from it caused Chansey to get faster at fleeing.",
+		de: "Es hat gelernt, rasch davonzulaufen, da es viele Pokémon auf die nahrhaften und köstlichen Eier abgesehen haben, die es legt."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/47.ts
+++ b/data/Sun & Moon/Hidden Fates/47.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Kangaskhan",
 		fr: "Kangourex",
+		de: "Kangama"
 	},
 
 	illustrator: "You Iribi",
@@ -33,10 +34,12 @@ const card: Card = {
 			name: {
 				en: "Parental Fury",
 				fr: "Fureur Maternelle",
+				de: "Mütterliche Rage"
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 40 damage for each heads.",
 				fr: "Lancez une pièce jusqu’à ce que vous obteniez un côté pile. Cette attaque inflige 40 dégâts pour chaque côté face.",
+				de: "Wirf so lang 1 Münze, bis zum ersten Mal das Ergebnis Zahl kommt. Diese Attacke fügt 40 Schadenspunkte pro Kopf zu."
 			},
 			damage: "40×",
 
@@ -54,6 +57,7 @@ const card: Card = {
 
 	description: {
 		en: "Kangaskhan protects its child by keeping it in its pouch. It has zero forgiveness for those who harm its child and will beat them down.",
+		de: "Sein Junges beschützt es in seinem Beutel. Wer dieses verwundet, den erwarten Kangamas Groll und eine rücksichtslose Tracht Prügel."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/48.ts
+++ b/data/Sun & Moon/Hidden Fates/48.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -32,10 +33,12 @@ const card: Card = {
 			name: {
 				en: "Curiosity",
 				fr: "Curiosité",
+				de: "Neugier"
 			},
 			effect: {
 				en: "Your opponent reveals their hand.",
 				fr: "Votre adversaire dévoile sa main.",
+				de: "Dein Gegner zeigt dir seine Handkarten."
 			},
 
 		},
@@ -47,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Spin Tackle",
 				fr: "Charge Tournoyante",
+				de: "Dreh-Tackle"
 			},
 			effect: {
 				en: "Flip a coin. If tails, this Pokémon does 10 damage to itself.",
 				fr: "Lancez une pièce. Si c’est pile, ce Pokémon s’inflige 10 dégâts.",
+				de: "Wirf 1 Münze. Bei Zahl fügt sich dieses Pokémon selbst 10 Schadenspunkte zu."
 			},
 			damage: 30,
 
@@ -68,6 +73,7 @@ const card: Card = {
 
 	description: {
 		en: "The question of why only Eevee has such unstable genes has still not been solved.",
+		de: "Evoli ist das einzige Pokémon mit einem höchst instabilen Erbmaterial. Die Ursache dafür ist nach wie vor unklar."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/49.ts
+++ b/data/Sun & Moon/Hidden Fates/49.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Eevee",
 		fr: "Évoli",
+		de: "Evoli"
 	},
 
 	illustrator: "Hitoshi Ariga",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				de: "Nagen"
 			},
 
 			damage: 20,
@@ -50,6 +52,7 @@ const card: Card = {
 
 	description: {
 		en: "Current studies show it can evolve into an incredible eight different species of Pokémon.",
+		de: "Nach derzeitigem Forschungsstand kann es sich zu acht verschiedenen Pokémon entwickeln."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/5.ts
+++ b/data/Sun & Moon/Hidden Fates/5.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Scyther",
 		fr: "Insécateur",
+		de: "Sichlor"
 	},
 
 	illustrator: "Hasuno",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Sharp Scythe",
 				fr: "Faucille Acérée",
+				de: "Scharfe Sense"
 			},
 
 			damage: 30,
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "Its two sharp scythes are more than just weapons. It uses them with dexterity to dress its prey before eating.",
+		de: "Seine scharfen Sicheln sind nicht nur Waffen. Vor einer Mahlzeit filetiert es damit auch geschickt seine Beute."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/50.ts
+++ b/data/Sun & Moon/Hidden Fates/50.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Snorlax",
 		fr: "Ronflex",
+		de: "Relaxo"
 	},
 
 	illustrator: "Akira Komayama",
@@ -35,6 +36,7 @@ const card: Card = {
 			name: {
 				en: "Incredible Snore",
 				fr: "Ronflement Incroyable",
+				de: "Lautes Schnarchen"
 			},
 
 			damage: 100,
@@ -53,6 +55,7 @@ const card: Card = {
 
 	description: {
 		en: "It doesn't do anything other than eat and sleep. When prompted to make a serious effort, though, it apparently displays awesome power.",
+		de: "Wenn es nicht gerade frisst, dann schläft es. Macht es aber einmal Ernst, ist Schluss mit lustig."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/51.ts
+++ b/data/Sun & Moon/Hidden Fates/51.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Bill’s Analysis",
 		fr: "Analyse de Léo",
+		de: "Bills Analyse"
 	},
 	illustrator: "Naoki Saito",
 	rarity: "Rare",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Regardez les 7 cartes du dessus de votre deck. Vous pouvez montrer jusqu’à 2 cartes Dresseur que vous y trouvez, puis les ajouter à votre main. Mélangez les autres cartes avec votre deck.",
-		en: "Look at the top 7 cards of your deck. You may reveal up to 2 Trainer cards you find there and put them into your hand. Shuffle the other cards back into your deck."
+		en: "Look at the top 7 cards of your deck. You may reveal up to 2 Trainer cards you find there and put them into your hand. Shuffle the other cards back into your deck.",
+		de: "Schau dir die obersten 7 Karten deines Decks an. Du kannst bis zu 2 Trainerkarten, die du dort findest, deinem Gegner zeigen und auf deine Hand nehmen. Mische die anderen Karten zurück in dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/52.ts
+++ b/data/Sun & Moon/Hidden Fates/52.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Blaine’s Last Stand",
 		fr: "Dernière Chance d’Auguste",
+		de: "Pyros letzter Widerstand"
 	},
 	illustrator: "Ken Sugimori",
 	rarity: "Rare",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Vous ne pouvez jouer cette carte que si c’est votre dernière carte en main.\n\nPiochez 2 cartes pour chacun de vos Pokémon Fire en jeu.",
-		en: "You can play this card only when it is the last card in your hand.\n\nDraw 2 cards for each Fire Pokémon you have in play."
+		en: "You can play this card only when it is the last card in your hand.\n\nDraw 2 cards for each Fire Pokémon you have in play.",
+		de: "Du kannst diese Karte nur spielen, wenn sie die letzte Karte auf deiner Hand ist. Ziehe 2 Karten für jedes {R}-Pokémon, das du im Spiel hast. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/53.ts
+++ b/data/Sun & Moon/Hidden Fates/53.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Brock’s Grit",
 		fr: "Vaillance de Pierre",
+		de: "Rockos Durchhaltevermögen"
 	},
 	illustrator: "Megumi Mizutani",
 	rarity: "Uncommon",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Choisissez une combinaison de 6 cartes Pokémon et cartes Énergie de base dans votre pile de défausse et mélangez-les avec votre deck.",
-		en: "Shuffle 6 in any combination of Pokémon and basic Energy cards from your discard pile into your deck."
+		en: "Shuffle 6 in any combination of Pokémon and basic Energy cards from your discard pile into your deck.",
+		de: "Mische eine beliebige Kombination aus 6 Pokémon und Basis-Energiekarten aus deinem Ablagestapel in dein Deck. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/54.ts
+++ b/data/Sun & Moon/Hidden Fates/54.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Brock’s Pewter City Gym",
 		fr: "Arène d’Argenta de Pierre",
+		de: "Rockos Marmoria-Arena"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Uncommon",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Les Onix-GX (les vôtres et ceux de votre adversaire) subissent 40 dégâts de moins des attaques de l’adversaire (après application de la Faiblesse et de la Résistance).",
-		en: "Onix-GX (both yours and your opponent’s) take 40 less damage from the opponent’s attacks (after applying Weakness and Resistance)."
+		en: "Onix-GX (both yours and your opponent’s) take 40 less damage from the opponent’s attacks (after applying Weakness and Resistance).",
+		de: "Onix-GX (deinen und denen deines Gegners) werden durch Attacken des Gegners 40 Schadenspunkte weniger zugefügt (nachdem Schwäche und Resistenz verrechnet wurden). Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 	trainerType: "Stadium",
 

--- a/data/Sun & Moon/Hidden Fates/55.ts
+++ b/data/Sun & Moon/Hidden Fates/55.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Brock’s Training",
 		fr: "Entraînement de Pierre",
+		de: "Rockos Training"
 	},
 	illustrator: "TOKIYA",
 	rarity: "Rare",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Attachez une carte Énergie de votre main à l’un de vos Racaillou, Gravalanch, Grolem, Onix-GX, Osselait, Rhinocorne, Rhinoféros ou Simularbre.",
-		en: "Attach an Energy card from your hand to 1 of your Geodude, Graveler, Golem, Onix-GX, Cubone, Rhyhorn, Rhydon, or Sudowoodo."
+		en: "Attach an Energy card from your hand to 1 of your Geodude, Graveler, Golem, Onix-GX, Cubone, Rhyhorn, Rhydon, or Sudowoodo.",
+		de: "Lege 1 Energiekarte aus deiner Hand an 1 deiner Kleinstein, Georok, Geowaz, Onix-GX, Tragosso, Rihorn, Rizeros oder Mogelbaum an. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/56.ts
+++ b/data/Sun & Moon/Hidden Fates/56.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Erika’s Hospitality",
 		fr: "Hospitalité d’Erika",
+		de: "Erikas Gastfreundschaft"
 	},
 	illustrator: "Sanosuke Sakuma",
 	rarity: "Rare",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Vous ne pouvez jouer cette carte que si vous avez 4 autres cartes ou moins dans votre main.\n\nPiochez une carte pour chacun des Pokémon en jeu de votre adversaire.",
-		en: "You can play this card only if you have 4 or fewer other cards in your hand.\n\nDraw a card for each of your opponent’s Pokémon in play."
+		en: "You can play this card only if you have 4 or fewer other cards in your hand.\n\nDraw a card for each of your opponent’s Pokémon in play.",
+		de: "Du kannst diese Karte nur spielen, wenn du 4 oder weniger andere Karten auf deiner Hand hast. Ziehe 1 Karte für jedes Pokémon deines Gegners im Spiel. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/57.ts
+++ b/data/Sun & Moon/Hidden Fates/57.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Giovanni’s Exile",
 		fr: "Exil de Giovanni",
+		de: "Giovannis Exil"
 	},
 	illustrator: "Megumi Mizutani",
 	rarity: "Uncommon",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Défaussez jusqu’à 2 de vos Pokémon de Banc qui n’ont pas de marqueurs de dégâts, ainsi que toutes les cartes qui leur sont attachées.",
-		en: "Discard up to 2 of your Benched Pokémon that have no damage counters on them and all cards attached to them."
+		en: "Discard up to 2 of your Benched Pokémon that have no damage counters on them and all cards attached to them.",
+		de: "Lege bis zu 2 Pokémon auf deiner Bank, auf denen keine Schadensmarken liegen, und alle an sie angelegten Karten auf deinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/58.ts
+++ b/data/Sun & Moon/Hidden Fates/58.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Jessie & James",
 		fr: "Jessie et James",
+		de: "Jessie & James"
 	},
 
 	illustrator: "Megumi Mizutani",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Chaque joueur défausse 2 cartes de sa main. Votre adversaire défausse en premier.",
-		en: "Each player discards 2 cards from their hand. Your opponent discards first."
+		en: "Each player discards 2 cards from their hand. Your opponent discards first.",
+		de: "Jeder Spieler legt 2 Karten aus seiner Hand auf seinen Ablagestapel. Dein Gegner legt als Erster ab. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Hidden Fates/59.ts
+++ b/data/Sun & Moon/Hidden Fates/59.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Koga’s Trap",
 		fr: "Piège de Koga",
+		de: "Kogas Falle"
 	},
 	illustrator: "Megumi Mizutani",
 	rarity: "Uncommon",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Le Pokémon Actif de votre adversaire est maintenant Confus et Empoisonné.",
-		en: "Your opponent’s Active Pokémon is now Confused and Poisoned."
+		en: "Your opponent’s Active Pokémon is now Confused and Poisoned.",
+		de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt und vergiftet. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/6.ts
+++ b/data/Sun & Moon/Hidden Fates/6.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pinsir GX",
 		fr: "Scarabrute-GX",
+		de: "Pinsir-GX"
 	},
 
 	illustrator: "5ban Graphics",
@@ -34,6 +35,7 @@ const card: Card = {
 			name: {
 				en: "Superpowered Horns",
 				fr: "Cornes Surpuissantes",
+				de: "Superstarke Hörner"
 			},
 
 			damage: 110,
@@ -48,10 +50,12 @@ const card: Card = {
 			name: {
 				en: "Guillotine GX",
 				fr: "Guillotine-GX",
+				de: "Guillotine-GX"
 			},
 			effect: {
 				en: "(You can’t use more than 1 GX attack in a game.)",
 				fr: "(Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "(Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 160,
 

--- a/data/Sun & Moon/Hidden Fates/60.ts
+++ b/data/Sun & Moon/Hidden Fates/60.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Lt. Surge’s Strategy",
 		fr: "Stratégie de Major Bob",
+		de: "Major Bobs Strategie"
 	},
 	illustrator: "Megumi Mizutani",
 	rarity: "Uncommon",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Vous ne pouvez jouer cette carte que s’il vous reste plus de cartes Récompense qu’à votre adversaire.\n\nPendant ce tour, vous pouvez jouer 3 cartes Supporter (y compris cette carte).",
-		en: "You can play this card only if you have more Prize cards remaining than your opponent.\n\nDuring this turn, you can play 3 Supporter cards (including this card)."
+		en: "You can play this card only if you have more Prize cards remaining than your opponent.\n\nDuring this turn, you can play 3 Supporter cards (including this card).",
+		de: "Du kannst diese Karte nur spielen, wenn du mehr verbleibende Preiskarten hast als dein Gegner. Du kannst während dieses Zuges 3 Unterstützerkarten (einschließlich dieser Karte) spielen. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/61.ts
+++ b/data/Sun & Moon/Hidden Fates/61.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Misty’s Cerulean City Gym",
 		fr: "Arène d’Azuria d’Ondine",
+		de: "Mistys Azuria-Arena"
 	},
 	illustrator: "5ban Graphics",
 	rarity: "Uncommon",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Les attaques des Staross-GX (les vôtres et ceux de votre adversaire) infligent 40 dégâts supplémentaires au Pokémon Actif de l’adversaire (avant application de la Faiblesse et de la Résistance).",
-		en: "The attacks of Starmie-GX (both yours and your opponent’s) do 40 more damage to the opponent’s Active Pokémon (before applying Weakness and Resistance)."
+		en: "The attacks of Starmie-GX (both yours and your opponent’s) do 40 more damage to the opponent’s Active Pokémon (before applying Weakness and Resistance).",
+		de: "Die Attacken von Starmie-GX (deinen und denen deines Gegners) fügen dem Aktiven Pokémon des Gegners 40 Schadenspunkte mehr zu (bevor Schwäche und Resistenz verrechnet werden). Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadionkarte ins Spiel kommt. Wenn eine andere Karte mit dem gleichen Namen im Spiel ist, kannst du diese Karte nicht spielen."
 	},
 	trainerType: "Stadium",
 

--- a/data/Sun & Moon/Hidden Fates/62.ts
+++ b/data/Sun & Moon/Hidden Fates/62.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Misty’s Determination",
 		fr: "Détermination d’Ondine",
+		de: "Mistys Entschlossenheit"
 	},
 	illustrator: "Megumi Mizutani",
 	rarity: "Uncommon",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Défaussez une carte de votre main. Dans ce cas, regardez les 8 cartes du dessus de votre deck, puis ajoutez l’une d’entre elles à votre main. Mélangez les autres cartes avec votre deck.",
-		en: "Discard a card from your hand. If you do, look at the top 8 cards of your deck and put 1 of them into your hand. Shuffle the other cards back into your deck."
+		en: "Discard a card from your hand. If you do, look at the top 8 cards of your deck and put 1 of them into your hand. Shuffle the other cards back into your deck.",
+		de: "Lege 1 Karte von deiner Hand auf deinen Ablagestapel. Wenn du das machst, schau dir die obersten 8 Karten deines Decks an und nimm 1 davon auf deine Hand. Mische die anderen Karten anschließend in dein Deck. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/63.ts
+++ b/data/Sun & Moon/Hidden Fates/63.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Misty’s Water Command",
 		fr: "Maîtrise Aquatique d’Ondine",
+		de: "Mistys Wasserkontrolle"
 	},
 	illustrator: "TOKIYA",
 	rarity: "Rare",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Déplacez autant d’Énergies Water que vous le voulez de vos Pokémon vers vos Psykokwak, Hypotrempe, Stari, Staross-GX, Magicarpe, Léviator ou Lokhlass, de la manière que vous voulez.",
-		en: "Move any number of Water Energy from your Pokémon to your Psyduck, Horsea, Staryu, Starmie-GX, Magikarp, Gyarados, or Lapras in any way you like."
+		en: "Move any number of Water Energy from your Pokémon to your Psyduck, Horsea, Staryu, Starmie-GX, Magikarp, Gyarados, or Lapras in any way you like.",
+		de: "Verschiebe beliebig viele {W}-Energien von deinen Pokémon beliebig auf deine Enton, Seeper, Sterndu, Starmie-GX, Karpador, Garados oder Lapras. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/64.ts
+++ b/data/Sun & Moon/Hidden Fates/64.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Pokémon Center Lady",
 		fr: "Dame du Centre Pokémon",
+		de: "Pokémon-Center-Dame"
 	},
 
 	illustrator: "TOKIYA",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Soignez 60 dégâts et retirez tous les États Spéciaux de l’un de vos Pokémon.",
-		en: "Heal 60 damage and remove all Special Conditions from 1 of your Pokémon."
+		en: "Heal 60 damage and remove all Special Conditions from 1 of your Pokémon.",
+		de: "Heile 60 Schadenspunkte bei 1 deiner Pokémon. Alle Speziellen Zustände auf diesem Pokémon verlieren ihre Wirkung. Du kannst während deines Zuges (vor deinem Angriff) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Hidden Fates/65.ts
+++ b/data/Sun & Moon/Hidden Fates/65.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Sabrina’s Suggestion",
 		fr: "Suggestion de Morgane",
+		de: "Sabrinas Vorschlag"
 	},
 	illustrator: "Hitoshi Ariga",
 	rarity: "Uncommon",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Votre adversaire dévoile sa main. Vous pouvez choisir une carte Supporter que vous y trouvez et utiliser son effet en tant qu’effet de cette carte.",
-		en: "Your opponent reveals their hand. You may choose a Supporter card you find there and use the effect of that card as the effect of this card."
+		en: "Your opponent reveals their hand. You may choose a Supporter card you find there and use the effect of that card as the effect of this card.",
+		de: "Dein Gegner zeigt dir seine Handkarten. Du kannst 1 Unterstützerkarte, die du dort findest, wählen und den Effekt jener Karte als Effekt dieser Karte einsetzen. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/66.ts
+++ b/data/Sun & Moon/Hidden Fates/66.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Moltres & Zapdos & Articuno GX",
 		fr: "Sulfura, Électhor et Artikodin-GX",
+		de: "Lavados & Zapdos & Arktos-GX"
 	},
 
 	illustrator: "5ban Graphics",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Trinity Burn",
 				fr: "Triple Brûlure",
+				de: "Dreiheitsbrand"
 			},
 
 			damage: 210,
@@ -44,10 +46,12 @@ const card: Card = {
 			name: {
 				en: "Sky Legends GX",
 				fr: "Légendes Célestes GX",
+				de: "Legenden der Lüfte GX"
 			},
 			effect: {
 				en: "Shuffle this Pokémon and all cards attached to it into your deck. If this Pokémon has at least 1 extra Fire, Water, and Lightning Energy attached to it (in addition to this attack’s cost), this attack does 110 damage to 3 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",
-				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie Fire, Water et Lightning supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)"
+				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie Fire, Water et Lightning supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Mische dieses Pokémon und alle an es angelegten Karten in dein Deck. Wenn an dieses Pokémon mindestens 1 extra {R}-, {W}- und {L}-Energie angelegt ist (zusätzlich zu den Kosten dieser Attacke), fügt diese Attacke 3 Pokémon deines Gegners 110 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		},

--- a/data/Sun & Moon/Hidden Fates/67.ts
+++ b/data/Sun & Moon/Hidden Fates/67.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Giovanni’s Exile",
 		fr: "Exil de Giovanni",
+		de: "Giovannis Exil"
 	},
 	illustrator: "TOKIYA",
 	rarity: "Ultra Rare",
@@ -24,7 +25,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Défaussez jusqu’à 2 de vos Pokémon de Banc qui n’ont pas de marqueurs de dégâts, ainsi que toutes les cartes qui leur sont attachées.",
-		en: "Discard up to 2 of your Benched Pokémon that have no damage counters on them and all cards attached to them."
+		en: "Discard up to 2 of your Benched Pokémon that have no damage counters on them and all cards attached to them.",
+		de: "Lege bis zu 2 Pokémon auf deiner Bank, auf denen keine Schadensmarken liegen, und alle an sie angelegten Karten auf deinen Ablagestapel. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 	trainerType: "Supporter",
 

--- a/data/Sun & Moon/Hidden Fates/68.ts
+++ b/data/Sun & Moon/Hidden Fates/68.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Jessie & James",
 		fr: "Jessie et James",
+		de: "Jessie & James"
 	},
 
 	illustrator: "Megumi Mizutani",
@@ -14,7 +15,8 @@ const card: Card = {
 
 	effect: {
 		fr: "Chaque joueur défausse 2 cartes de sa main. Votre adversaire défausse en premier.",
-		en: "Each player discards 2 cards from their hand. Your opponent discards first."
+		en: "Each player discards 2 cards from their hand. Your opponent discards first.",
+		de: "Jeder Spieler legt 2 Karten aus seiner Hand auf seinen Ablagestapel. Dein Gegner legt als Erster ab. Du kannst während deines Zuges (bevor du angreifst) nur 1 Unterstützerkarte spielen."
 	},
 
 	trainerType: "Supporter",

--- a/data/Sun & Moon/Hidden Fates/69.ts
+++ b/data/Sun & Moon/Hidden Fates/69.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Moltres & Zapdos & Articuno GX",
 		fr: "Sulfura, Électhor et Artikodin-GX",
+		de: "Lavados & Zapdos & Arktos-GX"
 	},
 
 	illustrator: "5ban Graphics",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Trinity Burn",
 				fr: "Triple Brûlure",
+				de: "Dreiheitsbrand"
 			},
 
 			damage: 210,
@@ -44,10 +46,12 @@ const card: Card = {
 			name: {
 				en: "Sky Legends GX",
 				fr: "Légendes Célestes GX",
+				de: "Legenden der Lüfte GX"
 			},
 			effect: {
 				en: "Shuffle this Pokémon and all cards attached to it into your deck. If this Pokémon has at least 1 extra Fire, Water, and Lightning Energy attached to it (in addition to this attack’s cost), this attack does 110 damage to 3 of your opponent’s Pokémon. (Don’t apply Weakness and Resistance for Benched Pokémon.) (You can’t use more than 1 GX attack in a game.)",
-				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie Fire, Water et Lightning supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)"
+				fr: "Mélangez ce Pokémon et toutes les cartes qui lui sont attachées avec votre deck. Si au moins une Énergie Fire, Water et Lightning supplémentaire sont attachées à ce Pokémon (en plus du coût de cette attaque), cette attaque inflige 110 dégâts à 3 des Pokémon de votre adversaire. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.) (Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "Mische dieses Pokémon und alle an es angelegten Karten in dein Deck. Wenn an dieses Pokémon mindestens 1 extra {R}-, {W}- und {L}-Energie angelegt ist (zusätzlich zu den Kosten dieser Attacke), fügt diese Attacke 3 Pokémon deines Gegners 110 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) (Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 
 		}

--- a/data/Sun & Moon/Hidden Fates/7.ts
+++ b/data/Sun & Moon/Hidden Fates/7.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charmander",
 		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	illustrator: "Megumi Mizutani",
@@ -32,6 +33,7 @@ const card: Card = {
 			name: {
 				en: "Gnaw",
 				fr: "Ronge",
+				de: "Nagen"
 			},
 
 			damage: 10,
@@ -45,6 +47,7 @@ const card: Card = {
 			name: {
 				en: "Flare",
 				fr: "Flamboiement",
+				de: "Flackern"
 			},
 
 			damage: 20,
@@ -63,6 +66,7 @@ const card: Card = {
 
 	description: {
 		en: "The flame on its tail indicates Charmander's life force. If it is healthy, the flame burns brightly.",
+		de: "Die Flamme auf seiner Schweifspitze zeigt die Lebensenergie an. Ist es gesund, leuchtet sie hell."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/8.ts
+++ b/data/Sun & Moon/Hidden Fates/8.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charmeleon",
 		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	illustrator: "Shin Nagasawa",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmander",
 		fr: "Salamèche",
+		de: "Glumanda"
 	},
 
 	stage: "Stage1",
@@ -38,6 +40,7 @@ const card: Card = {
 			name: {
 				en: "Slash",
 				fr: "Tranche",
+				de: "Schlitzer"
 			},
 
 			damage: 30,
@@ -52,6 +55,7 @@ const card: Card = {
 			name: {
 				en: "Flamethrower",
 				fr: "Lance-Flammes",
+				de: "Flammenwurf"
 			},
 
 			damage: 80,
@@ -70,6 +74,7 @@ const card: Card = {
 
 	description: {
 		en: "It lashes about with its tail to knock down its foe. It then tears up the fallen opponent with sharp claws.",
+		de: "Es schlägt im Kampf mit seinem Schwanz nach seinen Gegnern. Anschließend zerfetzt es die Gegner mit seinen scharfen Klauen."
 	},
 
 	thirdParty: {

--- a/data/Sun & Moon/Hidden Fates/9.ts
+++ b/data/Sun & Moon/Hidden Fates/9.ts
@@ -5,6 +5,7 @@ const card: Card = {
 	name: {
 		en: "Charizard GX",
 		fr: "Dracaufeu-GX",
+		de: "Glurak-GX"
 	},
 
 	illustrator: "aky CG Works",
@@ -25,6 +26,7 @@ const card: Card = {
 	evolveFrom: {
 		en: "Charmeleon",
 		fr: "Reptincel",
+		de: "Glutexo"
 	},
 
 	suffix: "GX",
@@ -40,6 +42,7 @@ const card: Card = {
 			name: {
 				en: "Flamethrower",
 				fr: "Lance-Flammes",
+				de: "Flammenwurf"
 			},
 
 			damage: 140,
@@ -55,10 +58,12 @@ const card: Card = {
 			name: {
 				en: "Flare Blitz GX",
 				fr: "Boutefeu-GX",
+				de: "Flammenblitz-GX"
 			},
 			effect: {
 				en: "(You can’t use more than 1 GX attack in a game.)",
 				fr: "(Vous ne pouvez utiliser qu’une attaque GX par partie.)",
+				de: "(Du kannst pro Spiel nur 1 GX-Attacke einsetzen.)"
 			},
 			damage: 300,
 


### PR DESCRIPTION
## Add missing German translations for sm115

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
