### PR TITLE
Add missing German translations for pop2

### DIFF
--- a/data/POP/POP Series 2/11.ts
+++ b/data/POP/POP Series 2/11.ts
@@ -4,7 +4,8 @@ import Set from '../POP Series 2'
 const card: Card = {
 	name: {
 		en: "TV Reporter",
-		fr: "Journaliste télé"
+		fr: "Journaliste télé",
+		de: "TV Reporter"
 	},
 
 	illustrator: "Ken Sugimori",


### PR DESCRIPTION
## Add missing German translations for pop2

### How and why?

I was playing around with the databse, when I noticed I can't find plenty of my
german cards due to lacking docs or because there was english text in the german
card docs.

So I build a tool locally (with AI) to check for german gaps and fill them up
with actual authentic card data. To make sure this data is accurate I'm using
PokéWiki (large german card database) + OCR on card screenshots + the
`NSSpellChecker` with the German dictionary to make sure no mistakes from the
wiki or the scan get into the files.

I will create plenty of PRs because the german documentation right now is far
from complete. If you have any question let me know. Where changes come from
etc. is fully logged on my device and I can tell you where which text comes
from.
