### PR TITLE
fix: add reverse variant for sm10-23

### DIFF
--- a/data/Sun & Moon/Unbroken Bonds/23.ts
+++ b/data/Sun & Moon/Unbroken Bonds/23.ts
@@ -85,10 +85,22 @@ const card: Card = {
 		de: "Früher nutzte man die heißen Ausscheidungen von Flampion, um sich den Körper zu wärmen."
 	},
 
-	thirdParty: {
-		cardmarket: 372315,
-		tcgplayer: 189066
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 372315,
+				tcgplayer: 189066
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 372315,
+				tcgplayer: 189066
+			}
+		}
+	]
 }
 
 export default card


### PR DESCRIPTION
## Changes

Added `normal` and `reverse` variants for Darumaka (`sm10-23`) using the detailed variant schema. TCGPlayer product `189066` includes both Normal and Reverse Holofoil printings.