### PR TITLE
fix(data): Correct Japanese card names in neo1

### DIFF
--- a/data-asia/neo/neo1/001.ts
+++ b/data-asia/neo/neo1/001.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "奇妙な",
+		ja: "ナゾノクサ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/004.ts
+++ b/data-asia/neo/neo1/004.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "スパラク",
+		ja: "イトマル",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/005.ts
+++ b/data-asia/neo/neo1/005.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ホッピップ",
+		ja: "ハネッコ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/006.ts
+++ b/data-asia/neo/neo1/006.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "サンカーン",
+		ja: "ヒマナッツ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/007.ts
+++ b/data-asia/neo/neo1/007.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "シャックル",
+		ja: "ツボツボ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/008.ts
+++ b/data-asia/neo/neo1/008.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "暗闇",
+		ja: "クサイハナ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/009.ts
+++ b/data-asia/neo/neo1/009.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Bayleef",
+		ja: "ベイリーフ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/012.ts
+++ b/data-asia/neo/neo1/012.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "スキプルーム",
+		ja: "ポポッコ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/013.ts
+++ b/data-asia/neo/neo1/013.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "サンフロラ",
+		ja: "キマワリ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/014.ts
+++ b/data-asia/neo/neo1/014.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ミーガニウム",
+		ja: "メガニウム",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/015.ts
+++ b/data-asia/neo/neo1/015.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Bellossom",
+		ja: "キレイハナ",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/016.ts
+++ b/data-asia/neo/neo1/016.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ジャンプラフ",
+		ja: "ワタッコ",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/018.ts
+++ b/data-asia/neo/neo1/018.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "シンダキル",
+		ja: "ヒノアラシ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/019.ts
+++ b/data-asia/neo/neo1/019.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "マグマー",
+		ja: "ブーバー",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/020.ts
+++ b/data-asia/neo/neo1/020.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "キラバ",
+		ja: "マグマラシ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/021.ts
+++ b/data-asia/neo/neo1/021.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "染色",
+		ja: "バクフーン",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/022.ts
+++ b/data-asia/neo/neo1/022.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "マグビー",
+		ja: "ブビィ",
 	},
 
 	rarity: "Rare",

--- a/data-asia/neo/neo1/023.ts
+++ b/data-asia/neo/neo1/023.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "馬",
+		ja: "タッツー",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/024.ts
+++ b/data-asia/neo/neo1/024.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "totodile",
+		ja: "ワニノコ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/026.ts
+++ b/data-asia/neo/neo1/026.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ウーパー",
+		ja: "ウパー",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/027.ts
+++ b/data-asia/neo/neo1/027.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "swinub",
+		ja: "ウリムー",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/028.ts
+++ b/data-asia/neo/neo1/028.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "マンティン",
+		ja: "マンタイン",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/030.ts
+++ b/data-asia/neo/neo1/030.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "クロコノー",
+		ja: "アリゲイツ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/031.ts
+++ b/data-asia/neo/neo1/031.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "quagsire",
+		ja: "ヌオー",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/032.ts
+++ b/data-asia/neo/neo1/032.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ピロスワイン",
+		ja: "イノムー",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/033.ts
+++ b/data-asia/neo/neo1/033.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "feraligatr",
+		ja: "オーダイル",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/034.ts
+++ b/data-asia/neo/neo1/034.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "アズマリル",
+		ja: "マリルリ",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/037.ts
+++ b/data-asia/neo/neo1/037.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "チンチョウ",
+		ja: "チョンチー",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/038.ts
+++ b/data-asia/neo/neo1/038.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Mareep",
+		ja: "メリープ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/039.ts
+++ b/data-asia/neo/neo1/039.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Electabuzz",
+		ja: "エレブー",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/040.ts
+++ b/data-asia/neo/neo1/040.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ラントン",
+		ja: "ランターン",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/041.ts
+++ b/data-asia/neo/neo1/041.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "フラフィー",
+		ja: "モココ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/042.ts
+++ b/data-asia/neo/neo1/042.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ピチュ",
+		ja: "ピチュー",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/043.ts
+++ b/data-asia/neo/neo1/043.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "アンファロス",
+		ja: "デンリュウ",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/044.ts
+++ b/data-asia/neo/neo1/044.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Elekid",
+		ja: "エレキッド",
 	},
 
 	rarity: "Rare",

--- a/data-asia/neo/neo1/045.ts
+++ b/data-asia/neo/neo1/045.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "slowpoke",
+		ja: "ヤドン",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/046.ts
+++ b/data-asia/neo/neo1/046.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "natu",
+		ja: "ネイティ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/047.ts
+++ b/data-asia/neo/neo1/047.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Girafarig",
+		ja: "キリンリキ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/048.ts
+++ b/data-asia/neo/neo1/048.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "xatu",
+		ja: "ネイティオ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/049.ts
+++ b/data-asia/neo/neo1/049.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "スローキング",
+		ja: "ヤドキング",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/050.ts
+++ b/data-asia/neo/neo1/050.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "onix",
+		ja: "イワーク",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/051.ts
+++ b/data-asia/neo/neo1/051.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "sudowoodo",
+		ja: "ウソッキー",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/052.ts
+++ b/data-asia/neo/neo1/052.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "グリガー",
+		ja: "グライガー",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/053.ts
+++ b/data-asia/neo/neo1/053.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ファンピー",
+		ja: "ゴマゾウ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/055.ts
+++ b/data-asia/neo/neo1/055.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "マークロウ",
+		ja: "ヤミカラス",
 	},
 
 	rarity: "Rare",

--- a/data-asia/neo/neo1/056.ts
+++ b/data-asia/neo/neo1/056.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "スニーエル",
+		ja: "ニューラ",
 	},
 
 	rarity: "Rare",

--- a/data-asia/neo/neo1/057.ts
+++ b/data-asia/neo/neo1/057.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Steelix",
+		ja: "ハガネール",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/058.ts
+++ b/data-asia/neo/neo1/058.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "スカルモリー",
+		ja: "エアームド",
 	},
 
 	rarity: "Holo Rare",

--- a/data-asia/neo/neo1/059.ts
+++ b/data-asia/neo/neo1/059.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "セントレット",
+		ja: "オタチ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/060.ts
+++ b/data-asia/neo/neo1/060.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "hoothoot",
+		ja: "ホーホー",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/061.ts
+++ b/data-asia/neo/neo1/061.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Snubbull",
+		ja: "ブルー",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/062.ts
+++ b/data-asia/neo/neo1/062.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "スタントラー",
+		ja: "オドシシ",
 	},
 
 	rarity: "Common",

--- a/data-asia/neo/neo1/063.ts
+++ b/data-asia/neo/neo1/063.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "クリーフ",
+		ja: "ピッピ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/064.ts
+++ b/data-asia/neo/neo1/064.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "Furret",
+		ja: "オオタチ",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/065.ts
+++ b/data-asia/neo/neo1/065.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "ノクトウル",
+		ja: "ヨルノズク",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/066.ts
+++ b/data-asia/neo/neo1/066.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "togepi",
+		ja: "トゲピー",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/067.ts
+++ b/data-asia/neo/neo1/067.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "aipom",
+		ja: "エイパム",
 	},
 
 	rarity: "Uncommon",

--- a/data-asia/neo/neo1/070.ts
+++ b/data-asia/neo/neo1/070.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "クレファ",
+		ja: "ピィ",
 	},
 
 	rarity: "Rare",

--- a/data-asia/neo/neo1/071.ts
+++ b/data-asia/neo/neo1/071.ts
@@ -4,7 +4,7 @@ import Set from "../neo1"
 const card: Card = {
 	set: Set,
 	name: {
-		ja: "togetic",
+		ja: "トゲチック",
 	},
 
 	rarity: "Holo Rare",


### PR DESCRIPTION
partially addresses #1726

## Changes

Corrects **59** Japanese Pokémon card names in **`data-asia/neo/neo1`** (Neo Genesis, Japanese).

> Note on the path: `neo1`–`neo4` exist twice in this repository — `data/Neo/…` for the English sets and `data-asia/neo/…` for the Japanese ones. **This PR touches only `data-asia/neo/neo1`.**

Each replacement is the Japanese name this database already uses for that Pokémon, so nothing new is introduced — only propagated. The values come from composing two files already in the repo:

- `scripts/utils-data/jp_card_translations.ts` — 815 entries, ja → en, bijective (815 distinct English values, no collisions), so it inverts cleanly
- `scripts/utils-data/pokedex.ts` — 801 entries, dexId → en

Inverting the first and composing with the second gives dexId → printed Japanese name from this repository's own data. No external source is involved.

## Details

### Why these names are wrong

The Japanese `name` fields in this set are machine translations of the **English** card name rather than the printed Japanese name. That is visible in the set's own history: the first commit of the PR that added it (#798, commit `6ae36b58`) wrote `neo1/001.ts` as

```ts
name: {
   en: "Oddish",
   ja: "奇妙な",
   fr: "Bizarre",
   de: "Seltsam",
   es: "Extraño",
   it: "Strano",
   pt: "Ímpar",
},
```

— seven languages, every one of them the common adjective *"odd"*. Review then asked for the non-Japanese languages to be removed, which left the machine-translated `ja` value standing alone, looking like source data.

The card structure itself is genuine: numbering, dexIds, rarity and category are all real. Only the name strings were filled in by translation.

The 59 corrections fall into three shapes:

- **22 are Latin text sitting in a `name.ja` field** — `Bayleef`, `totodile`, `onix`, `sudowoodo`, `Girafarig`. These need no Japanese to check.
- **33 are katakana spellings of the English name**, which is not how the Japanese card is printed — `スパラク` → `イトマル` (Spinarak), `スカルモリー` → `エアームド` (Skarmory), `アンファロス` → `デンリュウ` (Ampharos).
- **4 are translations of the English word** — `奇妙な` "odd" for Oddish, `暗闇` "gloom" for Gloom, `馬` "horse" for Horsea, `染色` "dyeing" for Typhlosion.

**13 dexId cards in this set are left untouched** because they are already correct — チコリータ, レディバ, レディアン, アリアドス, ヘラクロス, マリル, シードラ, キングドラ, ピカチュウ, ドンファン, グランブル, ミルタンク, ルギア. Every one is a species whose Japanese name *is* its English name, so translating it happened to round-trip.

Two rows are worth pointing at because they look like mistakes and are not:

- **`Snubbull` → `ブルー`.** Snubbull's Japanese name really is ブルー (which is also the loanword "blue").
- Four rows are one-character vowel-length fixes where the species was already right: `ピチュ` → `ピチュー`, `ウーパー` → `ウパー`, `ミーガニウム` → `メガニウム`, `ラントン` → `ランターン`.

### The full change, row by row

Current value, what it literally says, and the proposed printed name. Every row was read by hand.

| # | dexId | current `name.ja` | what it says | proposed | en |
|---|---|---|---|---|---|
| 001 | 43 | `奇妙な` | “odd”, the adjective — a translation of the English name *Oddish* | **`ナゾノクサ`** | Oddish |
| 004 | 167 | `スパラク` | katakana for “Spinarak”, the English name | **`イトマル`** | Spinarak |
| 005 | 187 | `ホッピップ` | katakana for “Hoppip”, the English name | **`ハネッコ`** | Hoppip |
| 006 | 191 | `サンカーン` | katakana for “Sunkern”, the English name | **`ヒマナッツ`** | Sunkern |
| 007 | 213 | `シャックル` | katakana for “Shuckle”, the English name | **`ツボツボ`** | Shuckle |
| 008 | 44 | `暗闇` | “darkness, gloom” — a translation of the English name *Gloom* | **`クサイハナ`** | Gloom |
| 009 | 153 | `Bayleef` | the English name *Bayleef*, in Latin letters | **`ベイリーフ`** | Bayleef |
| 012 | 188 | `スキプルーム` | katakana for “Skiploom”, the English name | **`ポポッコ`** | Skiploom |
| 013 | 192 | `サンフロラ` | katakana for “Sunflora”, the English name | **`キマワリ`** | Sunflora |
| 014 | 154 | `ミーガニウム` | katakana for “Meganium”; the printed name is メガニウム, without the long *ī* | **`メガニウム`** | Meganium |
| 015 | 182 | `Bellossom` | the English name *Bellossom*, in Latin letters | **`キレイハナ`** | Bellossom |
| 016 | 189 | `ジャンプラフ` | katakana for “Jumpluff”, the English name | **`ワタッコ`** | Jumpluff |
| 018 | 155 | `シンダキル` | katakana for “Cyndaquil”, the English name | **`ヒノアラシ`** | Cyndaquil |
| 019 | 126 | `マグマー` | katakana for “Magmar”, the English name | **`ブーバー`** | Magmar |
| 020 | 156 | `キラバ` | katakana for “Quilava”, the English name | **`マグマラシ`** | Quilava |
| 021 | 157 | `染色` | “dyeing, staining” — a translation artefact for *Typhlosion* | **`バクフーン`** | Typhlosion |
| 022 | 240 | `マグビー` | katakana for “Magby”, the English name | **`ブビィ`** | Magby |
| 023 | 116 | `馬` | “horse” — a translation of the English name *Horsea* | **`タッツー`** | Horsea |
| 024 | 158 | `totodile` | the English name *Totodile*, in Latin letters | **`ワニノコ`** | Totodile |
| 026 | 194 | `ウーパー` | katakana for “Wooper”; the printed name is ウパー, without the long *ū* | **`ウパー`** | Wooper |
| 027 | 220 | `swinub` | the English name *Swinub*, in Latin letters | **`ウリムー`** | Swinub |
| 028 | 226 | `マンティン` | katakana for “Mantine”, the English name | **`マンタイン`** | Mantine |
| 030 | 159 | `クロコノー` | katakana for “Croconaw”, the English name | **`アリゲイツ`** | Croconaw |
| 031 | 195 | `quagsire` | the English name *Quagsire*, in Latin letters | **`ヌオー`** | Quagsire |
| 032 | 221 | `ピロスワイン` | katakana for “Piloswine”, the English name | **`イノムー`** | Piloswine |
| 033 | 160 | `feraligatr` | the English name *Feraligatr*, in Latin letters | **`オーダイル`** | Feraligatr |
| 034 | 184 | `アズマリル` | katakana for “Azumarill”, the English name | **`マリルリ`** | Azumarill |
| 037 | 170 | `チンチョウ` | katakana for “Chinchou”, the English name | **`チョンチー`** | Chinchou |
| 038 | 179 | `Mareep` | the English name *Mareep*, in Latin letters | **`メリープ`** | Mareep |
| 039 | 125 | `Electabuzz` | the English name *Electabuzz*, in Latin letters | **`エレブー`** | Electabuzz |
| 040 | 171 | `ラントン` | katakana for “Lanturn”; the printed name is ランターン | **`ランターン`** | Lanturn |
| 041 | 180 | `フラフィー` | katakana for “Flaaffy”, the English name | **`モココ`** | Flaaffy |
| 042 | 172 | `ピチュ` | katakana for “Pichu”; the printed name is ピチュー, with a long final vowel | **`ピチュー`** | Pichu |
| 043 | 181 | `アンファロス` | katakana for “Ampharos”, the English name | **`デンリュウ`** | Ampharos |
| 044 | 239 | `Elekid` | the English name *Elekid*, in Latin letters | **`エレキッド`** | Elekid |
| 045 | 79 | `slowpoke` | the English name *Slowpoke*, in Latin letters | **`ヤドン`** | Slowpoke |
| 046 | 177 | `natu` | the English name *Natu*, in Latin letters | **`ネイティ`** | Natu |
| 047 | 203 | `Girafarig` | the English name *Girafarig*, in Latin letters | **`キリンリキ`** | Girafarig |
| 048 | 178 | `xatu` | the English name *Xatu*, in Latin letters | **`ネイティオ`** | Xatu |
| 049 | 199 | `スローキング` | katakana for “Slowking”, the English name | **`ヤドキング`** | Slowking |
| 050 | 95 | `onix` | the English name *Onix*, in Latin letters | **`イワーク`** | Onix |
| 051 | 185 | `sudowoodo` | the English name *Sudowoodo*, in Latin letters | **`ウソッキー`** | Sudowoodo |
| 052 | 207 | `グリガー` | katakana for “Gligar”, the English name | **`グライガー`** | Gligar |
| 053 | 231 | `ファンピー` | katakana for “Phanpy”, the English name | **`ゴマゾウ`** | Phanpy |
| 055 | 198 | `マークロウ` | katakana for “Murkrow”, the English name | **`ヤミカラス`** | Murkrow |
| 056 | 215 | `スニーエル` | katakana for “Sneasel”, the English name | **`ニューラ`** | Sneasel |
| 057 | 208 | `Steelix` | the English name *Steelix*, in Latin letters | **`ハガネール`** | Steelix |
| 058 | 227 | `スカルモリー` | katakana for “Skarmory”, the English name | **`エアームド`** | Skarmory |
| 059 | 161 | `セントレット` | katakana for “Sentret”, the English name | **`オタチ`** | Sentret |
| 060 | 163 | `hoothoot` | the English name *Hoothoot*, in Latin letters | **`ホーホー`** | Hoothoot |
| 061 | 209 | `Snubbull` | the English name *Snubbull*, in Latin letters — and its Japanese name really is ブルー, which is also the loanword “blue” | **`ブルー`** | Snubbull |
| 062 | 234 | `スタントラー` | katakana for “Stantler”, the English name | **`オドシシ`** | Stantler |
| 063 | 35 | `クリーフ` | katakana for “Clef-”, from the English name *Clefairy* | **`ピッピ`** | Clefairy |
| 064 | 162 | `Furret` | the English name *Furret*, in Latin letters | **`オオタチ`** | Furret |
| 065 | 164 | `ノクトウル` | katakana for “Noctowl”, the English name | **`ヨルノズク`** | Noctowl |
| 066 | 175 | `togepi` | the English name *Togepi*, in Latin letters | **`トゲピー`** | Togepi |
| 067 | 190 | `aipom` | the English name *Aipom*, in Latin letters | **`エイパム`** | Aipom |
| 070 | 173 | `クレファ` | katakana for “Cleffa”, the English name | **`ピィ`** | Cleffa |
| 071 | 176 | `togetic` | the English name *Togetic*, in Latin letters | **`トゲチック`** | Togetic |
### Scope, and what this PR does not fix

Deliberately names-only, and only the Pokémon cards:

- **The 24 Trainer/Energy cards in this set are not touched.** They carry no dexId, so the method above cannot reach them at all. Several of them are clearly affected by the same translation pass — `077` is `Moomooミルク`, `086` is `ecogym`, `082` is `新しいpokedex`, `096` is `エネルギーをリサイクルします` — but others in that group read fine (`エルム教授`, `フォーカスバンド`, `タイムカプセル`), so this is not a case of applying one rule. Repairing them needs a printed source rather than an inference, so I have left all 24 alone rather than guess at some of them.
- **Attack names and effect text are not touched.** They are machine-translated too — `neo1/001.ts` still reads `コインをひっくり返します。…オッディッシュに行われます` where the printed card does not. The precedent for a names-only pass is this repository's own: the PMCG repair in July 2026 (#1717 and siblings) was names-only, and `PMCG1/001.ts` still reads a correct `フシギダネ` above a transliterated `リーチシード`.

The full measurement for the whole affected range — the five series, the three gaps, and what can and cannot be derived from the repo's own data — is [in a comment on #1726](https://github.com/tcgdex/cards-database/issues/1726#issuecomment-5378184882).

### Checks

- `bun run validate` passes — exits 0 with no output.
- **59 files changed, 59 insertions, 59 deletions** — exactly one line per file. `data-asia` is not consistently formatted, so the edit replaces only the one string literal and re-serialises nothing; tab counts are identical before and after.

```diff
 	name: {
-		ja: "奇妙な",
+		ja: "ナゾノクサ",
 	},
```

If you would rather have this as a single batched PR, differently split, or not at all, say so and I will follow that instead — happy to adjust to whatever is easiest to review.

