### PR TITLE
docs: fix typo informations -> information

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 # TCGdex - Pokémon TCG Cards Database
 
-A Multilanguage Pokémon TCG Database with Cards Pictures and most of the informations contained on the cards.
+A Multilanguage Pokémon TCG Database with Cards Pictures and most of the information contained on the cards.
 
 ## Getting Started
 


### PR DESCRIPTION
One-word typo fix in `README.md:26`. "Information" is uncountable in English, so it has no plural form.
