### PR TITLE
fix: Add normal variant for swsh4/121 (Found in V Battle Deck)

### DIFF
--- a/data/Sword & Shield/Vivid Voltage/121.ts
+++ b/data/Sword & Shield/Vivid Voltage/121.ts
@@ -112,6 +112,13 @@ const card: Card = {
 				tcgplayer: 226575
 			}
 		},
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 512315,
+				tcgplayer: 270101
+			}
+		},
 	],
 }
 


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->
There's no issue number for this fix.

## Changes

<!-- Quickly explain your changes -->
The normal card variant for SWSH04: Vivid Voltage - Dialga 121 was missing.

## Details

<!-- You can also give more details about your changes -->
The missing 'normal' variant is available inside the V Battle Deck. I'm not sure if you also add these kind of variants to the variant list of the card?
The TCGPlayer info is available here: https://www.tcgplayer.com/product/270101?Language=English
The (reverse) holo info here: https://www.tcgplayer.com/product/226575?Language=English
