### PR TITLE
fix(data): Add missing French translations for tk-hs-g

### DIFF
--- a/data/Trainer kits/HS trainer Kit (Gyarados)/1.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/1.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Totodile",
+		fr: "Kaiminus",
 	},
 
 	illustrator: "kawayoo",
@@ -23,6 +24,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Gnaw",
+				fr: "Ronge",
 			},
 			damage: 10,
 		},
@@ -33,6 +35,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Wave Splash",
+				fr: "Grosse vague",
 			},
 			damage: 20,
 		},

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/10.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/10.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/11.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/11.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/12.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/12.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Magikarp",
+		fr: "Magicarpe",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -23,6 +24,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Splash",
+				fr: "Trempette",
 			},
 			damage: 10,
 		},

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/13.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/13.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Croconaw",
+		fr: "Crocrodil",
 	},
 
 	illustrator: "kawayoo",
@@ -17,6 +18,7 @@ const card: Card = {
 	],
 	evolveFrom: {
 		en: "Totodile",
+		fr: "Kaiminus",
 	},
 	stage: "Stage1",
 	attacks: [
@@ -27,6 +29,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Wave Splash",
+				fr: "Grosse vague",
 			},
 			damage: 30,
 		},
@@ -38,9 +41,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Big Bite",
+				fr: "Grosse morsure",
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
+				fr: "Le Pokémon Défenseur ne peut pas battre en retraite durant le prochain tour de votre adversaire.",
 			},
 			damage: 50,
 		},

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/14.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/14.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Totodile",
+		fr: "Kaiminus",
 	},
 
 	illustrator: "kawayoo",
@@ -23,6 +24,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Gnaw",
+				fr: "Ronge",
 			},
 			damage: 10,
 		},
@@ -33,6 +35,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Wave Splash",
+				fr: "Grosse vague",
 			},
 			damage: 20,
 		},

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/15.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/15.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Marill",
+		fr: "Marill",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -23,9 +24,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Water Splash",
+				fr: "Éclaboussure",
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
+				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
 			},
 			damage: "10+",
 		},
@@ -37,6 +40,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Tail Slap",
+				fr: "Coud’keu",
 			},
 			damage: 30,
 		},

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/16.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/16.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/17.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/17.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Croconaw",
+		fr: "Crocrodil",
 	},
 
 	illustrator: "kawayoo",
@@ -17,6 +18,7 @@ const card: Card = {
 	],
 	evolveFrom: {
 		en: "Totodile",
+		fr: "Kaiminus",
 	},
 	stage: "Stage1",
 	attacks: [
@@ -27,6 +29,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Wave Splash",
+				fr: "Grosse vague",
 			},
 			damage: 30,
 		},
@@ -38,9 +41,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Big Bite",
+				fr: "Grosse morsure",
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
+				fr: "Le Pokémon Défenseur ne peut pas battre en retraite durant le prochain tour de votre adversaire.",
 			},
 			damage: 50,
 		},

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/18.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/18.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Bill",
+		fr: "Léo",
 	},
 
 	illustrator: "Ken Sugimori",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/19.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/19.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Magikarp",
+		fr: "Magicarpe",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -23,6 +24,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Splash",
+				fr: "Trempette",
 			},
 			damage: 10,
 		},

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/2.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/2.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/21.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/21.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Energy Switch",
+		fr: "Échange d’Énergie",
 	},
 
 	illustrator: "Wataru Kawahara",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/22.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/22.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Pokémon Communication",
+		fr: "Communication Pokémon",
 	},
 
 	illustrator: "Takashi Yamaguchi",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/23.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/23.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Poké Ball",
+		fr: "Poké Ball",
 	},
 
 	illustrator: "Hideaki Hakozaki",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/24.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/24.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Marill",
+		fr: "Marill",
 	},
 
 	illustrator: "Kouki Saitou",
@@ -23,9 +24,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Water Splash",
+				fr: "Éclaboussure",
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 10 damage plus 10 more damage.",
+				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires.",
 			},
 			damage: "10+",
 		},
@@ -37,6 +40,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Tail Slap",
+				fr: "Coud’keu",
 			},
 			damage: 30,
 		},

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/25.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/25.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Professor Elm's Training Method",
+		fr: "Méthode d'entraînement du Prof. Orme",
 	},
 
 	illustrator: "Ken Sugimori",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/26.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/26.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/27.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/27.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Pokémon Communication",
+		fr: "Communication Pokémon",
 	},
 
 	illustrator: "Takashi Yamaguchi",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/28.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/28.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Switch",
+		fr: "Échange",
 	},
 
 	illustrator: "Hideaki Hakozaki",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/29.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/29.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/3.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/3.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/30.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/30.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Gyarados",
+		fr: "Léviator",
 	},
 
 	illustrator: "Mitsuhiro Arita",
@@ -17,6 +18,7 @@ const card: Card = {
 	],
 	evolveFrom: {
 		en: "Magikarp",
+		fr: "Magicarpe",
 	},
 	stage: "Stage1",
 	attacks: [
@@ -28,6 +30,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Hydro Splash",
+				fr: "Hydro-éclaboussure",
 			},
 			damage: 50,
 		},
@@ -40,9 +43,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Hyper Beam",
+				fr: "Ultralaser",
 			},
 			effect: {
 				en: "Discard an Energy card attached to the Defending Pokémon.",
+				fr: "Défaussez une carte Énergie attachée au Pokémon Défenseur.",
 			},
 			damage: 80,
 		},

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/4.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/4.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/5.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/5.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Bill",
+		fr: "Léo",
 	},
 
 	illustrator: "Ken Sugimori",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/6.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/6.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/7.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/7.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/8.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/8.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Gyarados)/9.ts
+++ b/data/Trainer kits/HS trainer Kit (Gyarados)/9.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Gyarados)'
 const card: Card = {
 	name: {
 		en: "Water Energy",
+		fr: "Énergie Eau",
 	},
 
 	rarity: "None",


### PR DESCRIPTION
## Changes

The HS Trainer Kit (Gyarados) (`tk-hs-g`) carried French text on exactly one of its 30 cards. This adds the **53** missing `fr` values — every card name, `evolveFrom`, attack name and attack effect in the set.

## Details

The kit was released in French on 5 November 2010 as *HS Kit du Dresseur (Léviator)* ([PokéCardex](https://www.pokecardex.com/series/TK4-L), 30 cards), and every card in it is a reprint of a `hgss1` card whose French text this database already carries. So each value was taken from the `hgss1` card the kit reprints, after checking the two cards line up — English name, HP, stage, `evolveFrom`, attack names, energy costs, damage, effect text, weaknesses, resistances, retreat cost. All 30 matched.

Each card was then cross-checked against [its own Poképédia page for this set](https://www.pokepedia.fr/HS_Kit_du_Dresseur), which is where three values end up differing from `hgss1`:

- **Cards 13 and 17 are `Crocrodil`, not `Crocodil`.** The French `hgss1` 38 card is misprinted and this database reproduces the misprint faithfully; Poképédia records that every reprint — these two kit cards and `col1` 41 — corrected the name. `hgss1` is left untouched.
- **Card 30's `Hyper Beam` effect reads `Défaussez une carte Énergie attachée au Pokémon Défenseur.`**, where `hgss1` 4 has `Défaussez-vous d’une carte Énergie attachée…`. The kit rewords it, and card 20 of this same set — the one card that already had French — already carries the kit wording.
- **Card 25 is `Méthode d'entraînement du Prof. Orme`**, with the space, matching Poképédia's page for this card and the `col1` 82 value; `hgss1` 100 has `Prof.Orme`.

Everything else is copied verbatim from `hgss1`, including its typographic apostrophes (`Échange d’Énergie`, `Coud’keu`).

The single English string left in place is card 20's Pokédex `description`: no French source carries it, and that matches the rest of the database, where descriptions stay in English on the large majority of otherwise French-complete cards.

`npm run validate` passes. 53 insertions, 0 deletions — no English string was touched.

Same shape as #2125 (`B1`), one set per PR.
