### PR TITLE
fix(data): Add missing French translations for tk-hs-r

### DIFF
--- a/data/Trainer kits/HS trainer Kit (Raichu)/1.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/1.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Moomoo Milk",
+		fr: "Lait Meumeu",
 	},
 
 	illustrator: "Noriko Hotta",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/10.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/10.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/11.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/11.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/12.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/12.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Meowth",
+		fr: "Miaouss",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -23,9 +24,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Pay Day",
+				fr: "Jackpot",
 			},
 			effect: {
 				en: "Draw a card.",
+				fr: "Piochez une carte.",
 			},
 			damage: 10,
 		},
@@ -36,6 +39,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Dig Claws",
+				fr: "Creusogriffes",
 			},
 			damage: 20,
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/13.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/13.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Mareep",
+		fr: "Wattouat",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -23,9 +24,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Static Electricity",
+				fr: "Électricité statique",
 			},
 			effect: {
 				en: "Search your deck for a number of Lightning Energy cards up to the number of Mareep in play (both yours and your opponent's) and attach them to Mareep. Shuffle your deck afterward.",
+				fr: "Cherchez dans votre deck un nombre de cartes Énergie {L} allant jusqu’au nombre de Wattouat en jeu (les vôtres et ceux de votre adversaire) et attachez-les à Wattouat. Mélangez ensuite votre deck.",
 			},
 		},
 		{
@@ -35,6 +38,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Ram",
+				fr: "Collision",
 			},
 			damage: 20,
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/14.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/14.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/15.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/15.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/16.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/16.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Pikachu",
+		fr: "Pikachu",
 	},
 
 	illustrator: "match",
@@ -23,6 +24,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Tail Slap",
+				fr: "Coud’keu",
 			},
 			damage: 10,
 		},
@@ -33,9 +35,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
+				fr: "Vive-attaque",
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
+				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
 			},
 			damage: "20+",
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/17.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/17.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Flaaffy",
+		fr: "Lainergie",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -17,6 +18,7 @@ const card: Card = {
 	],
 	evolveFrom: {
 		en: "Mareep",
+		fr: "Wattouat",
 	},
 	stage: "Stage1",
 	attacks: [
@@ -26,9 +28,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunder Spear",
+				fr: "Lance-éclair",
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				fr: "Choisissez l’un des Pokémon de votre adversaire. Cette attaque inflige 20 dégâts à ce Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
 			},
 		},
 		{
@@ -39,9 +43,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Thundershock",
+				fr: "Éclair",
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
 			},
 			damage: 40,
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/18.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/18.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/19.ts
@@ -32,6 +32,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
+				fr: "Lancez une pièce jusqu’à ce qu’elle tombe sur pile. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
 			},
 			damage: "30×",
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/2.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/2.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Pikachu",
+		fr: "Pikachu",
 	},
 
 	illustrator: "match",
@@ -23,6 +24,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Tail Slap",
+				fr: "Coud’keu",
 			},
 			damage: 10,
 		},
@@ -33,9 +35,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Quick Attack",
+				fr: "Vive-attaque",
 			},
 			effect: {
 				en: "Flip a coin. If heads, this attack does 20 damage plus 10 more damage.",
+				fr: "Lancez une pièce. Si c’est face, cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires.",
 			},
 			damage: "20+",
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/20.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/20.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Mareep",
+		fr: "Wattouat",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -23,9 +24,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Static Electricity",
+				fr: "Électricité statique",
 			},
 			effect: {
 				en: "Search your deck for a number of Lightning Energy cards up to the number of Mareep in play (both yours and your opponent's) and attach them to Mareep. Shuffle your deck afterward.",
+				fr: "Cherchez dans votre deck un nombre de cartes Énergie {L} allant jusqu’au nombre de Wattouat en jeu (les vôtres et ceux de votre adversaire) et attachez-les à Wattouat. Mélangez ensuite votre deck.",
 			},
 		},
 		{
@@ -35,6 +38,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Ram",
+				fr: "Collision",
 			},
 			damage: 20,
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/21.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/21.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Copycat",
+		fr: "Copieuse",
 	},
 
 	illustrator: "Kanako Eo",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/22.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/22.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Pokémon Collector",
+		fr: "Collectionneur de Pokémon",
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/23.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/23.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/24.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/24.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Switch",
+		fr: "Échange",
 	},
 
 	illustrator: "Hideaki Hakozaki",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/25.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/25.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Poké Ball",
+		fr: "Poké Ball",
 	},
 
 	illustrator: "Hideaki Hakozaki",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/26.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/26.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Moomoo Milk",
+		fr: "Lait Meumeu",
 	},
 
 	illustrator: "Noriko Hotta",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/27.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/27.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Pokémon Collector",
+		fr: "Collectionneur de Pokémon",
 	},
 
 	illustrator: "Masakazu Fukuda",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/28.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/28.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/29.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/29.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Energy Switch",
+		fr: "Échange d’Énergie",
 	},
 
 	illustrator: "Wataru Kawahara",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/3.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/3.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Flaaffy",
+		fr: "Lainergie",
 	},
 
 	illustrator: "Masakazu Fukuda",
@@ -17,6 +18,7 @@ const card: Card = {
 	],
 	evolveFrom: {
 		en: "Mareep",
+		fr: "Wattouat",
 	},
 	stage: "Stage1",
 	attacks: [
@@ -26,9 +28,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunder Spear",
+				fr: "Lance-éclair",
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
+				fr: "Choisissez l’un des Pokémon de votre adversaire. Cette attaque inflige 20 dégâts à ce Pokémon. (N’appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
 			},
 		},
 		{
@@ -39,9 +43,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Thundershock",
+				fr: "Éclair",
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed.",
+				fr: "Lancez une pièce. Si c’est face, le Pokémon Défenseur est maintenant Paralysé.",
 			},
 			damage: 40,
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/30.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/30.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Raichu",
+		fr: "Raichu",
 	},
 
 	illustrator: "match",
@@ -17,6 +18,7 @@ const card: Card = {
 	],
 	evolveFrom: {
 		en: "Pikachu",
+		fr: "Pikachu",
 	},
 	stage: "Stage1",
 	attacks: [
@@ -26,9 +28,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Iron Tail",
+				fr: "Queue de fer",
 			},
 			effect: {
 				en: "Flip a coin until you get tails. This attack does 30 damage times the number of heads.",
+				fr: "Lancez une pièce jusqu’à ce qu’elle tombe sur pile. Cette attaque inflige 30 dégâts multipliés par le nombre de faces.",
 			},
 			damage: "30×",
 		},
@@ -39,9 +43,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Thunderbolt",
+				fr: "Tonnerre",
 			},
 			effect: {
 				en: "Discard all Energy attached to Raichu.",
+				fr: "Défaussez toutes les cartes Énergie attachées à Raichu.",
 			},
 			damage: 100,
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/4.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/4.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Meowth",
+		fr: "Miaouss",
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -23,9 +24,11 @@ const card: Card = {
 			],
 			name: {
 				en: "Pay Day",
+				fr: "Jackpot",
 			},
 			effect: {
 				en: "Draw a card.",
+				fr: "Piochez une carte.",
 			},
 			damage: 10,
 		},
@@ -36,6 +39,7 @@ const card: Card = {
 			],
 			name: {
 				en: "Dig Claws",
+				fr: "Creusogriffes",
 			},
 			damage: 20,
 		},

--- a/data/Trainer kits/HS trainer Kit (Raichu)/5.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/5.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/6.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/6.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/7.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/7.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/8.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/8.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",

--- a/data/Trainer kits/HS trainer Kit (Raichu)/9.ts
+++ b/data/Trainer kits/HS trainer Kit (Raichu)/9.ts
@@ -4,6 +4,7 @@ import Set from '../HS trainer Kit (Raichu)'
 const card: Card = {
 	name: {
 		en: "Lightning Energy",
+		fr: "Énergie Électrique",
 	},
 
 	rarity: "None",


### PR DESCRIPTION
## Changes

The HS Trainer Kit (Raichu) (`tk-hs-r`) had French text on 1 of its 30 cards, so `GET /v2/fr/sets/tk-hs-r` returned a single card out of 30. This adds the **63** missing `fr` values — every card name, `evolveFrom`, attack name and attack effect. The set is now complete in French.

## Details

The kit was released in French on 5 November 2010 as *HS Kit du Dresseur (Raichu)* ([PokéCardex](https://www.pokecardex.com/series/TK4-R), 30 cards), and every card in it is a reprint of a `hgss1` card whose French text this database already carries. Each value was taken from the `hgss1` card the kit reprints, after checking the two cards line up — English name, HP, stage, `evolveFrom`, attack names, energy costs, damage, effect text, weaknesses, resistances, retreat cost. All 30 matched.

Every French string was then read off the card itself, from the scans on the [Poképédia pages for this set](https://www.pokepedia.fr/HS_Kit_du_Dresseur). Two values come out different from `hgss1`:

- **Cards 13 and 20 (`Wattouat`, `Électricité statique`) use `{L}`, not the word `Lightning`.** The card prints the Lightning symbol — `un nombre de cartes Énergie {L} allant jusqu'au…` — where `hgss1` 73 has `cartes Énergie Lightning`, the English type name left in the French string. Fixed here for the two kit cards; `hgss1` 73 is left for its own PR.
- **Card 30's `Thunderbolt` reads `Défaussez toutes les cartes Énergie attachées à Raichu.`**, where `hgss1` 10 has `Défaussez-vous de toutes les cartes Énergie…`. The kit rewords it; card 19 of this set — the one card that already had French — already carries the kit wording, and the scan confirms it. The sibling kit does the same thing (see #2271).

One divergence went the other way: Poképédia transcribes `Queue de fer` on cards 19 and 30 as `Cette carte inflige 30 dégâts…`, but the scan reads `Cette attaque inflige 30 dégâts…`, which is what `hgss1` 10 has and what this PR uses.

Everything else is copied verbatim from `hgss1`, typographic apostrophes included (`Coud’keu`, `jusqu’à`).

`npm run validate` passes. 63 insertions, 0 deletions — no English string was touched.

Same shape as #2271 (`tk-hs-g`) and #2125 (`B1`), one set per PR.
