### PR TITLE
fix(data): Restore the energy symbols lost from Neo Destiny French text

### DIFF
--- a/data/Neo/Neo Destiny/1.ts
+++ b/data/Neo/Neo Destiny/1.ts
@@ -61,7 +61,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard all Energy cards attached to this Pokémon in order to use this attack.",
-				fr: "Défaussez-vous de toutes les cartes Énergie  attachées à Pharamp obscur ou cette attaque ne fait rien.",
+				fr: "Défaussez-vous de toutes les cartes Énergie {L} attachées à Pharamp obscur ou cette attaque ne fait rien.",
 				de: "Lege alle an Dunkles Ampharos angelegten {L}-Energiekarten auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen."
 			},
 			damage: 50,

--- a/data/Neo/Neo Destiny/10.ts
+++ b/data/Neo/Neo Destiny/10.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may discard any number of Energy cards attached to your Pokémon. Flip a coin for each Energy card discarded in this way. This attack does 40 damage times the number of heads.",
-				fr: "Vous pouvez vous défausser de n'importe quel nombre de cartes Énergie  attachées à votre Pokémon. Lancez une pièce pour chaque carte Énergie  défaussée de cette manière. Cette attaque fait 40 dégâts multipliés par le nombre de faces.",
+				fr: "Vous pouvez vous défausser de n'importe quel nombre de cartes Énergie {R} attachées à votre Pokémon. Lancez une pièce pour chaque carte Énergie {R} défaussée de cette manière. Cette attaque fait 40 dégâts multipliés par le nombre de faces.",
 				de: "Du kannst eine beliebige Anzahl an dein Pokémon angelegte {R}-Energiekarten auf deinen Ablagestapel legen. Wirf für jede {R}-Energiekarte, die du auf diese Weise auf deinen Ablagestapel gelegt hast, eine Münze. Dieser Angriff fügt 40 Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "40x",

--- a/data/Neo/Neo Destiny/106.ts
+++ b/data/Neo/Neo Destiny/106.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Remove a number of damage counters from 1 of your Benched Pokémon equal to the number of Energy cards attached to Shining Celebi. If the Pokémon has fewer damage counters than that, remove all of them.",
-				fr: "Retirez un nombre de marqueurs de dégâts sur un des Pokémon de votre Banc égal au nombre d'Énergies  attachées à Celebi brillant. Si le Pokémon a moins de marqueurs de dégâts, retirez-les tous.",
+				fr: "Retirez un nombre de marqueurs de dégâts sur un des Pokémon de votre Banc égal au nombre d'Énergies {W} attachées à Celebi brillant. Si le Pokémon a moins de marqueurs de dégâts, retirez-les tous.",
 				de: "Entferne so viele Schadensmarken von einem deiner Pokémon, wie {W}-Energie an Schimmerndes Celebi angelegt sind. Wenn dieses Pokémon weniger Schadensmarken hat, entferne alle."
 			},
 

--- a/data/Neo/Neo Destiny/107.ts
+++ b/data/Neo/Neo Destiny/107.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card and 1 Energy card attached to Shining Charizard or this attack does nothing. Flip a coin. If tails, Shining Charizard does 30 damage to itself.",
-				fr: "Défaussez-vous d'une carte Énergie  et d'une carte Énergie  attachées à Dracaufeu brillant ou cette attaque ne fait rien. Lancez une pièce. Si c'est pile, Dracaufeu brillant s'inflige 30 dégâts.",
+				fr: "Défaussez-vous d'une carte Énergie {R} et d'une carte Énergie {L} attachées à Dracaufeu brillant ou cette attaque ne fait rien. Lancez une pièce. Si c'est pile, Dracaufeu brillant s'inflige 30 dégâts.",
 				de: "Lege eine jeweils an Glurak angelegte {R}-Energiekarte und {L}-Energiekarte auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen. Wirf eine Münze. Bei „Zahl“ fügt sich Schimmerndes Glurak selber 30 Schadenspunkte zu."
 			},
 			damage: 100,

--- a/data/Neo/Neo Destiny/108.ts
+++ b/data/Neo/Neo Destiny/108.ts
@@ -59,7 +59,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 50 damage plus 10 more damage for each Energy attached to Shining Kabutops but not used to pay for this attack's Energy cost. Don't apply Resistance.",
-				fr: "Inflige 50 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Kabutops brillant mais non utilisée pour payer le coût d'Énergie de cette attaque. N'appliquez pas la Résistance.",
+				fr: "Inflige 50 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {W} attachée à Kabutops brillant mais non utilisée pour payer le coût d'Énergie de cette attaque. N'appliquez pas la Résistance.",
 				de: "Fügt 50 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Schimmerndes Kabutops angelegte {W}-Energie, die nicht zum Zahlen der Angriffskosten verwendet wird, zu. Wende Resistenz nicht an."
 			},
 			damage: "50+",

--- a/data/Neo/Neo Destiny/109.ts
+++ b/data/Neo/Neo Destiny/109.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Energy card attached to Shining Mewtwo or this attack does nothing. This attack does 40 damage plus 10 damage for each Energy attached to the Defending Pokémon.",
-				fr: "Défaussez-vous d'une carte Énergie  attachée à Mewtwo brillant ou cette attaque ne fait rien. Cette attaque inflige 40 dégâts plus 10 dégâts pour chaque Énergie attachée au Pokémon Défenseur.",
+				fr: "Défaussez-vous d'une carte Énergie {R} attachée à Mewtwo brillant ou cette attaque ne fait rien. Cette attaque inflige 40 dégâts plus 10 dégâts pour chaque Énergie attachée au Pokémon Défenseur.",
 				de: "Lege eine an Schimmerndes Mewtu angelegte {R}-Energiekarte auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen. Dieser Angriff fügt 40 Schadenspunkte plus weitere 10 Schadenspunkte für jede an das verteidigende Pokémon angelegte Energie zu."
 			},
 			damage: "40+",

--- a/data/Neo/Neo Destiny/11.ts
+++ b/data/Neo/Neo Destiny/11.ts
@@ -43,7 +43,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a number of coins equal to the number of Energy cards attached to Dark Tyranitar. This attack does 20 damage times the number of heads. Then, for each heads, discard the top card from your opponent's deck.",
-				fr: "Lancez un nombre de pièces égal au nombre de cartes Énergie  attachées à Tyranocif obscur. Cette attaque inflige 20 dégâts multipliés par le nombre de faces. Puis, pour chaque face, défaussez-vous de la carte du dessus du deck de votre adversaire.",
+				fr: "Lancez un nombre de pièces égal au nombre de cartes Énergie {F} attachées à Tyranocif obscur. Cette attaque inflige 20 dégâts multipliés par le nombre de faces. Puis, pour chaque face, défaussez-vous de la carte du dessus du deck de votre adversaire.",
 				de: "Wirf so viele Münzen, wie an Dunkles Despotar {F}-Energiekarten angelegt sind. Dieser Angriff fügt 20 Schadenspunkte mal der Anzahl „Kopf“ zu. Lege dann für jedes Mal „Kopf“ die oberste Karte vom Deck deines Gegners auf den Ablagestapel."
 			},
 			damage: "20x",

--- a/data/Neo/Neo Destiny/111.ts
+++ b/data/Neo/Neo Destiny/111.ts
@@ -42,7 +42,7 @@ const card: Card = {
 
 			effect: {
 				en: "If your opponent has any Benched Pokémon, choose 1 of them and this attack does 10 damage to that Pokémon for each Energy attached to Shining Raichu. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Si votre adversaire a des Pokémon sur son Banc, choisissez l'un d'eux et cette attaque inflige 10 dégâts à ce Pokémon pour chaque Énergie  attachée à Raichu brillant. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
+				fr: "Si votre adversaire a des Pokémon sur son Banc, choisissez l'un d'eux et cette attaque inflige 10 dégâts à ce Pokémon pour chaque Énergie {W} attachée à Raichu brillant. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon du Banc.)",
 				de: "Wenn dein Gegner mindestens ein Pokémon auf seiner Bank hat, wähle eines von diesen und dieser Angriff fügt diesem Pokémon 10 Schadenspunkte für jede an Schimmerndes Raichu angelegte {W}-Energie zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 

--- a/data/Neo/Neo Destiny/113.ts
+++ b/data/Neo/Neo Destiny/113.ts
@@ -63,7 +63,7 @@ const card: Card = {
 		},
 
 		effect: {
-			fr: "Lancez une pièce pour chaque carte Énergie  attachée à Tyranocif brillant. Pour chaque face, défaussez-vous d'une carte Énergie  attachée à Tyranocif brillant ou cette attaque ne fait rien. Puis, pour chaque face, choisissez une carte Énergie attachée au Pokémon Défenseur et obligez votre adversaire à s'en défausser. S'il a moins de cartes Énergie, il doit se défausser de toutes ses cartes Énergie.",
+			fr: "Lancez une pièce pour chaque carte Énergie {R} attachée à Tyranocif brillant. Pour chaque face, défaussez-vous d'une carte Énergie {R} attachée à Tyranocif brillant ou cette attaque ne fait rien. Puis, pour chaque face, choisissez une carte Énergie attachée au Pokémon Défenseur et obligez votre adversaire à s'en défausser. S'il a moins de cartes Énergie, il doit se défausser de toutes ses cartes Énergie.",
 			de: "Wirf für jede an Schimmerndes Despotar abgelegte -Energiekarte eine Münze. Lege für jedes Mal 'Kopf' eine an Schimmerndes Despotar abgelegte -Energiekarte auf deinen Ablagestapel, oder dieser Angriff hat keine Auswirkungen. Wähle dann für jedes Mal 'Kopf' eine an das verteidigende Pokémon angelegte Energiekarte und lege diese auf den Ablagestapel deines gegners. Wenn das verteidigende Pokémon weniger Energiekarten hat, lege sie alle ab."
 		},
 

--- a/data/Neo/Neo Destiny/14.ts
+++ b/data/Neo/Neo Destiny/14.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Light Dragonite is your Active Pokémon, each Special Energy card provides Colorless Energy instead of its usual type and its other effects stop working. This power stops working while Light Dragonite is Asleep, Confused, or Paralyzed.",
-				fr: "Tant que Dracolosse lumineux est votre Pokémon Actif, toutes les cartes Énergie spéciale fournissent de l'Énergie  au lieu de leur type d'Énergie habituel et leurs autres effets cessent de fonctionner. Ce pouvoir cesse de fonctionner si Dracolosse lumineux est Endormi, Confus ou Paralysé.",
+				fr: "Tant que Dracolosse lumineux est votre Pokémon Actif, toutes les cartes Énergie spéciale fournissent de l'Énergie {C} au lieu de leur type d'Énergie habituel et leurs autres effets cessent de fonctionner. Ce pouvoir cesse de fonctionner si Dracolosse lumineux est Endormi, Confus ou Paralysé.",
 				de: "Solange Helles Dragoran dein aktives Pokémon ist, erzeugt jede Spezialenergiekarte {C}-Energie statt ihres normalen Typs, und alle ihre anderen Effekte funktionieren nicht. Diese Fähigkeit verliert ihre Wirkung, solange Helles Dragoran schläft, verwirrt oder gelähmt ist."
 			},
 		},

--- a/data/Neo/Neo Destiny/18.ts
+++ b/data/Neo/Neo Destiny/18.ts
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may discard a Energy card attached to Dark Magcargo when you use this attack. If you do and if your opponent has any Benched Pokémon, choose 1 of them and this attack does 20 damage to it. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Vous pouvez vous défausser d'une carte Énergie  attachée à Volcaropod obscur quand vous utilisez cette attaque. Si vous le faites, et si votre adversaire a des Pokémon sur son Banc, choisissez l'un d'eux et cette attaque lui inflige 20 dégâts (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
+				fr: "Vous pouvez vous défausser d'une carte Énergie {R} attachée à Volcaropod obscur quand vous utilisez cette attaque. Si vous le faites, et si votre adversaire a des Pokémon sur son Banc, choisissez l'un d'eux et cette attaque lui inflige 20 dégâts (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
 				de: "Du kannst eine an Dunkles Magcargo angelegte {R}-Energiekarte auf deinen Ablagestapel legen, wenn du diesen Angriff verwendest. Falls du dies tust und falls dein Gegner mindestens ein Pokémon auf der Bank hat, bestimmme eines von diesen. Dieser Angriff fügt diesem Pokémon 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 20,

--- a/data/Neo/Neo Destiny/25.ts
+++ b/data/Neo/Neo Destiny/25.ts
@@ -47,7 +47,7 @@ const card: Card = {
 
 			effect: {
 				en: "If the Defending Pokémon has Dark in its name or is a Pokémon, flip a coin. If heads, this attack does 100 damage instead of 50.",
-				fr: "Si le Pokémon Défenseur est un Pokémon obscur ou si c'est un Pokémon , lancez une pièce. Si c'est face, cette attaque inflige 100 dégâts au lieu de 50.",
+				fr: "Si le Pokémon Défenseur est un Pokémon obscur ou si c'est un Pokémon {D}, lancez une pièce. Si c'est face, cette attaque inflige 100 dégâts au lieu de 50.",
 				de: "Wirf eine Münze, wenn das verteidigende Pokémon „Dunkles“ in seinem Namen hat oder ein {D}-Pokémon ist. Bei „Kopf“ fügt dieser Angriff 100 Schadenspunkte statt 50 zu."
 			},
 

--- a/data/Neo/Neo Destiny/37.ts
+++ b/data/Neo/Neo Destiny/37.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each Energy card attached to Dark Omanyte. Don't apply Weakness and Resistance. You can't do more than 30 damage in this way.",
-				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque inflige 10 dégâts pour chaque  carte Énergie attachée à Amonita obscur. N'appliquez ni la Faiblesse, ni la Résistance. Vous ne pouvez pas infliger plus de 30 dégâts de cette manière.",
+				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque inflige 10 dégâts pour chaque {W} carte Énergie attachée à Amonita obscur. N'appliquez ni la Faiblesse, ni la Résistance. Vous ne pouvez pas infliger plus de 30 dégâts de cette manière.",
 				de: "Wähle eines der Pokémon deines Gegners. Dieser Angriff fügt für jede an Dunkles Amonitas angelegte {W}-Energiekarte 10 Schadenspunkte zu. Wende Schwäche und Resistenz nicht an. Du kannst auf diese Weise nicht mehr als 30 Schadenspunkte verursachen."
 			},
 

--- a/data/Neo/Neo Destiny/39.ts
+++ b/data/Neo/Neo Destiny/39.ts
@@ -62,7 +62,7 @@ const card: Card = {
 
 			effect: {
 				en: "Discard the top 5 cards of your deck. (If there are fewer than 5 cards in your deck, discard all of them.) This attack does 20 damage for each Energy card you discarded in this way.",
-				fr: "Défaussez-vous des 5 premières cartes du dessus de votre deck. (Si vous avez moins de 5 cartes dans votre deck, défaussez-vous de toutes.) Cette attaque inflige 20 dégâts pour chaque carte Énergie  défaussée de cette manière.",
+				fr: "Défaussez-vous des 5 premières cartes du dessus de votre deck. (Si vous avez moins de 5 cartes dans votre deck, défaussez-vous de toutes.) Cette attaque inflige 20 dégâts pour chaque carte Énergie {R} défaussée de cette manière.",
 				de: "Lege die obersten 5 Karten deines Decks auf deinen Ablagestapel. (Wenn weniger als 5 Karten in deinem Deck sind, lege sie alle ab.) Dieser Angriff fügt für jede so abgeworfene {R}-Energiekarte 20 Schadenspunkte zu."
 			},
 

--- a/data/Neo/Neo Destiny/46.ts
+++ b/data/Neo/Neo Destiny/46.ts
@@ -43,7 +43,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If you have any benched Pokémon, search your deck for a Energy card and attach it to 1 of them. Then shuffle your deck.",
-				fr: "Si vous avez des Pokémon sur votre Banc, cherchez une carte Énergie  dans votre deck et attachez-la à l'un d'eux. Mélangez ensuite votre deck.",
+				fr: "Si vous avez des Pokémon sur votre Banc, cherchez une carte Énergie {R} dans votre deck et attachez-la à l'un d'eux. Mélangez ensuite votre deck.",
 				de: "Falls du mindestens ein Pokémon auf deiner Bank hast, durchsuche dein Deck nach einer {R}-Energiekarte und lege diese an eines dieser Pokémon an. Mische dein Deck danach."
 			},
 
@@ -61,7 +61,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip 2 coins. For each heads, discard a Energy card attached to Light Flareon or this attack does nothing. This attack does 30 damage plus 20 damage for each heads.",
-				fr: "Lancez 2 pièces. Pour chaque face, défaussez-vous d'une carte Énergie  attachée à Pyroli lumineux ou cette attaque ne fait rien. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
+				fr: "Lancez 2 pièces. Pour chaque face, défaussez-vous d'une carte Énergie {R} attachée à Pyroli lumineux ou cette attaque ne fait rien. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
 				de: "Wirf zwei Münzen. Lege pro „Kopf“ eine an Helles Flamara angelegte {R}-Energiekarte auf deinen Ablagestapel oder dieser Angriff hat keine Auswirkungen. Dieser Angriff fügt 30 Schadenspunkte plus 20 Schadenspunkte für jeden „Kopf“ zu."
 			},
 			damage: "30+",

--- a/data/Neo/Neo Destiny/50.ts
+++ b/data/Neo/Neo Destiny/50.ts
@@ -62,7 +62,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Energy card attached to Light Ninetales in order to use this attack.",
-				fr: "Défaussez-vous d'une carte Énergie  attachée à Feunard lumineux pour utiliser cette attaque.",
+				fr: "Défaussez-vous d'une carte Énergie {R} attachée à Feunard lumineux pour utiliser cette attaque.",
 				de: "Lege eine an Helles Vulnona angelegte {R}-Energiekarte auf deinen Ablagestapel, um diesen Angriff zu verwenden."
 			},
 			damage: 50,

--- a/data/Neo/Neo Destiny/62.ts
+++ b/data/Neo/Neo Destiny/62.ts
@@ -61,7 +61,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, the Defending Pokémon is now Paralyzed. If tails, during your opponent's next turn, your opponent pays more to retreat the Defending Pokémon.",
-				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé. Si c'est pile, pendant le prochain tour de votre adversaire, votre adversaire paie  supplémentaires pour faire battre en retraite le Pokémon Défenseur.",
+				fr: "Lancez une pièce. Si c'est face, le Pokémon Défenseur est maintenant Paralysé. Si c'est pile, pendant le prochain tour de votre adversaire, votre adversaire paie {C} supplémentaires pour faire battre en retraite le Pokémon Défenseur.",
 				de: "Wirf eine Münze. Bei „Kopf“ ist das verteidigende Pokémon jetzt gelähmt. Bei „Zahl“ bezahlt dein Gegner während seines nächsten Zuges {C} mehr, wenn er das verteidigende Pokémon zurückziehen will."
 			},
 			damage: 20,

--- a/data/Neo/Neo Destiny/7.ts
+++ b/data/Neo/Neo Destiny/7.ts
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If there are any Energy cards attached to Dark Houndoom, discard 1 of them and this attack does 30 damage plus 20 more damage (plus 10 more damage for the Energy you discarded). If there aren't any, this attack does 30 damage.",
-				fr: "S'il y a des cartes Énergie  attachées à Démolosse obscur, défaussez-vous en d'une. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires (plus 10 dégâts pour la carte Énergie  défaussée). Sinon, cette attaque inflige 30 dégâts.",
+				fr: "S'il y a des cartes Énergie {D} attachées à Démolosse obscur, défaussez-vous en d'une. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires (plus 10 dégâts pour la carte Énergie {D} défaussée). Sinon, cette attaque inflige 30 dégâts.",
 				de: "Falls mindestens eine {D}-Energiekarte an Dunkles Hundemon angelegt ist, lege eine davon auf deinen Ablagestapel, und dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte zu (plus 10 weitere für die abgelegte {D}-Energiekarte). Sonst fügt dieser Angriff 30 Schadenspunkte zu."
 			},
 			damage: "30+",

--- a/data/Neo/Neo Destiny/72.ts
+++ b/data/Neo/Neo Destiny/72.ts
@@ -44,7 +44,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Attach up to 2 Energy cards from your hand to 1 of your Pokémon.",
-				fr: "Attachez jusqu'à 2 cartes Énergie  de votre main à l'un de vos Pokémon .",
+				fr: "Attachez jusqu'à 2 cartes Énergie {G} de votre main à l'un de vos Pokémon {G}.",
 				de: "Lege bis zu zwei 2 {G}-Energiekarten aus deiner Hand an eines deiner {G}-Pokémon an."
 			},
 

--- a/data/Neo/Neo Destiny/85.ts
+++ b/data/Neo/Neo Destiny/85.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each Energy attached to Totodile but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
-				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Kaiminus en plus du coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
+				fr: "Inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {W} attachée à Kaiminus en plus du coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
 				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Karnimani angelegte {W}-Energie, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wird, zu. Du kannst auf diese Weise höchstens 20 weitere Schadenspunkte zufügen."
 			},
 			damage: "10+",

--- a/data/Neo/Neo Destiny/91.ts
+++ b/data/Neo/Neo Destiny/91.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card attached to this Pokémon in order to use this attack.",
-				fr: "Défaussez-vous d'une carte Énergie  attachée à Goupix pour pouvoir utiliser cette attaque.",
+				fr: "Défaussez-vous d'une carte Énergie {R} attachée à Goupix pour pouvoir utiliser cette attaque.",
 				de: "Lege eine an Vulpix angelegte {R}-Energiekarte auf deinen Ablagestapel, um diesen Angriff zu verwenden."
 			},
 			damage: 30,

--- a/data/Neo/Neo Destiny/92.ts
+++ b/data/Neo/Neo Destiny/92.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		en: "This card stays in play when you play it. Discard this card if another Stadium card comes into play. Each player pays Colorless more to retreat a Baby Pokémon or Basic Pokémon.",
-		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-vous de cette carte si une autre carte Stade arrive en jeu.\n\nChaque joueur paie  supplémentaire pour faire battre en retraite un Bébé Pokémon ou un Pokémon de base.",
+		fr: "Cette carte reste en jeu lorsque vous la jouez. Défaussez-vous de cette carte si une autre carte Stade arrive en jeu.\n\nChaque joueur paie {C} supplémentaire pour faire battre en retraite un Bébé Pokémon ou un Pokémon de base.",
 		de: "Diese Karte bleibt im Spiel, wenn du sie spielst. Lege diese Karte ab, sobald eine weitere Stadion-Karte ins Spiel kommt. Jeder Spieler bezahlt {C} mehr, um ein Baby-Pokémon oder ein Basis-Pokémon zurückzuziehen."
 	},
 


### PR DESCRIPTION
## Changes

Same loss as #2273, this time in Neo Destiny (`neo4`): the inline energy symbols were dropped from the French rules text, leaving only the space they sat in.

```
en: "Discard 1 Energy card attached to Shining Charizard or this attack does nothing. ..."
fr: "Défaussez-vous d'une carte Énergie  et d'une carte Énergie  attachées à ..."
de: "Lege eine jeweils an Glurak angelegte {R}-Energiekarte und {L}-Energiekarte ..."
```

**28 symbols** restored, in **23 strings** across **22 cards**. Only `fr` values change — 23 lines in, 23 lines out.

## Details

Each symbol comes from the German token list or from the type the English string spells out, and the two were cross-checked against each other; they agreed on all 21 strings where both carry the information. A gap only counts as a lost symbol when the count matches exactly, and ordering follows the English sentence rather than the German one, which reorders clauses.

Two cards had lost their symbols in more than one language, so they were read off the French card scans instead:

- **107 `Dracaufeu brillant`** — the English string has lost both types (`Discard 1 Energy card and 1 Energy card`); the card reads `carte Énergie {R} et d'une carte Énergie {L}`, matching the German.
- **113 `Tyranocif brillant`** — the English string for that attack is missing entirely and the German lost its tokens too. The card's `Feu destructeur` reads `carte Énergie {R}` twice, consistent with its `{D}{R}{R}` attack cost.

`npm run validate` passes. No English or German string was modified.

Second set of the series after #2273 (`ecard2`), one PR each.
