### PR TITLE
fix(data): Restore the energy symbols lost from XY promos French text

### DIFF
--- a/data/XY/XY Black Star Promos/XY128.ts
+++ b/data/XY/XY Black Star Promos/XY128.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If this Pokémon has any Fire Energy attached to it, this attack does 20 damage to 2 of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Si de l'Énergie  est attachée à ce Pokémon, cette attaque inflige 20 dégâts à 2 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
+				fr: "Si de l'Énergie {R} est attachée à ce Pokémon, cette attaque inflige 20 dégâts à 2 des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
 			},
 			damage: 40,
 

--- a/data/XY/XY Black Star Promos/XY130.ts
+++ b/data/XY/XY Black Star Promos/XY130.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "When you play this Pokémon from your hand to evolve 1 of your Pokémon, you may attach 1 Darkness Energy from your discard pile to this Pokémon for each Prize card your opponent has taken.",
-				fr: "Lorsque vous jouez ce Pokémon de votre main pour faire évoluer l'un de vos Pokémon, vous pouvez attacher 1 Énergie  de votre pile de défausse à ce Pokémon pour chaque carte Récompense que votre adversaire a récupérée."
+				fr: "Lorsque vous jouez ce Pokémon de votre main pour faire évoluer l'un de vos Pokémon, vous pouvez attacher 1 Énergie {D} de votre pile de défausse à ce Pokémon pour chaque carte Récompense que votre adversaire a récupérée."
 			},
 		},
 	],

--- a/data/XY/XY Black Star Promos/XY135.ts
+++ b/data/XY/XY Black Star Promos/XY135.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Move as many Psychic Energy attached to your Pokémon to your other Pokémon in any way you like.",
-				fr: "Déplacez autant d'Énergies  attachées à vos Pokémon que vous voulez vers vos autres Pokémon, de la manière que vous voulez."
+				fr: "Déplacez autant d'Énergies {P} attachées à vos Pokémon que vous voulez vers vos autres Pokémon, de la manière que vous voulez."
 			},
 			damage: 100,
 

--- a/data/XY/XY Black Star Promos/XY160.ts
+++ b/data/XY/XY Black Star Promos/XY160.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If this Pokémon has any Lightning Energy attached to it, this attack does 20 damage to each of your opponent's Benched Pokémon. (Don't apply weakness and Resistance for Benched Pokémon.)",
-				fr: "Si de l'Énergie  est attachée à ce Pokémon, cette attaque inflige 20 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
+				fr: "Si de l'Énergie {L} est attachée à ce Pokémon, cette attaque inflige 20 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
 			},
 			damage: 120,
 

--- a/data/XY/XY Black Star Promos/XY164.ts
+++ b/data/XY/XY Black Star Promos/XY164.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin for each Fire Energy attached to this Pokémon. This attack does 50 damage times the number of heads.",
-				fr: "Lancez une pièce pour chaque Énergie  attachée à ce Pokémon. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face."
+				fr: "Lancez une pièce pour chaque Énergie {R} attachée à ce Pokémon. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face."
 			},
 			damage: 50,
 

--- a/data/XY/XY Black Star Promos/XY171.ts
+++ b/data/XY/XY Black Star Promos/XY171.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard as many basic Fire Energy attached to this Pokémon as you like. This attack does 40 more damage for each Energy card discarded in this way.",
-				fr: "Défaussez autant d'Énergies  attachées à ce Pokémon que vous voulez. Cette attaque inflige 40 dégâts supplémentaires pour chaque carte Énergie défaussée de cette façon."
+				fr: "Défaussez autant d'Énergies {R} attachées à ce Pokémon que vous voulez. Cette attaque inflige 40 dégâts supplémentaires pour chaque carte Énergie défaussée de cette façon."
 			},
 			damage: 100,
 

--- a/data/XY/XY Black Star Promos/XY173.ts
+++ b/data/XY/XY Black Star Promos/XY173.ts
@@ -34,7 +34,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may discard a Fire Energy card from your hand. If you do, during this turn, your Basic Fire Pokémon's attacks do 30 more damage to your opponent's Active Pokémon (before applying Weakness and Resistance).",
-				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez défausser une carte Énergie  de votre main. Dans ce cas, pendant ce tour, les attaques de vos Pokémon  de base infligent 30 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance)."
+				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez défausser une carte Énergie {R} de votre main. Dans ce cas, pendant ce tour, les attaques de vos Pokémon {R} de base infligent 30 dégâts supplémentaires au Pokémon Actif de votre adversaire (avant application de la Faiblesse et de la Résistance)."
 			},
 		},
 	],

--- a/data/XY/XY Black Star Promos/XY175.ts
+++ b/data/XY/XY Black Star Promos/XY175.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Prevent all effects of your opponent's attacks, except damage, done to each of your Pokémon that has any Metal Energy attached to it. (Existing effects are not removed.)",
-				fr: "Évitez tous les effets des attaques de votre adversaire, excepté les dégâts, infligés à chacun de vos Pokémon auquel de l'Énergie  est attachée. (Les effets déjà en action ne sont pas retirés.)"
+				fr: "Évitez tous les effets des attaques de votre adversaire, excepté les dégâts, infligés à chacun de vos Pokémon auquel de l'Énergie {M} est attachée. (Les effets déjà en action ne sont pas retirés.)"
 			},
 		},
 	],

--- a/data/XY/XY Black Star Promos/XY185.ts
+++ b/data/XY/XY Black Star Promos/XY185.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin for each Fire Energy attached to this Pokémon. This attack does 50 damage times the number of heads.",
-				fr: "Lancez une pièce pour chaque Énergie  attachée à ce Pokémon. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face."
+				fr: "Lancez une pièce pour chaque Énergie {R} attachée à ce Pokémon. Cette attaque inflige 50 dégâts multipliés par le nombre de côtés face."
 			},
 			damage: 50,
 

--- a/data/XY/XY Black Star Promos/XY189.ts
+++ b/data/XY/XY Black Star Promos/XY189.ts
@@ -50,7 +50,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to this Pokémon.",
-				fr: "Défaussez une Énergie  attachée à ce Pokémon."
+				fr: "Défaussez une Énergie {R} attachée à ce Pokémon."
 			},
 			damage: 50,
 

--- a/data/XY/XY Black Star Promos/XY190.ts
+++ b/data/XY/XY Black Star Promos/XY190.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for a Water Pokémon, reveal it, and put it into your hand. Shuffle your deck afterward.",
-				fr: "Cherchez un Pokémon  dans votre deck, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck."
+				fr: "Cherchez un Pokémon {W} dans votre deck, montrez-le, puis ajoutez-le à votre main. Mélangez ensuite votre deck."
 			},
 
 		},

--- a/data/XY/XY Black Star Promos/XY191.ts
+++ b/data/XY/XY Black Star Promos/XY191.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "This Pokémon's attacks do 50 more damage to your opponent's Darkness Pokémon (before applying Weakness and Resistance).",
-				fr: "Les attaques de ce Pokémon infligent 50 dégâts supplémentaires aux Pokémon  de votre adversaire (avant application de la Faiblesse et de la Résistance)."
+				fr: "Les attaques de ce Pokémon infligent 50 dégâts supplémentaires aux Pokémon {D} de votre adversaire (avant application de la Faiblesse et de la Résistance)."
 			},
 		},
 	],

--- a/data/XY/XY Black Star Promos/XY197.ts
+++ b/data/XY/XY Black Star Promos/XY197.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Choose Grass, Fire, Water, Lightning, Psychic, Fighting, Darkness, Metal, Fairy, or Dragon type. Until the end of your next turn, this Pokémon is that type.",
-				fr: "Choisissez le type , , , , , , , ,  ou . Jusqu'à la fin de votre prochain tour, ce Pokémon est de ce type."
+				fr: "Choisissez le type {G}, {R}, {W}, {L}, {P}, {F}, {D}, {M}, {Y} ou {N}. Jusqu'à la fin de votre prochain tour, ce Pokémon est de ce type."
 			},
 
 		},

--- a/data/XY/XY Black Star Promos/XY200.ts
+++ b/data/XY/XY Black Star Promos/XY200.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "This attack does 10 damage to each of your opponent's Benched Pokémon for each Colorless in that Pokémon's Retreat Cost. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire pour chaque  dans le Coût de Retraite du Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
+				fr: "Cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire pour chaque {C} dans le Coût de Retraite du Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
 			},
 			damage: 120,
 

--- a/data/XY/XY Black Star Promos/XY200a.ts
+++ b/data/XY/XY Black Star Promos/XY200a.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "This attack does 10 damage to each of your opponent's Benched Pokémon for each Colorless in that Pokémon's Retreat Cost. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire pour chaque  dans le Coût de Retraite du Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
+				fr: "Cette attaque inflige 10 dégâts à chacun des Pokémon de Banc de votre adversaire pour chaque {C} dans le Coût de Retraite du Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)"
 			},
 			damage: 120,
 

--- a/data/XY/XY Black Star Promos/XY202.ts
+++ b/data/XY/XY Black Star Promos/XY202.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for a Lightning Energy card and attach it to this Pokémon. Shuffle your deck afterward.",
-				fr: "Cherchez une carte Énergie  dans votre deck et attachez-la à ce Pokémon. Mélangez ensuite votre deck."
+				fr: "Cherchez une carte Énergie {L} dans votre deck et attachez-la à ce Pokémon. Mélangez ensuite votre deck."
 			},
 
 		},

--- a/data/XY/XY Black Star Promos/XY84.ts
+++ b/data/XY/XY Black Star Promos/XY84.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard all Lightning Energy attached to this Pokémon. This attack does 50 damage times the number of Energy cards you discarded.",
-				fr: "Défaussez toutes les Énergies  attachées à ce Pokémon. Cette attaque inflige 50 dégâts multipliés par le nombre de cartes Énergies que vous avez défaussées."
+				fr: "Défaussez toutes les Énergies {L} attachées à ce Pokémon. Cette attaque inflige 50 dégâts multipliés par le nombre de cartes Énergies que vous avez défaussées."
 			},
 			damage: "50×",
 

--- a/data/XY/XY Black Star Promos/XY94.ts
+++ b/data/XY/XY Black Star Promos/XY94.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as this Pokémon is your Active Pokémon, your opponent's Basic Pokémon's attacks cost Colorless more.",
-				fr: "Tant que ce Pokémon est votre Pokémon Actif, les attaques des Pokémon de base de votre adversaire coûtent  de plus."
+				fr: "Tant que ce Pokémon est votre Pokémon Actif, les attaques des Pokémon de base de votre adversaire coûtent {C} de plus."
 			},
 		},
 	],


### PR DESCRIPTION
## Changes

Same loss as #2273 to #2276, this time in XY Black Star Promos (`xyp`): the inline energy symbols were dropped from the French rules text, leaving only the space they sat in.

```
en: "Choose Grass, Fire, Water, Lightning, Psychic, Fighting, Darkness, Metal, Fairy, or Dragon type. ..."
fr: "Choisissez le type , , , , , , , ,  ou . Jusqu'à la fin de votre prochain tour, ..."
```

**28 symbols** restored, in **18 strings** across **18 cards**. Only `fr` values change — 18 lines in, 18 lines out.

## Details

This set carries no German text, so every symbol comes from the type the English string spells out in the same clause, in the English word order. A gap only counts as a lost symbol when the number of gaps matches the number of types the English string names exactly — `XY197` above lines up 10 for 10, `XY173` 2 for 2 (`carte Énergie {R}` then `Pokémon {R} de base`).

Three of them sit outside the `carte Énergie …` pattern and are just as unambiguous: `pour chaque {C} dans le Coût de Retraite` (`XY200`, `XY200a`, from `for each Colorless in that Pokémon's Retreat Cost`) and `coûtent {C} de plus` (`XY94`, from `attacks cost Colorless more`).

`npm run validate` passes. No English string was modified.

Fifth set of the series, after #2273 (`ecard2`), #2274 (`neo4`), #2275 (`ecard1`) and #2276 (`ex16`), one PR each.
