### PR TITLE
fix(data): Restore the energy symbols lost from EX Dragon French text

### DIFF
--- a/data/EX/Dragon/100.ts
+++ b/data/EX/Dragon/100.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your discard pile for 2 Fire Energy cards and attach them to Charizard (1 if there is only 1).",
-				fr: "Lancez une pièce. Si c'est face, cherchez dans votre pile de défausse deux cartes Énergie  (ou une s'il n'y en a qu'une) et attachez-les à Dracaufeu.",
+				fr: "Lancez une pièce. Si c'est face, cherchez dans votre pile de défausse deux cartes Énergie {R} (ou une s'il n'y en a qu'une) et attachez-les à Dracaufeu.",
 				de: "Wirf 1 Münze. Durchsuche bei „Kopf“ deinen Ablagestapel nach 2 {R}-Energiekarten und lege sie an Glurak an (1 falls nur 1 vorhanden)."
 			},
 			damage: 30,
@@ -62,7 +62,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may discard a Fire Energy card attached to Charizard. If you do, choose 1 of your opponent's Benched Pokémon and do 30 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Vous pouvez défausser une carte Énergie  attachée à Dracaufeu. Vous pouvez alors choisir un des Pokémon de Banc de votre adversaire et lui infliger 30 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
+				fr: "Vous pouvez défausser une carte Énergie {R} attachée à Dracaufeu. Vous pouvez alors choisir un des Pokémon de Banc de votre adversaire et lui infliger 30 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
 				de: "Du darfst 1 an Glurak abgelegte {R}-Energie auf deinen Ablagestapel legen, wenn du diesen Angriff einsetzt. Wenn du das machst, wähle 1 Pokémon auf der Bank deines Gegners und dieser Angriff fügt ihm 30 Schadenspunkte zu. (Schwäche und Resistenz für Pokémon auf der Bank nicht anwenden.)"
 			},
 			damage: 60,

--- a/data/EX/Dragon/12.ts
+++ b/data/EX/Dragon/12.ts
@@ -51,7 +51,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "The Defending Pokémon is now Burned. Flip a coin. If tails, discard a Fire Energy card attached to Torkoal.",
-				fr: "Le Pokémon Défenseur est maintenant Brûlé. Lancez une pièce. Si c'est pile, défaussez une carte Énergie  attachée à Chartor.",
+				fr: "Le Pokémon Défenseur est maintenant Brûlé. Lancez une pièce. Si c'est pile, défaussez une carte Énergie {R} attachée à Chartor.",
 				de: "Das Verteidigende Pokémon ist jetzt verbrannt. Wirf 1 Münze. Bei „Zahl“ lege 1 an Qurtel angelegt {R}-Energiekarte auf deinen Ablagestapel."
 			},
 

--- a/data/EX/Dragon/16.ts
+++ b/data/EX/Dragon/16.ts
@@ -52,7 +52,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 10 damage for each Colorless Energy in that Pokémon's Retreat Cost to that Pokémon (after applying effects to the Retreat Cost). (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Choisissez un des Pokémon de votre adversaire. Cette attaque lui inflige 10 dégâts pour chaque Énergie  de son Coût de retraite (après application des effets sur le Coût de retraite). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
+				fr: "Choisissez un des Pokémon de votre adversaire. Cette attaque lui inflige 10 dégâts pour chaque Énergie {C} de son Coût de retraite (après application des effets sur le Coût de retraite). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc).",
 				de: "Wähle 1 gegnerisches Pokémon. Dieser Angriff fügt 10 Schadenspunkte für jede {C}-Energie in den Rückzugskosten des gewählten Pokémon zu (nachdem alle Effekte auf die Rückzugskosten verrechnet wurden). (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 

--- a/data/EX/Dragon/18.ts
+++ b/data/EX/Dragon/18.ts
@@ -58,7 +58,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may switch Ninjask with 1 of your Benched Pokémon. If you do, you may move any number of Grass Energy cards attached to Ninjask to the new Active Pokémon.",
-				fr: "Vous pouvez échanger Ninjask contre un des Pokémon de votre Banc. Vous pouvez alors attacher au nouveau Pokémon Actif autant de cartes Énergie  attachées à Ninjask que vous le voulez.",
+				fr: "Vous pouvez échanger Ninjask contre un des Pokémon de votre Banc. Vous pouvez alors attacher au nouveau Pokémon Actif autant de cartes Énergie {G} attachées à Ninjask que vous le voulez.",
 				de: "Du kannst Ninjask gegen 1 Pokémon auf deiner Bank austauschen. Wenn du das machst, kannst du beliebig viele an Ninjask angelegte {G}-Energiekarten an das neue Aktive Pokémon anlegen."
 			},
 			damage: 30,

--- a/data/EX/Dragon/34.ts
+++ b/data/EX/Dragon/34.ts
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy card attached to Houndoom.",
-				fr: "Défaussez une carte Énergie  attachée à Démolosse.",
+				fr: "Défaussez une carte Énergie {R} attachée à Démolosse.",
 				de: "Entferne 1 {R}-Energiekarte von Hundemon und lege sie auf den Ablagestapel."
 			},
 			damage: 50,

--- a/data/EX/Dragon/57.ts
+++ b/data/EX/Dragon/57.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Grass Energy card attached to Grimer. The Defending Pokémon is now Poisoned.",
-				fr: "Défaussez une carte Énergie  attachée à Tadmorv. Le Pokémon Défenseur est maintenant Empoisonné.",
+				fr: "Défaussez une carte Énergie {G} attachée à Tadmorv. Le Pokémon Défenseur est maintenant Empoisonné.",
 				de: "Entferne 1 {G}-Energiekarte von Sleima und lege sie auf den Ablagestapel. Das Verteidigende Pokémon ist jetzt vergiftet."
 			},
 

--- a/data/EX/Dragon/65.ts
+++ b/data/EX/Dragon/65.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 10 damage plus 10 more damage for each Water Energy attached to Mudkip but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
-				fr: "Cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Gobou qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
+				fr: "Cette attaque inflige 10 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {W} attachée à Gobou qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
 				de: "Dieser Angriff fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Hydropi angelegte {W}-Energiekarte zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 20 Schadenspunkte hinzufügen."
 			},
 			damage: "10+",

--- a/data/EX/Dragon/70.ts
+++ b/data/EX/Dragon/70.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy card attached to Numel and then discard an Energy card attached to the Defending Pokémon.",
-				fr: "Défaussez une carte Énergie  attachée à Chamallot puis une carte Énergie attachée au Pokémon Défenseur.",
+				fr: "Défaussez une carte Énergie {R} attachée à Chamallot puis une carte Énergie attachée au Pokémon Défenseur.",
 				de: "Lege 1 {R}-Energiekarte von Camaub auf deinen Ablagestapel und lege danach eine Energiekarte vom Verteidigenden Pokémon auf den Ablagestapel deines Gegners."
 			},
 			damage: 10,

--- a/data/EX/Dragon/81.ts
+++ b/data/EX/Dragon/81.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for Grass Basic Pokémon and put as many of them as you like onto your Bench. Shuffle your deck afterward.",
-				fr: "Cherchez dans votre deck des Pokémon de base  et placez-en autant que vous le voulez sur votre Banc. Ensuite, mélangez votre deck.",
+				fr: "Cherchez dans votre deck des Pokémon de base {G} et placez-en autant que vous le voulez sur votre Banc. Ensuite, mélangez votre deck.",
 				de: "Durchsuche dein Deck nach {G}-Basis-Pokémon-Karten und lege beliebige viele von ihnen auf deine Bank. Mische dein Deck danach."
 			},
 

--- a/data/EX/Dragon/9.ts
+++ b/data/EX/Dragon/9.ts
@@ -51,7 +51,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Attach up to 2 Grass Energy cards from your hand to your Pokémon in any way you like.",
-				fr: "Attachez jusqu'à deux cartes Énergie  de votre main à vos Pokémon de la façon que vous voulez.",
+				fr: "Attachez jusqu'à deux cartes Énergie {G} de votre main à vos Pokémon de la façon que vous voulez.",
 				de: "Lege bis zu 2 {G}-Energiekarten von deiner Hand an deine Pokémon an."
 			},
 

--- a/data/EX/Dragon/90.ts
+++ b/data/EX/Dragon/90.ts
@@ -59,7 +59,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Water Energy card and a Lightning Energy card attached to Dragonite ex.",
-				fr: "Défaussez une carte Énergie  et une carte Énergie  attachée à Dracolosse ex.",
+				fr: "Défaussez une carte Énergie {W} et une carte Énergie {L} attachée à Dracolosse ex.",
 				de: "Entferne 1 {W}-Energiekarte und 1 {L}-Energiekarte, die an Dragoran ex angelegt sind, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 70,

--- a/data/EX/Dragon/92.ts
+++ b/data/EX/Dragon/92.ts
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 50 damage plus 20 more damage for each Water Energy attached to Kingdra ex but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way.",
-				fr: "Inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque carte Énergie  attachée à Hyporoi ex qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 40 dégâts de cette façon.",
+				fr: "Inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque carte Énergie {W} attachée à Hyporoi ex qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 40 dégâts de cette façon.",
 				de: "Dieser Angriff fügt 50 Schadenspunkte plus 20 weitere Schadenspunkte für jede an Seedraking ex angelegte {W}-Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 40 Schadenspunkte hinzufügen."
 			},
 			damage: "50+",

--- a/data/EX/Dragon/93.ts
+++ b/data/EX/Dragon/93.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy and a Water Energy attached to Latias ex.",
-				fr: "Défaussez une Énergie  et une Énergie  attachée à Latias ex.",
+				fr: "Défaussez une Énergie {R} et une Énergie {W} attachée à Latias ex.",
 				de: "Entferne 1 {R}-Energie und 1 {W}-Energie, die an Latias ex angelegt sind und lege sie auf deinen Ablagestapel."
 			},
 			damage: 100,

--- a/data/EX/Dragon/96.ts
+++ b/data/EX/Dragon/96.ts
@@ -77,7 +77,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost).",
-				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  dans le Coût de retraite du Pokémon Défenseur (après application des effets sur le Coût de retraite).",
+				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {C} dans le Coût de retraite du Pokémon Défenseur (après application des effets sur le Coût de retraite).",
 				de: "Fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede {C}-Energie in den Rückzugskosten des Verteidigenden Pokémon (nachdem Effekte auf die Rückzugskosten verrechnet wurden)."
 			},
 			damage: "40+",

--- a/data/EX/Dragon/97.ts
+++ b/data/EX/Dragon/97.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard either all Fire Energy or all Lightning Energy attached to Rayquaza ex. This attack does 40 damage times the amount of Fire or Lightning Energy discarded.",
-				fr: "Défaussez soit toutes les Énergies  soit toutes les Énergies  attachées à Rayquaza ex. Cette attaque inflige 40 dégâts multipliés par le nombre d'Énergie  ou  défaussées.",
+				fr: "Défaussez soit toutes les Énergies {R} soit toutes les Énergies {L} attachées à Rayquaza ex. Cette attaque inflige 40 dégâts multipliés par le nombre d'Énergie {R} ou {L} défaussées.",
 				de: "Entferne entweder jede {R}-Energie oder jede {L}-Energie, die an Rayquaza ex angelegt ist, und lege sie auf deinen Ablagestapel. Dieser Angriff fügt für jede auf diese Weise abgelegte Energie 40 Schadenspunkte zu."
 			},
 			damage: "40×",

--- a/data/EX/Dragon/99.ts
+++ b/data/EX/Dragon/99.ts
@@ -59,7 +59,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy card attached to Charmeleon.",
-				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie  attachée à Reptincel.",
+				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie {R} attachée à Reptincel.",
 				de: "Wirf 1 Münze. Entferne bei „Zahl“ eine {R}-Energiekarte von Glutexo."
 			},
 			damage: 40,


### PR DESCRIPTION
## Changes

Same loss as #2273 to #2277, this time in EX Dragon (`ex3`): the inline energy symbols were dropped from the French rules text, leaving only the space they sat in.

```
en: "Discard either all Fire Energy or all Lightning Energy attached to Rayquaza ex. ..."
fr: "Défaussez soit toutes les Énergies  soit toutes les Énergies  attachées à Rayquaza ex. ..."
```

**22 symbols** restored, in **17 strings** across **16 cards**. Only `fr` values change — 17 lines in, 17 lines out.

## Details

Each symbol comes from the type the English string spells out in the same clause, in the English word order, and 16 of the 17 strings are confirmed by the German token (`97.ts` is the one where German phrases the second half without a type). A gap only counts as a lost symbol when the counts match exactly — `97.ts` lines up 4 for 4 (`Énergies {R}` / `Énergies {L}` / `Énergie {R} ou {L}`), `90.ts` and `93.ts` 2 for 2.

Two sit outside the `carte Énergie …` pattern and are unambiguous in both languages: `des Pokémon de base {G}` (81, from `Grass Basic Pokémon`) and `pour chaque Énergie {C} de son Coût de retraite` (16).

`npm run validate` passes. No English or German string was modified.

Sixth set of the series, after #2273, #2274, #2275, #2276 and #2277, one PR each.
