### PR TITLE
fix(data): Restore the energy symbols lost from EX Deoxys French text

### DIFF
--- a/data/EX/Deoxys/101.ts
+++ b/data/EX/Deoxys/101.ts
@@ -62,7 +62,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard all Lightning Energy attached to Manectric ex and then choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Défaussez toutes les Énergies  attachées à Elecsprint ex puis choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 80 dégâts (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc).",
+				fr: "Défaussez toutes les Énergies {L} attachées à Elecsprint ex puis choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 80 dégâts (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc).",
 				de: "Discard all  Energy attached to Manectric ex and then choose 1 of your opponent's Pokémon. This attack does 80 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
 			},
 

--- a/data/EX/Deoxys/104.ts
+++ b/data/EX/Deoxys/104.ts
@@ -62,7 +62,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may discard a Darkness Energy attached to Sharpedo ex. If you do, this attack does 60 damage plus 20 more damage and discard 1 Energy card attached to the Defending Pokémon.",
-				fr: "Vous pouvez défausser une Énergie  attachée à Sharpedo ex. Cette attaque inflige alors 60 dégâts plus 20 dégâts supplémentaires. Défaussez une carte Énergie attachée au Pokémon Défenseur.",
+				fr: "Vous pouvez défausser une Énergie {D} attachée à Sharpedo ex. Cette attaque inflige alors 60 dégâts plus 20 dégâts supplémentaires. Défaussez une carte Énergie attachée au Pokémon Défenseur.",
 				de: "You may discard a  Energy attached to Sharpedo ex. If you do, this attack does 60 damage plus 20 more damage and discard 1 Energy card attached to the Defending Pokémon."
 			},
 			damage: "60+",

--- a/data/EX/Deoxys/108.ts
+++ b/data/EX/Deoxys/108.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Lightning Energy attached to Rocket's Raikou ex.",
-				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Raikou ex de Rocket.",
+				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {L} attachée à Raikou ex de Rocket.",
 				de: "Does 40 damage plus 10 more damage for each  Energy attached to Rocket's Raikou ex."
 			},
 			damage: "40+",
@@ -62,7 +62,7 @@ const card: Card = {
 		},
 
 		effect: {
-			fr: "Lorsque vous attachez une carte Énergie  de votre main à Raikou ex de Rocket, vous pouvez choisir 1 des Pokémon Défenseurs et l'échanger avec 1 des Pokémon de Banc de votre adversaire. Votre adversaire choisit le Pokémon de Banc à échanger. Ce pouvoir ne peut pas être utilisé si Raikou ex de Rocket est affecté par un État Spécial.",
+			fr: "Lorsque vous attachez une carte Énergie {D} de votre main à Raikou ex de Rocket, vous pouvez choisir 1 des Pokémon Défenseurs et l'échanger avec 1 des Pokémon de Banc de votre adversaire. Votre adversaire choisit le Pokémon de Banc à échanger. Ce pouvoir ne peut pas être utilisé si Raikou ex de Rocket est affecté par un État Spécial.",
 			de: "Whenever you attach a  Energy card from your hand to Rocket's Raikou ex, you may choose 1 of the Defending Pokémon and Switch it with 1 of your opponent's Benched Pokémon. Your opponent choose the Benched Pokémon to switch. This power can't be used if Rocket's Raikou ex is affected by a Special Condition"
 		},
 

--- a/data/EX/Deoxys/11.ts
+++ b/data/EX/Deoxys/11.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may search your discard pile for a Psychic or Metal Energy card and attach it to your Active Pokémon. Then, put 1 damage counter on that Pokémon. This power can't be used if Metagross is affected by a Special Condition.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez chercher dans votre pile de défausse une carte Énergie  ou  et l'attacher à votre Pokémon Actif. Placez alors un marqueur de dégât sur ce Pokémon. Ce pouvoir ne peut pas être utilisé si Metalosse est affecté par un État Spécial.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez chercher dans votre pile de défausse une carte Énergie {P} ou {M} et l'attacher à votre Pokémon Actif. Placez alors un marqueur de dégât sur ce Pokémon. Ce pouvoir ne peut pas être utilisé si Metalosse est affecté par un État Spécial.",
 				de: "Once during your turn (before your attack), you may search your discard pile for a  or  Energy card and attach it to your Active Pokémon. Then, put 1 damage counter on that Pokémon. This power can't be used if Metagross is affected by a Special Condition."
 			},
 		},

--- a/data/EX/Deoxys/19.ts
+++ b/data/EX/Deoxys/19.ts
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin for each Water Energy attached to Ludicolo. This attack does 40 damage plus 20 more damage for each heads.",
-				fr: "Lancez une pièce pour chaque Énergie  attachée à Ludicolo. Cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires multipliés par le nombre de faces.",
+				fr: "Lancez une pièce pour chaque Énergie {W} attachée à Ludicolo. Cette attaque inflige 40 dégâts plus 20 dégâts supplémentaires multipliés par le nombre de faces.",
 				de: "Flip a coin for each  Energy attached to Ludicolo. This attack does 40 damage plus 20 more damage for each heads."
 			},
 			damage: "40+",

--- a/data/EX/Deoxys/22.ts
+++ b/data/EX/Deoxys/22.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Rayquaza has any basic Fire Energy cards and any basic Lightning Energy cards attached to it, prevent all effects, except damage, by an opponent's attack done to Rayquaza.",
-				fr: "Tant que Rayquaza possède des cartes Énergie de base  et , prévenez tous les effets, dégâts inclus, infligés à Rayquaza par une attaque de votre adversaire.",
+				fr: "Tant que Rayquaza possède des cartes Énergie de base {R} et {L}, prévenez tous les effets, dégâts inclus, infligés à Rayquaza par une attaque de votre adversaire.",
 				de: "As long as Rayquaza has any basic  Energy cards and any basic  Energy card attached to it, prevent all effects, except damage, by an opponent's attack done to Rayquaza."
 			},
 		},

--- a/data/EX/Deoxys/26.ts
+++ b/data/EX/Deoxys/26.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Skarmory has any Metal Energy attached to it, the Retreat Cost for Skarmory is 0.",
-				fr: "Si Airmure possède une Énergie , son Coût de retraite est de 0.",
+				fr: "Si Airmure possède une Énergie {M}, son Coût de retraite est de 0.",
 				de: "If Skarmory has nay  Energy attached to it, the Retreat Cost for Skarmory is 0."
 			},
 		},
@@ -70,7 +70,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin for each Metal Energy attached to Skarmory. This attack does 10 damage plus 20 more damage for each heads.",
-				fr: "Lancez une pièce pour chaque Énergie  attachée à Airmure. Cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires multipliés par le nombre de faces.",
+				fr: "Lancez une pièce pour chaque Énergie {M} attachée à Airmure. Cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires multipliés par le nombre de faces.",
 				de: "Flip a coin for each  Energy attached to Skarmory. This attack does 10 damage plus 20 more danage for each heads."
 			},
 			damage: "10+",

--- a/data/EX/Deoxys/3.ts
+++ b/data/EX/Deoxys/3.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Breloom has any Grass Energy attached to it, the Defending Pokémon is now Poisoned.",
-				fr: "Si Chapignon possède des Énergies , le Pokémon Défenseur est maintenant Empoisonné.",
+				fr: "Si Chapignon possède des Énergies {G}, le Pokémon Défenseur est maintenant Empoisonné.",
 				de: "If Breloom has any  Energy attached to it, the Defending Pokémon is now Poisoned."
 			},
 			damage: 20,

--- a/data/EX/Deoxys/33.ts
+++ b/data/EX/Deoxys/33.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Lombre has any Water Energy attached to it, the Retreat Cost for Lombre is 0.",
-				fr: "Si Lombre possède une Énergie , son Coût de retraite est de 0.",
+				fr: "Si Lombre possède une Énergie {W}, son Coût de retraite est de 0.",
 				de: "If Lombre has any  Energy attached to it, the Retreat Cost of Lombre is 0."
 			},
 		},

--- a/data/EX/Deoxys/34.ts
+++ b/data/EX/Deoxys/34.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "When you attach a Water Energy card from your hand to Lombre, remove all Special Conditions from Lombre.",
-				fr: "Lorsque vous attachez une carte Énergie  de votre main à Lombre, retirez-lui tous ses États Spéciaux.",
+				fr: "Lorsque vous attachez une carte Énergie {W} de votre main à Lombre, retirez-lui tous ses États Spéciaux.",
 				de: "When you attach a  Energy card from your hand to Lombre, remove all Special Condition from Lombre."
 			},
 		},

--- a/data/EX/Deoxys/37.ts
+++ b/data/EX/Deoxys/37.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Magcargo has at least 2 Fire Energy attached to it, the Defending Pokémon is now Burned.",
-				fr: "Si Volcaropod possède au moins 2 Énergies , le Pokémon Défenseur est maintenant Brûlé.",
+				fr: "Si Volcaropod possède au moins 2 Énergies {R}, le Pokémon Défenseur est maintenant Brûlé.",
 				de: "If Magcargo has at least 2  Energy attached to it, the Defending Pokémon is now Burned."
 			},
 			damage: 50,

--- a/data/EX/Deoxys/38.ts
+++ b/data/EX/Deoxys/38.ts
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may do 40 damage plus 10 more damage for each Lightning Energy attached to Manectric. If you do, Manectric does 10 damage to itself.",
-				fr: "Vous pouvez infliger 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Elecsprint. Elecsprint s'inflige alors 10 dégâts.",
+				fr: "Vous pouvez infliger 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {L} attachée à Elecsprint. Elecsprint s'inflige alors 10 dégâts.",
 				de: "You may do 40 damage plus 10 more damage for each  Energy attached to Manectric. If you do, Manectric. If you do, Manectric does 10 damage to itself."
 			},
 			damage: "40+",

--- a/data/EX/Deoxys/48.ts
+++ b/data/EX/Deoxys/48.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Starmie has any Psychic Energy attached to it, damage done to Starmie by attacks is reduced by 10 (after applying Weakness and Resistance).",
-				fr: "Tant que Statoss possède une Énergie , les dégâts qui lui sont infligés par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
+				fr: "Tant que Statoss possède une Énergie {P}, les dégâts qui lui sont infligés par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
 				de: "As long as Starmie has any  Energy attached to it, damage done to Starmie by attacks is reduced by 10 (after applying Weakness and Resistance)."
 			},
 		},

--- a/data/EX/Deoxys/5.ts
+++ b/data/EX/Deoxys/5.ts
@@ -59,7 +59,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Claydol has any Psychic Energy attached to it, the Defending Pokémon is now Confused. If Claydol has any Fighting Energy attached to it, this attack does 20 damage plus 20 more damage.",
-				fr: "Si Kaorine possède des Énergies , le Pokémon Défenseur est maintenant Confus. Si Kaorine possède des Énergies , cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
+				fr: "Si Kaorine possède des Énergies {P}, le Pokémon Défenseur est maintenant Confus. Si Kaorine possède des Énergies {F}, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires.",
 				de: "If Claydol has any  Energy attached to it, the Defending Pokémon is now Confused. if Claydol has any  Energy attached to it, this attack does 20 damage plus 20 more damage."
 			},
 			damage: "20+",

--- a/data/EX/Deoxys/6.ts
+++ b/data/EX/Deoxys/6.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Any damage done to Crawdaunt by your opponent's attacks is reduced by 10 for each Darkness Energy attached to Crawdaunt (after applying Weakness and Resistance). You can't reduce more than 20 damage in this way.",
-				fr: "Tous dégâts infligés à Colhomard par une attaque de votre adversaire sont réduits de 10 pour chaque Énergie  attachée à Colhomard (après application de la Faiblesse et de la Résistance). Vous ne pouvez pas réduire de plus de 20 dégâts de cette façon.",
+				fr: "Tous dégâts infligés à Colhomard par une attaque de votre adversaire sont réduits de 10 pour chaque Énergie {D} attachée à Colhomard (après application de la Faiblesse et de la Résistance). Vous ne pouvez pas réduire de plus de 20 dégâts de cette façon.",
 				de: "Any damage done to Crawdount by your opponent's attacks is reduced by 10 for each  Energy attached to Crawdount (after applying Weakness and Resistance). You can't reduce more than 20 damage in this way."
 			},
 		},

--- a/data/EX/Deoxys/60.ts
+++ b/data/EX/Deoxys/60.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for a Lightning Energy card and attach it to Electrike. Shuffle your deck afterward.",
-				fr: "Cherchez dans votre deck 1 carte Énergie  et attachez-la à Dynavolt. Ensuite, mélangez votre deck.",
+				fr: "Cherchez dans votre deck 1 carte Énergie {L} et attachez-la à Dynavolt. Ensuite, mélangez votre deck.",
 				de: "Search your deck for a  Energy card and attach it to Electrike. Shuffle your deck afterward."
 			},
 

--- a/data/EX/Deoxys/85.ts
+++ b/data/EX/Deoxys/85.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "Attach Crystal Shard to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. As long as this card is attached to a Pokémon, that Pokémon's type is Colorless. If that Pokémon attacks, discard this card at the end of the turn.",
-		fr: "Attachez Écharde de cristal à 1 de vos Pokémon qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O., défaussez-la.\n\nTant que cette carte est attachée à un Pokémon, ce Pokémon est de type . S'il attaque, défaussez cette carte à la fin du tour.",
+		fr: "Attachez Écharde de cristal à 1 de vos Pokémon qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O., défaussez-la.\n\nTant que cette carte est attachée à un Pokémon, ce Pokémon est de type {C}. S'il attaque, défaussez cette carte à la fin du tour.",
 		de: "So lange diese Karte an ein Pokémon angelegt ist, ist der Typ (Farbe) dieses Pokémon . Greift das Pokémon an, lege diese Karte am Ende des Zuges auf deinen Ablagestapel."
 	},
 


### PR DESCRIPTION
## Changes

Same loss as #2273 to #2278, this time in EX Deoxys (`ex8`): the inline energy symbols were dropped from the French rules text, leaving only the space they sat in.

```
en: "Flip a coin for each Lightning Energy attached to Raikou. ..."
fr: "Lancez une pièce pour chaque Énergie  attachée à Raikou. ..."
```

**22 symbols** restored, in **19 strings** across **17 cards**. Only `fr` values change — 19 lines in, 19 lines out.

## Details

This set carries no German text, so every symbol comes from the type the English string spells out in the same clause, in the English word order. A gap only counts as a lost symbol when the number of gaps matches the number of types the English string names exactly — `5.ts` lines up 2 for 2 (`Énergies {P}` then `Énergies {F}`), `11.ts` fills the first half of `carte Énergie {P} ou {M}`.

One card had to be sourced elsewhere: **108 `Raikou ex de Rocket`**, whose Poké-POWER has no English string in the database at all (and whose `de` field holds an English sentence that lost its own symbol). [Bulbapedia](https://bulbapedia.bulbagarden.net/wiki/Rocket%27s_Raikou_ex_(EX_Deoxys_108)) gives `Whenever you attach a Darkness Energy card from your hand`, which matches the card's own `Darkness` type, so the French reads `une carte Énergie {D} de votre main`.

## Out of scope

On that same card, `108.ts` carries an English sentence in its `de` ability effect and `Thunderderous Blow` as its `de` attack name, and the `en` ability effect is missing. Untouched here.

`npm run validate` passes. No English or German string was modified.

Seventh set of the series, after #2273, #2274, #2275, #2276, #2277 and #2278, one PR each.
