### PR TITLE
fix(data): Restore the energy symbols lost from SWSH promos French text

### DIFF
--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH139.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH139.ts
@@ -28,7 +28,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Lightning Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {L} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Lightning", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH140.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH140.ts
@@ -28,7 +28,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Lightning Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {L} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Lightning", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH141.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH141.ts
@@ -28,7 +28,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Lightning Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {L} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Lightning", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH142.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH142.ts
@@ -28,7 +28,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Lightning Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {L} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Lightning", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH155.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH155.ts
@@ -78,7 +78,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Water Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {W} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH156.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH156.ts
@@ -78,7 +78,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Water Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {W} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH157.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH157.ts
@@ -78,7 +78,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Water Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {W} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH158.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH158.ts
@@ -78,7 +78,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Water Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {W} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Water"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH159.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH159.ts
@@ -64,7 +64,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Psychic Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {P} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Psychic", "Psychic", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH160.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH160.ts
@@ -64,7 +64,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Psychic Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {P} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Psychic", "Psychic", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH161.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH161.ts
@@ -64,7 +64,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Psychic Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {P} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Psychic", "Psychic", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH162.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH162.ts
@@ -64,7 +64,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Psychic Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {P} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Psychic", "Psychic", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH163.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH163.ts
@@ -50,7 +50,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Metal Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {M} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Metal", "Metal", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH164.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH164.ts
@@ -50,7 +50,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Metal Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {M} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Metal", "Metal", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH165.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH165.ts
@@ -50,7 +50,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Metal Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {M} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Metal", "Metal", "Colorless"],

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH166.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH166.ts
@@ -50,7 +50,7 @@ const card: Card = {
 
 		effect: {
 			en: "Attach up to 2 Metal Energy cards from your discard pile to this Pokémon.",
-			fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à ce Pokémon."
+			fr: "Attachez jusqu'à 2 cartes Énergie {M} de votre pile de défausse à ce Pokémon."
 		}
 	}, {
 		cost: ["Metal", "Metal", "Colorless"],


### PR DESCRIPTION
## Changes

Same loss as #2273 to #2282, this time in SWSH Black Star Promos (`swshp`): the inline energy symbols were dropped from the French rules text, leaving only the space they sat in.

```
en: "Attach up to 2 Lightning Energy cards from your discard pile to your Pokémon in any way you like."
fr: "Attachez jusqu'à 2 cartes Énergie  de votre pile de défausse à vos Pokémon, comme il vous plaît."
```

**16 symbols** restored, in **16 strings** across **16 cards**. Only `fr` values change — 16 lines in, 16 lines out.

## Details

All 16 are the same `Energy Sticker`-style attack text on the four-card runs of Pikachu (`{L}`), Squirtle (`{W}`), Ralts (`{P}`) and Klink (`{M}`) promos, each with exactly one hole and exactly one type named by the English string in the same clause, so the alignment is one-for-one throughout. This set carries no German text, so the English string is the only source, and the type matches each card's own type in all 16 cases.

`npm run validate` passes. No English string was modified.

Tenth set of the series, after #2273 to #2282, one PR each.
