### PR TITLE
feat(data): add the zh-cn card list for CSV9C 星彩晶璃

### DIFF
--- a/data-asia/SV/CSV9C/001.ts
+++ b/data-asia/SV/CSV9C/001.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "蛋蛋"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/002.ts
+++ b/data-asia/SV/CSV9C/002.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "触手百合"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/003.ts
+++ b/data-asia/SV/CSV9C/003.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "摇篮百合"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/004.ts
+++ b/data-asia/SV/CSV9C/004.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "尖牙笼"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/005.ts
+++ b/data-asia/SV/CSV9C/005.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "切割洛托姆"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/006.ts
+++ b/data-asia/SV/CSV9C/006.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "铁蚁ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/007.ts
+++ b/data-asia/SV/CSV9C/007.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "强颚鸡母虫"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/008.ts
+++ b/data-asia/SV/CSV9C/008.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "破破舵轮"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/009.ts
+++ b/data-asia/SV/CSV9C/009.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "幼棉棉"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/010.ts
+++ b/data-asia/SV/CSV9C/010.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "白蓬蓬"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/011.ts
+++ b/data-asia/SV/CSV9C/011.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "啃果虫"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/012.ts
+++ b/data-asia/SV/CSV9C/012.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "裹蜜虫"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/013.ts
+++ b/data-asia/SV/CSV9C/013.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "蜜集大蛇ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/014.ts
+++ b/data-asia/SV/CSV9C/014.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "萨戮德"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/015.ts
+++ b/data-asia/SV/CSV9C/015.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "热辣娃"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/016.ts
+++ b/data-asia/SV/CSV9C/016.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "虫滚泥"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/017.ts
+++ b/data-asia/SV/CSV9C/017.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "虫甲圣"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/018.ts
+++ b/data-asia/SV/CSV9C/018.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "古简蜗"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/019.ts
+++ b/data-asia/SV/CSV9C/019.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "斯魔茶"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/020.ts
+++ b/data-asia/SV/CSV9C/020.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "来悲粗茶ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/021.ts
+++ b/data-asia/SV/CSV9C/021.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "凤王"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/022.ts
+++ b/data-asia/SV/CSV9C/022.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "飘浮泡泡 太阳的样子"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/023.ts
+++ b/data-asia/SV/CSV9C/023.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "比克提尼"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/024.ts
+++ b/data-asia/SV/CSV9C/024.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "夜盗火蜥"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/025.ts
+++ b/data-asia/SV/CSV9C/025.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "焰后蜥"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/026.ts
+++ b/data-asia/SV/CSV9C/026.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "爆焰龟兽"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/027.ts
+++ b/data-asia/SV/CSV9C/027.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "炎兔儿"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/028.ts
+++ b/data-asia/SV/CSV9C/028.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "腾蹴小将"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/029.ts
+++ b/data-asia/SV/CSV9C/029.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "闪焰王牌ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/030.ts
+++ b/data-asia/SV/CSV9C/030.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "呆火鳄"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/031.ts
+++ b/data-asia/SV/CSV9C/031.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "炙烫鳄"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/032.ts
+++ b/data-asia/SV/CSV9C/032.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "骨纹巨声鳄"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/033.ts
+++ b/data-asia/SV/CSV9C/033.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "炭小侍"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/034.ts
+++ b/data-asia/SV/CSV9C/034.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "苍炎刃鬼ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/035.ts
+++ b/data-asia/SV/CSV9C/035.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "狠辣椒ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/036.ts
+++ b/data-asia/SV/CSV9C/036.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "破空焰"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/037.ts
+++ b/data-asia/SV/CSV9C/037.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "拉普拉斯ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/038.ts
+++ b/data-asia/SV/CSV9C/038.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "丑丑鱼"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/039.ts
+++ b/data-asia/SV/CSV9C/039.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "美纳斯"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/040.ts
+++ b/data-asia/SV/CSV9C/040.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "海豹球"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/041.ts
+++ b/data-asia/SV/CSV9C/041.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "海魔狮"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/042.ts
+++ b/data-asia/SV/CSV9C/042.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "帝牙海狮"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/043.ts
+++ b/data-asia/SV/CSV9C/043.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "无壳海兔"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/044.ts
+++ b/data-asia/SV/CSV9C/044.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "原盖海龟"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/045.ts
+++ b/data-asia/SV/CSV9C/045.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "肋骨海龟"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/046.ts
+++ b/data-asia/SV/CSV9C/046.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "几何雪花"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/047.ts
+++ b/data-asia/SV/CSV9C/047.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "磨牙彩皮鱼"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/048.ts
+++ b/data-asia/SV/CSV9C/048.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "润水鸭"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/049.ts
+++ b/data-asia/SV/CSV9C/049.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "涌跃鸭"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/050.ts
+++ b/data-asia/SV/CSV9C/050.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "狂欢浪舞鸭"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/051.ts
+++ b/data-asia/SV/CSV9C/051.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "轻身鳕"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/052.ts
+++ b/data-asia/SV/CSV9C/052.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "铁包袱"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/053.ts
+++ b/data-asia/SV/CSV9C/053.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "古剑豹"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/054.ts
+++ b/data-asia/SV/CSV9C/054.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "皮卡丘ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/055.ts
+++ b/data-asia/SV/CSV9C/055.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "小磁怪"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/056.ts
+++ b/data-asia/SV/CSV9C/056.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "三合一磁怪"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/057.ts
+++ b/data-asia/SV/CSV9C/057.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "自爆磁怪"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/058.ts
+++ b/data-asia/SV/CSV9C/058.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "电击兽"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/059.ts
+++ b/data-asia/SV/CSV9C/059.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "电击魔兽"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/060.ts
+++ b/data-asia/SV/CSV9C/060.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "灯笼鱼"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/061.ts
+++ b/data-asia/SV/CSV9C/061.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "电灯怪"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/062.ts
+++ b/data-asia/SV/CSV9C/062.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "洛托姆"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/063.ts
+++ b/data-asia/SV/CSV9C/063.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "电电虫"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/064.ts
+++ b/data-asia/SV/CSV9C/064.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "电蜘蛛ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/065.ts
+++ b/data-asia/SV/CSV9C/065.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "泥巴鱼"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/066.ts
+++ b/data-asia/SV/CSV9C/066.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "虫电宝"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/067.ts
+++ b/data-asia/SV/CSV9C/067.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "锹农炮虫"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/068.ts
+++ b/data-asia/SV/CSV9C/068.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "卡璞・鸣鸣"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/069.ts
+++ b/data-asia/SV/CSV9C/069.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "捷拉奥拉"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/070.ts
+++ b/data-asia/SV/CSV9C/070.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "密勒顿"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/071.ts
+++ b/data-asia/SV/CSV9C/071.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "呆呆兽"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/072.ts
+++ b/data-asia/SV/CSV9C/072.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "呆呆王"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/073.ts
+++ b/data-asia/SV/CSV9C/073.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "波克比"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/074.ts
+++ b/data-asia/SV/CSV9C/074.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "波克基古"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/075.ts
+++ b/data-asia/SV/CSV9C/075.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "波克基斯"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/076.ts
+++ b/data-asia/SV/CSV9C/076.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "玛力露"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/077.ts
+++ b/data-asia/SV/CSV9C/077.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "玛力露丽"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/078.ts
+++ b/data-asia/SV/CSV9C/078.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "拉帝亚斯ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/079.ts
+++ b/data-asia/SV/CSV9C/079.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "拉帝欧斯"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/080.ts
+++ b/data-asia/SV/CSV9C/080.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "飘飘球"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/081.ts
+++ b/data-asia/SV/CSV9C/081.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "随风球"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/082.ts
+++ b/data-asia/SV/CSV9C/082.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "由克希"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/083.ts
+++ b/data-asia/SV/CSV9C/083.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "艾姆利多"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/084.ts
+++ b/data-asia/SV/CSV9C/084.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "亚克诺姆"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/085.ts
+++ b/data-asia/SV/CSV9C/085.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "克雷色利亚"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/086.ts
+++ b/data-asia/SV/CSV9C/086.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "哭哭面具"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/087.ts
+++ b/data-asia/SV/CSV9C/087.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "迭失棺"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/088.ts
+++ b/data-asia/SV/CSV9C/088.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "妙喵"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/089.ts
+++ b/data-asia/SV/CSV9C/089.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "超能妙喵"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/090.ts
+++ b/data-asia/SV/CSV9C/090.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "仙子伊布ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/091.ts
+++ b/data-asia/SV/CSV9C/091.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "咚咚鼠"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/092.ts
+++ b/data-asia/SV/CSV9C/092.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "花舞鸟"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/093.ts
+++ b/data-asia/SV/CSV9C/093.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "沙丘娃"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/094.ts
+++ b/data-asia/SV/CSV9C/094.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "噬沙堡爷ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/095.ts
+++ b/data-asia/SV/CSV9C/095.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "振翼发"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/096.ts
+++ b/data-asia/SV/CSV9C/096.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "索财灵"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/097.ts
+++ b/data-asia/SV/CSV9C/097.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "猴怪"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/098.ts
+++ b/data-asia/SV/CSV9C/098.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "火暴猴"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/099.ts
+++ b/data-asia/SV/CSV9C/099.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "弃世猴"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/100.ts
+++ b/data-asia/SV/CSV9C/100.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "大颚蚁"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/101.ts
+++ b/data-asia/SV/CSV9C/101.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "超音波幼虫"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/102.ts
+++ b/data-asia/SV/CSV9C/102.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "沙漠蜻蜓ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/103.ts
+++ b/data-asia/SV/CSV9C/103.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "海兔兽"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/104.ts
+++ b/data-asia/SV/CSV9C/104.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "土地云"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/105.ts
+++ b/data-asia/SV/CSV9C/105.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "顽皮熊猫"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/106.ts
+++ b/data-asia/SV/CSV9C/106.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "蒂安希"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/107.ts
+++ b/data-asia/SV/CSV9C/107.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "拳拳蛸"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/108.ts
+++ b/data-asia/SV/CSV9C/108.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "八爪武师"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/109.ts
+++ b/data-asia/SV/CSV9C/109.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "列阵兵"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/110.ts
+++ b/data-asia/SV/CSV9C/110.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "晶光芽"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/111.ts
+++ b/data-asia/SV/CSV9C/111.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "晶光花"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/112.ts
+++ b/data-asia/SV/CSV9C/112.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "故勒顿"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/113.ts
+++ b/data-asia/SV/CSV9C/113.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "溶食兽"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/114.ts
+++ b/data-asia/SV/CSV9C/114.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "吞食兽"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/115.ts
+++ b/data-asia/SV/CSV9C/115.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "索罗亚"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/116.ts
+++ b/data-asia/SV/CSV9C/116.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "索罗亚克"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/117.ts
+++ b/data-asia/SV/CSV9C/117.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "单首龙"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/118.ts
+++ b/data-asia/SV/CSV9C/118.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "双首暴龙"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/119.ts
+++ b/data-asia/SV/CSV9C/119.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "三首恶龙ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/120.ts
+++ b/data-asia/SV/CSV9C/120.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "霸道熊猫"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/121.ts
+++ b/data-asia/SV/CSV9C/121.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "伊裴尔塔尔"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/122.ts
+++ b/data-asia/SV/CSV9C/122.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "捣蛋小妖"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/123.ts
+++ b/data-asia/SV/CSV9C/123.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "诈唬魔"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/124.ts
+++ b/data-asia/SV/CSV9C/124.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "长毛巨魔"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/125.ts
+++ b/data-asia/SV/CSV9C/125.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "滋汁鼹"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/126.ts
+++ b/data-asia/SV/CSV9C/126.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "涂标客"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/127.ts
+++ b/data-asia/SV/CSV9C/127.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "桃歹郎"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/128.ts
+++ b/data-asia/SV/CSV9C/128.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "阿罗拉 地鼠"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/129.ts
+++ b/data-asia/SV/CSV9C/129.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "阿罗拉 三地鼠"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/130.ts
+++ b/data-asia/SV/CSV9C/130.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "盔甲鸟"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/131.ts
+++ b/data-asia/SV/CSV9C/131.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "铜镜怪"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/132.ts
+++ b/data-asia/SV/CSV9C/132.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "青铜钟"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/133.ts
+++ b/data-asia/SV/CSV9C/133.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "盖诺赛克特"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/134.ts
+++ b/data-asia/SV/CSV9C/134.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "美录坦"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/135.ts
+++ b/data-asia/SV/CSV9C/135.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "美录梅塔"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/138.ts
+++ b/data-asia/SV/CSV9C/138.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "铝钢桥龙ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/139.ts
+++ b/data-asia/SV/CSV9C/139.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "苍响ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/140.ts
+++ b/data-asia/SV/CSV9C/140.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "噗隆隆"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/141.ts
+++ b/data-asia/SV/CSV9C/141.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "普隆隆姆"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/142.ts
+++ b/data-asia/SV/CSV9C/142.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "赛富豪"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/143.ts
+++ b/data-asia/SV/CSV9C/143.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "铁头壳"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/144.ts
+++ b/data-asia/SV/CSV9C/144.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "阿罗拉 椰蛋树ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/145.ts
+++ b/data-asia/SV/CSV9C/145.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "帝牙卢卡"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/146.ts
+++ b/data-asia/SV/CSV9C/146.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "帕路奇亚"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/147.ts
+++ b/data-asia/SV/CSV9C/147.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "酋雷姆"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/148.ts
+++ b/data-asia/SV/CSV9C/148.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "啃果虫"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/149.ts
+++ b/data-asia/SV/CSV9C/149.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "苹裹龙"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/150.ts
+++ b/data-asia/SV/CSV9C/150.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "丰蜜龙"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/151.ts
+++ b/data-asia/SV/CSV9C/151.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "无极汰那"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/152.ts
+++ b/data-asia/SV/CSV9C/152.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "米立龙ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/153.ts
+++ b/data-asia/SV/CSV9C/153.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "伊布"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/154.ts
+++ b/data-asia/SV/CSV9C/154.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "咕咕"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/155.ts
+++ b/data-asia/SV/CSV9C/155.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "猫头夜鹰"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/156.ts
+++ b/data-asia/SV/CSV9C/156.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "懒人獭"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/157.ts
+++ b/data-asia/SV/CSV9C/157.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "过动猿"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/158.ts
+++ b/data-asia/SV/CSV9C/158.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "请假王ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/159.ts
+++ b/data-asia/SV/CSV9C/159.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "猫鼬斩"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/160.ts
+++ b/data-asia/SV/CSV9C/160.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "变隐龙"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/161.ts
+++ b/data-asia/SV/CSV9C/161.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "旋转洛托姆"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/162.ts
+++ b/data-asia/SV/CSV9C/162.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "爆炸头水牛"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/163.ts
+++ b/data-asia/SV/CSV9C/163.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "毛头小鹰"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/164.ts
+++ b/data-asia/SV/CSV9C/164.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "勇士雄鹰"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/165.ts
+++ b/data-asia/SV/CSV9C/165.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "小箭雀"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/166.ts
+++ b/data-asia/SV/CSV9C/166.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "火箭雀"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/167.ts
+++ b/data-asia/SV/CSV9C/167.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "烈箭鹰"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/168.ts
+++ b/data-asia/SV/CSV9C/168.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "嗡蝠"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/169.ts
+++ b/data-asia/SV/CSV9C/169.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "音波龙ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/170.ts
+++ b/data-asia/SV/CSV9C/170.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "智挥猩"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/171.ts
+++ b/data-asia/SV/CSV9C/171.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "一对鼠"
+	},
+
+	category: "Pokemon",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/172.ts
+++ b/data-asia/SV/CSV9C/172.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "一家鼠"
+	},
+
+	category: "Pokemon",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/173.ts
+++ b/data-asia/SV/CSV9C/173.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "摩托蜥ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/174.ts
+++ b/data-asia/SV/CSV9C/174.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "太乐巴戈斯"
+	},
+
+	category: "Pokemon",
+	rarity: "Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/175.ts
+++ b/data-asia/SV/CSV9C/175.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "太乐巴戈斯ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Double rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/176.ts
+++ b/data-asia/SV/CSV9C/176.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "能量输送PRO"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "ACE SPEC Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/177.ts
+++ b/data-asia/SV/CSV9C/177.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "支援按铃"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/178.ts
+++ b/data-asia/SV/CSV9C/178.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "玻璃喇叭"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/179.ts
+++ b/data-asia/SV/CSV9C/179.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "推理套装"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/180.ts
+++ b/data-asia/SV/CSV9C/180.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "紧急切换"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "ACE SPEC Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/181.ts
+++ b/data-asia/SV/CSV9C/181.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "太晶珠（道具）"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/182.ts
+++ b/data-asia/SV/CSV9C/182.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "悠闲尾草"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/183.ts
+++ b/data-asia/SV/CSV9C/183.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "完美搅拌器"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "ACE SPEC Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/184.ts
+++ b/data-asia/SV/CSV9C/184.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "古老的根状化石"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/185.ts
+++ b/data-asia/SV/CSV9C/185.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "古老的背盖化石"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/186.ts
+++ b/data-asia/SV/CSV9C/186.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "贵重推车"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "ACE SPEC Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/187.ts
+++ b/data-asia/SV/CSV9C/187.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "奇迹耳机"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "ACE SPEC Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/188.ts
+++ b/data-asia/SV/CSV9C/188.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "百万吨吹风机"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "ACE SPEC Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/189.ts
+++ b/data-asia/SV/CSV9C/189.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "龙之秘药"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/190.ts
+++ b/data-asia/SV/CSV9C/190.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "反击增幅器"
+	},
+
+	category: "Trainer",
+	trainerType: "Tool",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/191.ts
+++ b/data-asia/SV/CSV9C/191.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "希望护身符"
+	},
+
+	category: "Trainer",
+	trainerType: "Tool",
+	rarity: "ACE SPEC Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/192.ts
+++ b/data-asia/SV/CSV9C/192.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "重力之玉"
+	},
+
+	category: "Trainer",
+	trainerType: "Tool",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/193.ts
+++ b/data-asia/SV/CSV9C/193.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "刺耳果（道具）"
+	},
+
+	category: "Trainer",
+	trainerType: "Tool",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/194.ts
+++ b/data-asia/SV/CSV9C/194.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "霹霹果（道具）"
+	},
+
+	category: "Trainer",
+	trainerType: "Tool",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/195.ts
+++ b/data-asia/SV/CSV9C/195.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "招式学习器 萤石"
+	},
+
+	category: "Trainer",
+	trainerType: "Tool",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/196.ts
+++ b/data-asia/SV/CSV9C/196.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "赤松"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/197.ts
+++ b/data-asia/SV/CSV9C/197.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "杜若"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/198.ts
+++ b/data-asia/SV/CSV9C/198.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "席藍"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/199.ts
+++ b/data-asia/SV/CSV9C/199.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "希特隆的机智"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/200.ts
+++ b/data-asia/SV/CSV9C/200.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "紫竽"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/201.ts
+++ b/data-asia/SV/CSV9C/201.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "朵拉塞娜"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Common",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/202.ts
+++ b/data-asia/SV/CSV9C/202.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "白蕾雅"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/203.ts
+++ b/data-asia/SV/CSV9C/203.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "阿蜜的目光"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/204.ts
+++ b/data-asia/SV/CSV9C/204.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "琉琪亚的展现"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/205.ts
+++ b/data-asia/SV/CSV9C/205.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "伟大巨树"
+	},
+
+	category: "Trainer",
+	trainerType: "Stadium",
+	rarity: "ACE SPEC Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/206.ts
+++ b/data-asia/SV/CSV9C/206.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "振奋竞技场"
+	},
+
+	category: "Trainer",
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/207.ts
+++ b/data-asia/SV/CSV9C/207.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "零之大空洞"
+	},
+
+	category: "Trainer",
+	trainerType: "Stadium",
+	rarity: "Uncommon",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/208.ts
+++ b/data-asia/SV/CSV9C/208.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "富裕能量"
+	},
+
+	category: "Energy",
+	energyType: "Special",
+	rarity: "ACE SPEC Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/209.ts
+++ b/data-asia/SV/CSV9C/209.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "爆焰龟兽"
+	},
+
+	category: "Pokemon",
+	rarity: "Illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/210.ts
+++ b/data-asia/SV/CSV9C/210.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "捷拉奥拉"
+	},
+
+	category: "Pokemon",
+	rarity: "Illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/211.ts
+++ b/data-asia/SV/CSV9C/211.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "克雷色利亚"
+	},
+
+	category: "Pokemon",
+	rarity: "Illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/212.ts
+++ b/data-asia/SV/CSV9C/212.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "索罗亚"
+	},
+
+	category: "Pokemon",
+	rarity: "Illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/213.ts
+++ b/data-asia/SV/CSV9C/213.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "铝钢桥龙"
+	},
+
+	category: "Pokemon",
+	rarity: "Illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/214.ts
+++ b/data-asia/SV/CSV9C/214.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "猫头夜鹰"
+	},
+
+	category: "Pokemon",
+	rarity: "Illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/215.ts
+++ b/data-asia/SV/CSV9C/215.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "铁蚁ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/216.ts
+++ b/data-asia/SV/CSV9C/216.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "来悲粗茶ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/217.ts
+++ b/data-asia/SV/CSV9C/217.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "蜜集大蛇ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/218.ts
+++ b/data-asia/SV/CSV9C/218.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "闪焰王牌ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/219.ts
+++ b/data-asia/SV/CSV9C/219.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "狠辣椒ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/220.ts
+++ b/data-asia/SV/CSV9C/220.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "拉普拉斯ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/221.ts
+++ b/data-asia/SV/CSV9C/221.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "皮卡丘ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/222.ts
+++ b/data-asia/SV/CSV9C/222.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "电蜘蛛ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/223.ts
+++ b/data-asia/SV/CSV9C/223.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "拉帝亚斯ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/224.ts
+++ b/data-asia/SV/CSV9C/224.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "噬沙堡爷ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/225.ts
+++ b/data-asia/SV/CSV9C/225.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "沙漠蜻蜓ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/226.ts
+++ b/data-asia/SV/CSV9C/226.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "三首恶龙ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/227.ts
+++ b/data-asia/SV/CSV9C/227.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "铝钢桥龙ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/228.ts
+++ b/data-asia/SV/CSV9C/228.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "阿罗拉 椰蛋树ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/229.ts
+++ b/data-asia/SV/CSV9C/229.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "米立龙ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/230.ts
+++ b/data-asia/SV/CSV9C/230.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "请假王ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/231.ts
+++ b/data-asia/SV/CSV9C/231.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "摩托蜥ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/232.ts
+++ b/data-asia/SV/CSV9C/232.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "太乐巴戈斯ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/233.ts
+++ b/data-asia/SV/CSV9C/233.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "赤松"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/234.ts
+++ b/data-asia/SV/CSV9C/234.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "杜若"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/235.ts
+++ b/data-asia/SV/CSV9C/235.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "席藍"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/236.ts
+++ b/data-asia/SV/CSV9C/236.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "希特隆的机智"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/237.ts
+++ b/data-asia/SV/CSV9C/237.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "紫竽"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/238.ts
+++ b/data-asia/SV/CSV9C/238.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "朵拉塞娜"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/239.ts
+++ b/data-asia/SV/CSV9C/239.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "白蕾雅"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/240.ts
+++ b/data-asia/SV/CSV9C/240.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "阿蜜的目光"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/241.ts
+++ b/data-asia/SV/CSV9C/241.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "琉琪亚的展现"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/242.ts
+++ b/data-asia/SV/CSV9C/242.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "铁蚁ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/243.ts
+++ b/data-asia/SV/CSV9C/243.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "来悲粗茶ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/244.ts
+++ b/data-asia/SV/CSV9C/244.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "蜜集大蛇ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/245.ts
+++ b/data-asia/SV/CSV9C/245.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "皮卡丘ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/246.ts
+++ b/data-asia/SV/CSV9C/246.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "电蜘蛛ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/247.ts
+++ b/data-asia/SV/CSV9C/247.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "拉帝亚斯ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/248.ts
+++ b/data-asia/SV/CSV9C/248.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "三首恶龙ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/249.ts
+++ b/data-asia/SV/CSV9C/249.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "铝钢桥龙ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/250.ts
+++ b/data-asia/SV/CSV9C/250.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "阿罗拉 椰蛋树ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/251.ts
+++ b/data-asia/SV/CSV9C/251.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "太乐巴戈斯ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/252.ts
+++ b/data-asia/SV/CSV9C/252.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "杜若"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/253.ts
+++ b/data-asia/SV/CSV9C/253.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "希特隆的机智"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/254.ts
+++ b/data-asia/SV/CSV9C/254.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "紫竽"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/255.ts
+++ b/data-asia/SV/CSV9C/255.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "白蕾雅"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/256.ts
+++ b/data-asia/SV/CSV9C/256.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "阿蜜的目光"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Ultra Rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/257.ts
+++ b/data-asia/SV/CSV9C/257.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "琉琪亚的展现"
+	},
+
+	category: "Trainer",
+	trainerType: "Supporter",
+	rarity: "Special illustration rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/258.ts
+++ b/data-asia/SV/CSV9C/258.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "闪焰王牌ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Hyper rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/259.ts
+++ b/data-asia/SV/CSV9C/259.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "拉普拉斯ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Hyper rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/260.ts
+++ b/data-asia/SV/CSV9C/260.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "皮卡丘ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Hyper rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/261.ts
+++ b/data-asia/SV/CSV9C/261.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "阿罗拉 椰蛋树ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Hyper rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/262.ts
+++ b/data-asia/SV/CSV9C/262.ts
@@ -1,0 +1,15 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "太乐巴戈斯ex"
+	},
+
+	category: "Pokemon",
+	rarity: "Hyper rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/263.ts
+++ b/data-asia/SV/CSV9C/263.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "夜间担架"
+	},
+
+	category: "Trainer",
+	trainerType: "Item",
+	rarity: "Hyper rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/264.ts
+++ b/data-asia/SV/CSV9C/264.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "反击增幅器"
+	},
+
+	category: "Trainer",
+	trainerType: "Tool",
+	rarity: "Hyper rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/265.ts
+++ b/data-asia/SV/CSV9C/265.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "力之沙漏"
+	},
+
+	category: "Trainer",
+	trainerType: "Tool",
+	rarity: "Hyper rare",
+}
+
+export default card

--- a/data-asia/SV/CSV9C/266.ts
+++ b/data-asia/SV/CSV9C/266.ts
@@ -1,0 +1,16 @@
+import { Card } from "../../../interfaces"
+import Set from "../CSV9C"
+
+const card: Card = {
+	set: Set,
+
+	name: {
+		'zh-cn': "零之大空洞"
+	},
+
+	category: "Trainer",
+	trainerType: "Stadium",
+	rarity: "Hyper rare",
+}
+
+export default card


### PR DESCRIPTION
`data-asia/SV/CSV9C.ts` has existed as a shell since the set was added, so
`/v2/zh-cn/sets/CSV9C` answers `cards: []` and a Simplified-Chinese card from
星彩晶璃 cannot be identified by anything reading the API. This adds the 264
card files.

All 57 `zh-cn` sets are in the same state — set metadata, zero card rows — so
this is one set offered as a **proposal about shape** rather than a bulk drop.
I have the same data prepared for 78 Simplified-Chinese sets / ~9,250 cards and
would rather agree the format on one set than open a PR with thousands of files
you did not ask for. Tell me what you would like changed and I will regenerate
the lot.

## Shape

Follows `data-asia/S/SC2D`, the populated Traditional-Chinese set already in the
tree: a single-language `name`, a `category`, nothing inferred.

```ts
import { Card } from "../../../interfaces"
import Set from "../CSV9C"

const card: Card = {
	set: Set,

	name: {
		'zh-cn': "太乐巴戈斯"
	},

	category: "Pokemon",
	rarity: "Rare",
}

export default card
```

`rarity` is mapped conservatively from the Chinese rarity letters
(C/U/R/RR/AR/SR/SAR/UR/ACE → Common/Uncommon/Rare/Double rare/Illustration
rare/Ultra Rare/Special illustration rare/Hyper rare/ACE SPEC Rare). Letters
with no unambiguous counterpart are **omitted** rather than approximated —
`SC2D`'s cards carry no rarity at all, so an absent rarity is a shape this
repository already contains.

`trainerType` and `energyType` come from the card-type column
(物品卡 → Item, 支援者卡 → Supporter, 竞技场卡 → Stadium, 宝可梦道具 → Tool;
基本…能量 → Normal, otherwise Special).

## What is deliberately missing

`hp`, `types`, `attacks`, `description`, `illustrator`, `dexId`, `retreat`,
`weaknesses`. The source is a **checklist**, so none of them are known, and
every one would have to be guessed or carried over from the Japanese card this
printing reprints. I would be glad to do that as follow-up — every row carries
the JP set it was reprinted from, so the join is available — but not as an
inference dressed as data.

`name` carries `zh-cn` only. The official English species name is known for
most of these cards and is **not** written into the name table: these printings
have no English release, and an English name on a Chinese-exclusive card is how
a Chinese card starts being answered by an English one.

## Two cards are missing on purpose

The source lists **136/208 twice** — as 铝钢龙 (Duraludon, C) and as 铝钢桥龙
(Archaludon, R holo) — while **137/208 is absent**. They are adjacent
evolutions and 138 is 铝钢桥龙ex, so the intended numbering is obvious to a
reader; that is exactly why it is not encoded here. Say the word and I will add
136 = 铝钢龙 and 137 = 铝钢桥龙, or I can raise it upstream first.

## Provenance, and a licensing question I would rather ask than assume

The data is extracted from **神奇宝贝百科 (wiki.52poke.com)** via the MediaWiki
API — wikitext, not rendered HTML — and cross-checked against your own
`/v2/zh-cn/sets` list. Extraction is polite (serialised, 700 ms floor,
identifying User-Agent, everything cached).

That wiki publishes under **CC BY-NC-SA 3.0**. What is taken here is
factual — a set code, a printed number, the name printed on the card, a rarity
letter — with no prose, images or commentary, and facts are not copyrightable
in the US (*Feist*). But you maintain an MIT-licensed database and the
**EU/UK sui generis database right** protects substantial extraction regardless
of originality, so this is your call rather than mine. If you would prefer a
different provenance I am happy to verify the same rows against The Pokémon
Company's own `pokemon.cn` product pages (each set links one) or against
physical cards, and resubmit.

## Verification

- 264 files typecheck against `interfaces.d.ts` with **0 errors**.
- Set completeness is proven before publishing: 1…208 each present exactly once
  (which is what caught the 136/137 error), and the total agreeing with the
  set's own declared `208+58`.
- Spot-checked against photographs of real cards: 174/208 太乐巴戈斯 (Rare,
  holo) and 214/208 猫头夜鹰 (Illustration rare) are two cards a collector sent
  us that no catalogue could identify — which is what prompted the work.

The extractor is open and reusable if you would like it:
<https://github.com/CorruptFun/Cardstock/tree/main/scripts/zh-pokemon>
