### PR TITLE
fix(data): Ascended Heroes Tepig cosmos variant type

### DIFF
--- a/data/Mega Evolution/Ascended Heroes/029.ts
+++ b/data/Mega Evolution/Ascended Heroes/029.ts
@@ -77,7 +77,7 @@ const card: Card = {
 		}
 	},
 	{
-		type: "reverse",
+		type: "holo",
 		foil: "cosmos",
 		thirdParty: {
 			cardmarket: 878075,


### PR DESCRIPTION
Ascended Heroes
- 029 Tepig: cosmos variant changed from `reverse` to `holo`
