### PR TITLE
Add Paldea Evolved Mimikyu Trick or Trade 2023 variant

### DIFF
--- a/data/Scarlet & Violet/Paldea Evolved/097.ts
+++ b/data/Scarlet & Violet/Paldea Evolved/097.ts
@@ -83,6 +83,14 @@ const card: Card = {
 			}
 		},
 		{
+			type: 'holo',
+			stamp: ['trick-or-trade'],
+			thirdParty: {
+				cardmarket: 785611,
+				tcgplayer: 515672
+			}
+		},
+		{
 			type: 'reverse',
 			thirdParty: {
 				cardmarket: 715572,


### PR DESCRIPTION
Paldea Evolved
- 097 Mimikyu: added `holo` with `trick-or-trade` stamp (Cardmarket 785611, TCGplayer 515672)
