### PR TITLE
Swap cardmarket and tcgplayer IDs

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2024/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/7.ts
@@ -69,8 +69,8 @@ const card: Card = {
 		{
 			type: 'normal',
 			thirdParty: {
-				cardmarket: 614376,
-				tcgplayer: 802829
+				cardmarket: 802829,
+				tcgplayer:  614376
 			}
 		}
 	]


### PR DESCRIPTION
for McDonald's Collection 2024/7.ts

<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes no issue

## Changes

The Cardmarket and TCGplayer product IDs for Quagsire (#7) in
McDonald's Collection 2024 were swapped.

## Details

Correct IDs:
- Cardmarket: 802829
- TCGplayer: 614376

Cardmarket:
https://www.cardmarket.com/en/Pokemon/Products?idProduct=802829

TCGplayer:
https://www.tcgplayer.com/product/614376



<!-- You can also give more details about your changes -->

