### PR TITLE
fix(data): Mark Dark Explorers Secret Rares as holo

### DIFF
--- a/data/Black & White/Dark Explorers/109.ts
+++ b/data/Black & White/Dark Explorers/109.ts
@@ -93,6 +93,12 @@ const card: Card = {
 		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als normal. Es ist sehr schwer zu finden."
 	},
 
+	variants: [
+		{
+			type: "holo"
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 280437,
 		tcgplayer: 85638

--- a/data/Black & White/Dark Explorers/110.ts
+++ b/data/Black & White/Dark Explorers/110.ts
@@ -92,6 +92,12 @@ const card: Card = {
 		de: "Dieses sehr seltene Pokémon hat eine andere Farbe als üblich. Es ist schwer zu finden."
 	},
 
+	variants: [
+		{
+			type: "holo"
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 280438,
 		tcgplayer: 83610

--- a/data/Black & White/Dark Explorers/111.ts
+++ b/data/Black & White/Dark Explorers/111.ts
@@ -26,6 +26,12 @@ const card: Card = {
 		de: "Tausche das Aktive Pokémon deines Gegners gegen 1 Pokémon auf seiner Bank aus. Du kannst während deines Zuges (vor deinem Angriff) beliebig viele Itemkarten spielen."
 	},
 
+	variants: [
+		{
+			type: "holo"
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 280439
 	}


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

## Changes

Dark Explorers Secret Rares 109-111 currently export as normal. This is because cards with a missing cariant always become normal: true, holo: false

In reality, all three secret rares in this set are holofoil-only printings.

## Details

- `109.ts` Gardevoir
- `110.ts` Archeops
- `111.ts` Pokémon Catcher

Each card gets a single `type: "holo"` variant.

## Sources (visual evidence)
- [Gardevoir](https://preview.redd.it/is-this-gardevoir-dark-explorers-card-real-v0-fozvbm8tqkve1.jpg?width=811&format=pjpg&auto=webp&s=a14c38cf2ad8a111c30e38e826c58e57f6226b21)
- [Archeops](https://i.redd.it/gewbvpee95471.jpg)
- [Pokémon Catcher](https://i.ebayimg.com/images/g/zf8AAeSwDfRpDwMT/s-l1600.webp)
