### PR TITLE
fix(data): Swap Cardmarket and TCGplayer IDs

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2024/7.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/7.ts
@@ -64,13 +64,13 @@ const card: Card = {
 	],
 
 	retreat: 2,
-	
+
 	variants: [
 		{
 			type: 'normal',
 			thirdParty: {
-				cardmarket: 614376,
-				tcgplayer: 802829
+				cardmarket: 802829,
+				tcgplayer: 614376
 			}
 		}
 	]


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

Supersedes #2290.

The original PR was accidentally opened from the fork's `master` branch. This PR contains the same fix on a dedicated branch based on the current upstream `master`.

Correct third-party IDs:
- Cardmarket: 802829
- TCGplayer: 614376

## Changes

Swap the Cardmarket and TCGplayer product IDs for Quagsire (#7) from McDonald's Collection 2024.

## Details

Direct id links to cards:
- https://www.cardmarket.com/en/Pokemon/Products?idProduct=802829
- https://www.tcgplayer.com/product/614376