### PR TITLE
fix(data): Mark Dark Explorers EX and Ultra Rares as holo

### DIFF
--- a/data/Black & White/Dark Explorers/103.ts
+++ b/data/Black & White/Dark Explorers/103.ts
@@ -75,7 +75,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 3
+	retreat: 3,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/104.ts
+++ b/data/Black & White/Dark Explorers/104.ts
@@ -74,7 +74,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 4
+	retreat: 4,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/105.ts
+++ b/data/Black & White/Dark Explorers/105.ts
@@ -74,7 +74,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/106.ts
+++ b/data/Black & White/Dark Explorers/106.ts
@@ -82,7 +82,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 4
+	retreat: 4,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/107.ts
+++ b/data/Black & White/Dark Explorers/107.ts
@@ -86,7 +86,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 2
+	retreat: 2,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/108.ts
+++ b/data/Black & White/Dark Explorers/108.ts
@@ -82,7 +82,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/13.ts
+++ b/data/Black & White/Dark Explorers/13.ts
@@ -75,7 +75,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 3
+	retreat: 3,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/26.ts
+++ b/data/Black & White/Dark Explorers/26.ts
@@ -74,7 +74,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 4
+	retreat: 4,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/38.ts
+++ b/data/Black & White/Dark Explorers/38.ts
@@ -74,7 +74,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/54.ts
+++ b/data/Black & White/Dark Explorers/54.ts
@@ -82,7 +82,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 4
+	retreat: 4,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/63.ts
+++ b/data/Black & White/Dark Explorers/63.ts
@@ -86,7 +86,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 2
+	retreat: 2,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Dark Explorers/90.ts
+++ b/data/Black & White/Dark Explorers/90.ts
@@ -82,7 +82,13 @@ const card: Card = {
 		},
 	],
 
-	retreat: 1
+	retreat: 1,
+
+	variants: [
+		{
+			type: "holo"
+		}
+	]
 }
 
 export default card


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

Follow-up to #2291.

## Changes

Dark Explorers in-set EX and full-art Ultra Rares currently export as normal. This is because cards with a missing cariant always become normal: true, holo: false

However, all twelve are holofoil-only printings.

## Details

In-set EX:
- `13.ts` Entei-EX
- `26.ts` Kyogre-EX
- `38.ts` Raikou-EX
- `54.ts` Groudon-EX
- `63.ts` Darkrai-EX
- `90.ts` Tornadus-EX

Full-art Ultra Rare:
- `103.ts` Entei-EX
- `104.ts` Kyogre-EX
- `105.ts` Raikou-EX
- `106.ts` Groudon-EX
- `107.ts` Darkrai-EX
- `108.ts` Tornadus-EX

Each card gets a single `type: "holo"` variant.
