### PR TITLE
fix(data): Correct Plasma Blast Archen-line variants

### DIFF
--- a/data/Black & White/Plasma Blast/53.ts
+++ b/data/Black & White/Plasma Blast/53.ts
@@ -83,20 +83,17 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal",
-			thirdParty: {
-				cardmarket: 281074,
-				tcgplayer: 83608
-			}
+			type: "normal"
 		},
 		{
-			type: "reverse",
-			thirdParty: {
-				cardmarket: 281074,
-				tcgplayer: 83608
-			}
+			type: "reverse"
 		}
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 281074,
+		tcgplayer: 83608
+	}
 }
 
 export default card

--- a/data/Black & White/Plasma Blast/53.ts
+++ b/data/Black & White/Plasma Blast/53.ts
@@ -59,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Wing Attack",
 				fr: "Cru-Aile",
+				es: "Ataque Ala",
 				it: "Attacco d'Ala",
 				de: "Flügelschlag"
 			},
@@ -80,6 +81,7 @@ const card: Card = {
 	description: {
 		en: "It was revived from an ancient fossil. Not able to fly, it lived in treetops and hopped from one branch to another.",
 		fr: "Un Pokémon recréé à partir d'un fossile. Il vit à la cime des arbres, mais ne peut voler et saute de branche en branche.",
+		es: "Ha renacido a partir de fósiles antiguos. Vive en la copa de los árboles y salta de una rama a otra porque no puede volar.",
 		it: "Rigenerato da un fossile, viveva sugli alberi e rincorreva le prede saltando di ramo in ramo perché non sapeva volare.",
 		de: "Es wurde aus einem Fossil reanimiert. Da es nicht fliegen kann, bewegt es sich hüpfend von Ast zu Ast."
 	},

--- a/data/Black & White/Plasma Blast/53.ts
+++ b/data/Black & White/Plasma Blast/53.ts
@@ -61,6 +61,7 @@ const card: Card = {
 				fr: "Cru-Aile",
 				es: "Ataque Ala",
 				it: "Attacco d'Ala",
+				pt: "Ataque de Asa",
 				de: "Flügelschlag"
 			},
 
@@ -83,6 +84,7 @@ const card: Card = {
 		fr: "Un Pokémon recréé à partir d'un fossile. Il vit à la cime des arbres, mais ne peut voler et saute de branche en branche.",
 		es: "Ha renacido a partir de fósiles antiguos. Vive en la copa de los árboles y salta de una rama a otra porque no puede volar.",
 		it: "Rigenerato da un fossile, viveva sugli alberi e rincorreva le prede saltando di ramo in ramo perché non sapeva volare.",
+		pt: "Ele foi revivido a partir de um antigo fóssil. Incapaz de voar, viveu no topo de árvores, pulando de galho em galho.",
 		de: "Es wurde aus einem Fossil reanimiert. Da es nicht fliegen kann, bewegt es sich hüpfend von Ast zu Ast."
 	},
 

--- a/data/Black & White/Plasma Blast/53.ts
+++ b/data/Black & White/Plasma Blast/53.ts
@@ -59,6 +59,7 @@ const card: Card = {
 			name: {
 				en: "Wing Attack",
 				fr: "Cru-Aile",
+				it: "Attacco d'Ala",
 				de: "Flügelschlag"
 			},
 
@@ -78,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It was revived from an ancient fossil. Not able to fly, it lived in treetops and hopped from one branch to another.",
+		it: "Rigenerato da un fossile, viveva sugli alberi e rincorreva le prede saltando di ramo in ramo perché non sapeva volare.",
 		de: "Es wurde aus einem Fossil reanimiert. Da es nicht fliegen kann, bewegt es sich hüpfend von Ast zu Ast."
 	},
 

--- a/data/Black & White/Plasma Blast/53.ts
+++ b/data/Black & White/Plasma Blast/53.ts
@@ -81,6 +81,15 @@ const card: Card = {
 		de: "Es wurde aus einem Fossil reanimiert. Da es nicht fliegen kann, bewegt es sich hüpfend von Ast zu Ast."
 	},
 
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 281074,
 		tcgplayer: 83608

--- a/data/Black & White/Plasma Blast/53.ts
+++ b/data/Black & White/Plasma Blast/53.ts
@@ -79,6 +79,7 @@ const card: Card = {
 
 	description: {
 		en: "It was revived from an ancient fossil. Not able to fly, it lived in treetops and hopped from one branch to another.",
+		fr: "Un Pokémon recréé à partir d'un fossile. Il vit à la cime des arbres, mais ne peut voler et saute de branche en branche.",
 		it: "Rigenerato da un fossile, viveva sugli alberi e rincorreva le prede saltando di ramo in ramo perché non sapeva volare.",
 		de: "Es wurde aus einem Fossil reanimiert. Da es nicht fliegen kann, bewegt es sich hüpfend von Ast zu Ast."
 	},

--- a/data/Black & White/Plasma Blast/53.ts
+++ b/data/Black & White/Plasma Blast/53.ts
@@ -83,17 +83,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 281074,
+				tcgplayer: 83608
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 281074,
+				tcgplayer: 83608
+			}
 		}
-	],
-
-	thirdParty: {
-		cardmarket: 281074,
-		tcgplayer: 83608
-	}
+	]
 }
 
 export default card

--- a/data/Black & White/Plasma Blast/53.ts
+++ b/data/Black & White/Plasma Blast/53.ts
@@ -90,17 +90,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 281074,
+				tcgplayer: 83608
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 281074,
+				tcgplayer: 83608
+			}
 		}
-	],
-
-	thirdParty: {
-		cardmarket: 281074,
-		tcgplayer: 83608
-	}
+	]
 }
 
 export default card

--- a/data/Black & White/Plasma Blast/54.ts
+++ b/data/Black & White/Plasma Blast/54.ts
@@ -88,17 +88,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 281075,
+				tcgplayer: 83611
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 281075,
+				tcgplayer: 83611
+			}
 		}
-	],
-
-	thirdParty: {
-		cardmarket: 281075,
-		tcgplayer: 83611
-	}
+	]
 }
 
 export default card

--- a/data/Black & White/Plasma Blast/54.ts
+++ b/data/Black & White/Plasma Blast/54.ts
@@ -107,17 +107,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo"
+			type: "holo",
+			thirdParty: {
+				cardmarket: 281075,
+				tcgplayer: 83611
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 281075,
+				tcgplayer: 83611
+			}
 		}
-	],
-
-	thirdParty: {
-		cardmarket: 281075,
-		tcgplayer: 83611
-	}
+	]
 }
 
 export default card

--- a/data/Black & White/Plasma Blast/54.ts
+++ b/data/Black & White/Plasma Blast/54.ts
@@ -86,6 +86,15 @@ const card: Card = {
 		de: "Zu Fuß ist es schneller als in der Luft. Es muss ein Tempo von 40 km/h erreichen, bevor es sich in die Lüfte aufschwingt."
 	},
 
+	variants: [
+		{
+			type: "holo"
+		},
+		{
+			type: "reverse"
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 281075,
 		tcgplayer: 83611

--- a/data/Black & White/Plasma Blast/54.ts
+++ b/data/Black & White/Plasma Blast/54.ts
@@ -88,20 +88,17 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "holo",
-			thirdParty: {
-				cardmarket: 281075,
-				tcgplayer: 83611
-			}
+			type: "holo"
 		},
 		{
-			type: "reverse",
-			thirdParty: {
-				cardmarket: 281075,
-				tcgplayer: 83611
-			}
+			type: "reverse"
 		}
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 281075,
+		tcgplayer: 83611
+	}
 }
 
 export default card

--- a/data/Black & White/Plasma Blast/54.ts
+++ b/data/Black & White/Plasma Blast/54.ts
@@ -29,6 +29,9 @@ const card: Card = {
 	evolveFrom: {
 		en: "Archen",
 		fr: "Arkéapti",
+		es: "Archen",
+		it: "Archen",
+		pt: "Archen",
 		de: "Flapteryx"
 	},
 
@@ -42,11 +45,17 @@ const card: Card = {
 			name: {
 				en: "Acrobatics",
 				fr: "Acrobatie",
+				es: "Acróbata",
+				it: "Acrobazia",
+				pt: "Acrobático",
 				de: "Akrobatik"
 			},
 			effect: {
 				en: "Flip 2 coins. This attack does 20 more damage for each heads.",
 				fr: "Lancez 2 pièces. Cette attaque inflige 20 dégâts supplémentaires pour chaque côté face.",
+				es: "Lanza 2 monedas. Este ataque hace 20 puntos de daño más por cada cara.",
+				it: "Lancia due volte una moneta. Ogni volta che esce testa, questo attacco infligge 20 danni in più.",
+				pt: "Jogue 2 moedas. Este ataque causa 20 de danos adicionais para cada cara.",
 				de: "Wirf 2 Münzen. Dieser Angriff fügt 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: 20,
@@ -60,11 +69,17 @@ const card: Card = {
 			name: {
 				en: "Swift Dive",
 				fr: "Vive Plongée",
+				es: "Picado Veloz",
+				it: "Picchiata Rapida",
+				pt: "Mergulho Rápido",
 				de: "Turbotaucher"
 			},
 			effect: {
 				en: "If this Pokémon's remaining HP is 50 or less, this attack's base damage is 50.",
 				fr: "S'il reste 50 PV ou moins à ce Pokémon, les dégâts de base de cette attaque sont de 50.",
+				es: "Si a este Pokémon le quedan 50 PV o menos, el daño básico de este ataque es 50.",
+				it: "Se i PV rimanenti di questo Pokémon diventano 50 o meno, il danno base di questo attacco è 50.",
+				pt: "Se o PS restante deste Pokémon for 50 ou menos, o dano base deste ataque é 50.",
 				de: "Wenn dieses Pokémon 50 oder weniger verbliebene KP hat, beträgt der Grundschaden dieser Attacke 50 Schadenspunkte."
 			},
 			damage: 100,
@@ -83,6 +98,10 @@ const card: Card = {
 
 	description: {
 		en: "It runs better than it flies. It takes off into the sky by running at a speed of 25 mph.",
+		fr: "Il est plus doué pour courir que pour voler. Il doit s'élancer à 40 km/h avant de pouvoir s'envoler.",
+		es: "Corre a mayor velocidad de la que puede volar. Alcanza una velocidad de 40 km/h antes de alzarse en vuelo hacia el cielo.",
+		it: "È più versato nella corsa che nel volo. Si lancia in aria a una velocità di 40 km/h sbattendo le ali.",
+		pt: "Corre melhor do que voa. Levanta voo aos céus correndo a uma velocidade de 25 milhas por hora.",
 		de: "Zu Fuß ist es schneller als in der Luft. Es muss ein Tempo von 40 km/h erreichen, bevor es sich in die Lüfte aufschwingt."
 	},
 

--- a/data/Black & White/Plasma Blast/82.ts
+++ b/data/Black & White/Plasma Blast/82.ts
@@ -29,20 +29,17 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal",
-			thirdParty: {
-				cardmarket: 281103,
-				tcgplayer: 88160
-			}
+			type: "normal"
 		},
 		{
-			type: "reverse",
-			thirdParty: {
-				cardmarket: 281103,
-				tcgplayer: 88160
-			}
+			type: "reverse"
 		}
-	]
+	],
+
+	thirdParty: {
+		cardmarket: 281103,
+		tcgplayer: 88160
+	}
 }
 
 export default card

--- a/data/Black & White/Plasma Blast/82.ts
+++ b/data/Black & White/Plasma Blast/82.ts
@@ -27,6 +27,15 @@ const card: Card = {
 
 	trainerType: "Item",
 
+	variants: [
+		{
+			type: "normal"
+		},
+		{
+			type: "reverse"
+		}
+	],
+
 	thirdParty: {
 		cardmarket: 281103,
 		tcgplayer: 88160

--- a/data/Black & White/Plasma Blast/82.ts
+++ b/data/Black & White/Plasma Blast/82.ts
@@ -29,17 +29,20 @@ const card: Card = {
 
 	variants: [
 		{
-			type: "normal"
+			type: "normal",
+			thirdParty: {
+				cardmarket: 281103,
+				tcgplayer: 88160
+			}
 		},
 		{
-			type: "reverse"
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 281103,
+				tcgplayer: 88160
+			}
 		}
-	],
-
-	thirdParty: {
-		cardmarket: 281103,
-		tcgplayer: 88160
-	}
+	]
 }
 
 export default card


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

## Changes

Plasma Blast Archen 53, Archeops 54, and Plume Fossil 82 currently export as normal-only. That is wrong for Archeops 54 (Rare Holo) and omits reverse holos on all three.

International print texts have also been updated for a handful of languages

Marketplace IDs moved to variant level

## Details

- `53.ts` Archen (Uncommon): `normal` + `reverse`
- `54.ts` Archeops (Rare Holo pack card): `holo` + `reverse`
- `82.ts` Plume Fossil (Uncommon): `normal` + `reverse`

## Portuguese reverse holos

Portuguese Plasma Blast was printed, but **that Portuguese set had no reverse holos**. English, German, French, and Italian did.

This PR still adds unscoped `reverse` on all three cards. The compiler does not language-filter variants, so Portuguese will also export `reverse: true`. That is a known overstatement. A previous attempt to scope reverse to `en`/`fr`/`it`/`de` was rejected, so this follows the accepted unscoped shape. No obvious compiler-compliant way to do this as of right now.

Maybe worthy of an Issue? I currently don't know of a way to override/amend the language list at the variant-level