### PR TITLE
Add variants for SWSH Black Star Promos 001-050

### DIFF
--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH001.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH001.ts
@@ -58,18 +58,26 @@ const card: Card = {
 
 	dexId: [810],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427081
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 427081,
+				tcgplayer: 200300
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 547426,
+				tcgplayer: 231458
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH002.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH002.ts
@@ -64,18 +64,26 @@ const card: Card = {
 
 	dexId: [813],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427086
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 427086,
+				tcgplayer: 200301
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 547456,
+				tcgplayer: 231466
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH003.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH003.ts
@@ -65,18 +65,26 @@ const card: Card = {
 
 	dexId: [816],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427091
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 427091,
+				tcgplayer: 200302
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 547476,
+				tcgplayer: 231468
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH004.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH004.ts
@@ -77,19 +77,18 @@ const card: Card = {
 	retreat: 2,
 	dexId: [52],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 427096
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 427096,
+				tcgplayer: 205465
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH005.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH005.ts
@@ -71,18 +71,25 @@ const card: Card = {
 	retreat: 2,
 	dexId: [52],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427101
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 427101,
+				tcgplayer: 205466
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 453338,
+				tcgplayer: 205467
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH006.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH006.ts
@@ -91,18 +91,25 @@ const card: Card = {
 
 	dexId: [812],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 437154
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 437154,
+				tcgplayer: 208261
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 208260
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH007.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH007.ts
@@ -89,18 +89,25 @@ const card: Card = {
 
 	dexId: [873],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 437159
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 437159,
+				tcgplayer: 208262
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 208263
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH008.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH008.ts
@@ -97,18 +97,25 @@ const card: Card = {
 
 	dexId: [863],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 437164
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 437164,
+				tcgplayer: 208265
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 208264
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH009.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH009.ts
@@ -95,18 +95,25 @@ const card: Card = {
 
 	dexId: [573],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 437169
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 437169,
+				tcgplayer: 208266
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 208267
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH010.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH010.ts
@@ -63,18 +63,25 @@ const card: Card = {
 
 	dexId: [829],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 439958
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 439958,
+				tcgplayer: 206429
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549416,
+				tcgplayer: 232765
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH011.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH011.ts
@@ -80,18 +80,25 @@ const card: Card = {
 
 	dexId: [831],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 439963
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 439963,
+				tcgplayer: 206427
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549421,
+				tcgplayer: 232769
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH012.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH012.ts
@@ -66,18 +66,25 @@ const card: Card = {
 
 	dexId: [877],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427106
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 427106,
+				tcgplayer: 206428
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549431,
+				tcgplayer: 232766
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH013.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH013.ts
@@ -87,18 +87,25 @@ const card: Card = {
 
 	dexId: [77],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427111
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 427111,
+				tcgplayer: 206430
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549426,
+				tcgplayer: 232767
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH014.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH014.ts
@@ -71,19 +71,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [812],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 450673
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 450673,
+				tcgplayer: 206421
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 610513,
+				tcgplayer: 220754
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH015.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH015.ts
@@ -64,19 +64,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [815],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 450578
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 450578,
+				tcgplayer: 206419
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 610514,
+				tcgplayer: 220755
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH016.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH016.ts
@@ -71,19 +71,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [818],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 450618
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 450618,
+				tcgplayer: 206418
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 609015,
+				tcgplayer: 220753
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH017.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH017.ts
@@ -71,19 +71,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [849],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 450873
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 450873,
+				tcgplayer: 206425
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 453328,
+				tcgplayer: 206426
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH018.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH018.ts
@@ -78,19 +78,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [888],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 465529
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 465529,
+				tcgplayer: 214233
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH019.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH019.ts
@@ -78,19 +78,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [889],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 465534
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 465534,
+				tcgplayer: 214234
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH020.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH020.ts
@@ -68,18 +68,17 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [25],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461594
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 461594,
+				tcgplayer: 214241
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH021.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH021.ts
@@ -78,19 +78,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [855],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 461664
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 461664,
+				tcgplayer: 214235
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 576518,
+				tcgplayer: 214236
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH022.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH022.ts
@@ -87,18 +87,25 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [841],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453448
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 453448,
+				tcgplayer: 213096
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 213097
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH023.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH023.ts
@@ -77,18 +77,25 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [405],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453453
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 453453,
+				tcgplayer: 213144
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 213145
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH024.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH024.ts
@@ -78,18 +78,25 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [839],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453458
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 453458,
+				tcgplayer: 213196
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 213197
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH025.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH025.ts
@@ -78,18 +78,25 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [569],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453463
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 453463,
+				tcgplayer: 213211
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 213212
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH026.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH026.ts
@@ -67,18 +67,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [226],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461669
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 461669,
+				tcgplayer: 214237
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH027.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH027.ts
@@ -81,18 +81,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [164],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461674
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 461674,
+				tcgplayer: 214238
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH028.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH028.ts
@@ -73,18 +73,34 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [884],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453308
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 453308,
+				tcgplayer: 214239
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["eb-games"],
+			thirdParty: {
+				cardmarket: 886516,
+				tcgplayer: 624648
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["gamestop"],
+			thirdParty: {
+				cardmarket: 742039,
+				tcgplayer: 247362
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH029.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH029.ts
@@ -82,19 +82,24 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [384],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453313,
-		tcgplayer: 214240
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 453313,
+				tcgplayer: 214240
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 619563
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH030.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH030.ts
@@ -68,19 +68,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [879],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 477159
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 477159,
+				tcgplayer: 214228
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 576519,
+				tcgplayer: 214229
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH031.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH031.ts
@@ -76,19 +76,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [877],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427106,
-		tcgplayer: 210579
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 461679,
+				tcgplayer: 210579
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH032.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH032.ts
@@ -59,18 +59,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [143],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461684
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 461684,
+				tcgplayer: 210578
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH033.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH033.ts
@@ -82,18 +82,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [888],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 465529
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491179,
+				tcgplayer: 220313
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH034.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH034.ts
@@ -74,18 +74,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [889],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 465534
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491184,
+				tcgplayer: 220314
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH035.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH035.ts
@@ -87,18 +87,25 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [724],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 487069
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 487069,
+				tcgplayer: 218579
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 218578
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH036.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH036.ts
@@ -78,18 +78,25 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [881],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 487074
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 487074,
+				tcgplayer: 218580
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 218581
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH037.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH037.ts
@@ -78,18 +78,25 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [635],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 487079
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 487079,
+				tcgplayer: 218583
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 218582
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH038.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH038.ts
@@ -68,18 +68,25 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [115],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 487084
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 487084,
+				tcgplayer: 218574
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 218576
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH039.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH039.ts
@@ -67,18 +67,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [25],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461594
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491189,
+				tcgplayer: 220268
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 549406,
+				tcgplayer: 232764
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH040.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH040.ts
@@ -72,18 +72,25 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [856],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 491194
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491194,
+				tcgplayer: 220269
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549411,
+				tcgplayer: 232768
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH041.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH041.ts
@@ -85,18 +85,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [136],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 491199
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491199,
+				tcgplayer: 220270
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH042.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH042.ts
@@ -76,18 +76,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [133],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491204,
+				tcgplayer: 220271
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH043.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH043.ts
@@ -73,19 +73,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [865],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 505860
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 505860,
+				tcgplayer: 220273
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 560033,
+				tcgplayer: 220274
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH044.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH044.ts
@@ -72,19 +72,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [890],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 496315
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 496325,
+				tcgplayer: 220279
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH045.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH045.ts
@@ -82,18 +82,25 @@ const card: Card = {
 	stage: "VMAX",
 	dexId: [890],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 496325
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 496320,
+				tcgplayer: 220281
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 496315,
+				tcgplayer: 220282
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH046.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH046.ts
@@ -76,18 +76,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [830],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505865
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505865,
+				tcgplayer: 223751
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH047.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH047.ts
@@ -86,18 +86,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [834],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505870
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505870,
+				tcgplayer: 223750
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH048.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH048.ts
@@ -85,18 +85,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [851],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505875
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505875,
+				tcgplayer: 223749
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH049.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH049.ts
@@ -73,19 +73,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [832],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 505855
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 505855,
+				tcgplayer: 223752
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 574323,
+				tcgplayer: 223753
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH050.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH050.ts
@@ -63,20 +63,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [6],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 505255,
-		tcgplayer: 223754
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 505255,
+				tcgplayer: 223754
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card


### PR DESCRIPTION
## Changes

Add variants for SWSH Black Star Promos SWSH001 to SWSH050

## Details

- 50 cards get `variants` with Cardmarket and TCGplayer ids
- covers the cosmos, prerelease (set logo and staff), jumbo, 25th anniversary, EB Games and GameStop printings, plus second printings with own marketplace ids

