### PR TITLE
Add variants for SWSH Black Star Promos 051-100

### DIFF
--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH051.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH051.ts
@@ -56,18 +56,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [131],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505895
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505895,
+				tcgplayer: 222071
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH052.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH052.ts
@@ -92,18 +92,18 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [94],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505880
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505880,
+				tcgplayer: 222072
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH053.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH053.ts
@@ -86,18 +86,18 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [68],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505885
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505885,
+				tcgplayer: 222073
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH054.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH054.ts
@@ -78,18 +78,18 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [839],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453458
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505890,
+				tcgplayer: 222074
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH055.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH055.ts
@@ -76,19 +76,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [858],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 510175
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 510180,
+				tcgplayer: 223755
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 510175,
+				tcgplayer: 223756
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH056.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH056.ts
@@ -72,19 +72,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [877],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 510185
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 510185,
+				tcgplayer: 223757
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH057.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH057.ts
@@ -63,19 +63,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [861],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 510190
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 510190,
+				tcgplayer: 223758
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 557272,
+				tcgplayer: 229436
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH058.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH058.ts
@@ -85,18 +85,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [869],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516314
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516314,
+				tcgplayer: 227029
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH059.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH059.ts
@@ -87,18 +87,18 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [862],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516319
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516319,
+				tcgplayer: 227030
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH060.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH060.ts
@@ -73,18 +73,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [884],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453308
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516324,
+				tcgplayer: 227031
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH061.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH061.ts
@@ -71,20 +71,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [25],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 496545,
-		tcgplayer: 232434
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 540616,
+				tcgplayer: 232434
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 565010,
+				tcgplayer: 232443
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH062.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH062.ts
@@ -11,12 +11,18 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "D",
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576730,
+				tcgplayer: 251086
+			}
+		},
+	],
 
 	name: {
 		en: "Pikachu VMAX",
@@ -67,11 +73,6 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "D",
-
-	thirdParty: {
-		cardmarket: 576730
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH063.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH063.ts
@@ -63,19 +63,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [25],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 461594
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 496545,
+				tcgplayer: 220315
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH064.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH064.ts
@@ -72,19 +72,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [890],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 496325
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 496550,
+				tcgplayer: 220316
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH065.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH065.ts
@@ -71,19 +71,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [133],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 496555
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 496555,
+				tcgplayer: 220317
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH066.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH066.ts
@@ -87,18 +87,25 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [6],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516329
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 516329,
+				tcgplayer: 224365
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 224366
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH067.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH067.ts
@@ -77,18 +77,25 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [232],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516334
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 516334,
+				tcgplayer: 224368
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 224367
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH068.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH068.ts
@@ -78,18 +78,25 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [143],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461684
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 516339,
+				tcgplayer: 224361
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 224362
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH069.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH069.ts
@@ -73,18 +73,25 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [249],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516344
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 516344,
+				tcgplayer: 224364
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 224363
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH070.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH070.ts
@@ -56,18 +56,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [810],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427081
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516349,
+				tcgplayer: 227028
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH071.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH071.ts
@@ -67,18 +67,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [813],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427086
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516354,
+				tcgplayer: 227027
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH072.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH072.ts
@@ -87,18 +87,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [134],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516359
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516359,
+				tcgplayer: 221753
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH073.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH073.ts
@@ -67,18 +67,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [816],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427091
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516364,
+				tcgplayer: 221754
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH074.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH074.ts
@@ -51,18 +51,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [25],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516369
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516369,
+				tcgplayer: 227646
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
@@ -56,13 +56,18 @@ const card: Card = {
 
 	retreat: 3,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
+	regulationMark: "D",
 
-	regulationMark: "D"
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 668172,
+				tcgplayer: 282259
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH076.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH076.ts
@@ -78,19 +78,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [888],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 465529
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 522960,
+				tcgplayer: 228595
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH077.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH077.ts
@@ -78,19 +78,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [889],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 465534
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 522965,
+				tcgplayer: 228596
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH078.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH078.ts
@@ -72,19 +72,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [826],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 522970
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 522970,
+				tcgplayer: 227025
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 522980,
+				tcgplayer: 227026
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH079.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH079.ts
@@ -88,18 +88,18 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 540621
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 540621,
+				tcgplayer: 232450
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH080.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH080.ts
@@ -57,18 +57,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 540626
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 540626,
+				tcgplayer: 232453
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH081.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH081.ts
@@ -93,18 +93,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461664
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 540631,
+				tcgplayer: 232458
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH082.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH082.ts
@@ -57,18 +57,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 540636
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 540636,
+				tcgplayer: 232461
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH083.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH083.ts
@@ -76,19 +76,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [65],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 530482
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 530487,
+				tcgplayer: 228980
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 530482,
+				tcgplayer: 228981
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH084.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH084.ts
@@ -74,19 +74,26 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 540641
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 540641,
+				tcgplayer: 232481
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 610515,
+				tcgplayer: 251623
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH085.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH085.ts
@@ -72,19 +72,26 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 540646
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 540646,
+				tcgplayer: 232499
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 610516,
+				tcgplayer: 243659
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH086.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH086.ts
@@ -75,19 +75,26 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 540651
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 540651,
+				tcgplayer: 232503
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 610517,
+				tcgplayer: 251622
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH087.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH087.ts
@@ -61,19 +61,17 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 540656,
-		tcgplayer: 232611
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 540656,
+				tcgplayer: 232611
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH088.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH088.ts
@@ -64,12 +64,22 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [421],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 546936,
+				tcgplayer: 234276
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 
 	attacks: [{
 		name: {
@@ -84,12 +94,6 @@ const card: Card = {
 		damage: 70,
 		cost: ["Grass", "Colorless", "Colorless"]
 	}],
-
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 546936
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH089.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH089.ts
@@ -64,12 +64,22 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [224],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 546941,
+				tcgplayer: 234277
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 
 	attacks: [{
 		name: {
@@ -84,12 +94,6 @@ const card: Card = {
 		damage: 50,
 		cost: ["Water", "Colorless", "Colorless"]
 	}],
-
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 546941
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH090.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH090.ts
@@ -78,18 +78,22 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [229],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 546961
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 546961,
+				tcgplayer: 234278
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH091.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH091.ts
@@ -83,18 +83,22 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [437],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 546966
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 546966,
+				tcgplayer: 234279
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH092.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH092.ts
@@ -68,18 +68,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 547031
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 547031,
+				tcgplayer: 234282
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH093.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH093.ts
@@ -68,18 +68,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 547036
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 547036,
+				tcgplayer: 234283
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH094.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH094.ts
@@ -84,18 +84,18 @@ const card: Card = {
 	retreat: 0,
 	dexId: [135],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 547021
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 547021,
+				tcgplayer: 234284
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH095.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH095.ts
@@ -67,18 +67,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [133],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 547026,
+				tcgplayer: 234287
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH096.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH096.ts
@@ -70,19 +70,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 549386
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549386,
+				tcgplayer: 232610
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH097.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH097.ts
@@ -88,18 +88,25 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 549391
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549391,
+				tcgplayer: 232608
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 556545,
+				tcgplayer: 232609
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH098.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH098.ts
@@ -74,19 +74,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 549396
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549396,
+				tcgplayer: 232612
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH099.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH099.ts
@@ -74,18 +74,25 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 549401
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549401,
+				tcgplayer: 232613
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 556553,
+				tcgplayer: 232614
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH100.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH100.ts
@@ -74,19 +74,18 @@ const card: Card = {
 
 	retreat: 3,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 538768
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 538768,
+				tcgplayer: 232723
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card


### PR DESCRIPTION
## Changes

Add variants for SWSH Black Star Promos SWSH051 to SWSH100

## Details

- 50 cards get `variants` with Cardmarket and TCGplayer ids
- covers the cosmos, prerelease (set logo and staff), jumbo and Special Delivery printings

