### PR TITLE
Add variants for SWSH Black Star Promos 101-150

### DIFF
--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH101.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH101.ts
@@ -65,19 +65,18 @@ const card: Card = {
 
 	retreat: 3,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 538773
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 538773,
+				tcgplayer: 232724
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH102.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH102.ts
@@ -81,18 +81,25 @@ const card: Card = {
 	stage: "VMAX",
 	dexId: [3],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 546981
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 546981,
+				tcgplayer: 234298
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 557273,
+				tcgplayer: 234375
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH103.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH103.ts
@@ -81,18 +81,25 @@ const card: Card = {
 	stage: "VMAX",
 	dexId: [9],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 546986
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 546986,
+				tcgplayer: 234299
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 557274,
+				tcgplayer: 234376
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH104.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH104.ts
@@ -71,19 +71,18 @@ const card: Card = {
 	retreat: 2,
 	dexId: [494],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 561769
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561769,
+				tcgplayer: 238546
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH105.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH105.ts
@@ -63,19 +63,18 @@ const card: Card = {
 	retreat: 2,
 	dexId: [282],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 561770
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561770,
+				tcgplayer: 238545
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH106.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH106.ts
@@ -63,19 +63,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [892],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 546971
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 546971,
+				tcgplayer: 234296
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 557275,
+				tcgplayer: 234377
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH107.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH107.ts
@@ -63,19 +63,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [892],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 546976
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 546976,
+				tcgplayer: 234297
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 557276,
+				tcgplayer: 234378
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH108.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH108.ts
@@ -73,19 +73,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [395],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 547866
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547866,
+				tcgplayer: 238555
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH109.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH109.ts
@@ -72,19 +72,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [248],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 547871
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547871,
+				tcgplayer: 238553
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH110.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH110.ts
@@ -74,19 +74,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 549396
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572538,
+				tcgplayer: 245875
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH111.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH111.ts
@@ -76,19 +76,30 @@ const card: Card = {
 	retreat: 1,
 	dexId: [78],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 561771
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561771,
+				tcgplayer: 236054
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 561772,
+				tcgplayer: 236055
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"]
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH112.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH112.ts
@@ -88,18 +88,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 450578
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 566760,
+				tcgplayer: 240891
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH113.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH113.ts
@@ -79,18 +79,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 450618
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 566761,
+				tcgplayer: 240892
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH114.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH114.ts
@@ -82,18 +82,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 566762
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 566762,
+				tcgplayer: 240893
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH115.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH115.ts
@@ -77,18 +77,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 566763
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 566763,
+				tcgplayer: 240894
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH116.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH116.ts
@@ -77,18 +77,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427106
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 557973,
+				tcgplayer: 241881
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH117.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH117.ts
@@ -70,18 +70,18 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 557974
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 557974,
+				tcgplayer: 241882
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH118.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH118.ts
@@ -77,18 +77,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 557975,
+				tcgplayer: 241883
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH119.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH119.ts
@@ -70,18 +70,18 @@ const card: Card = {
 
 	retreat: 4,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 461684
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 557976,
+				tcgplayer: 241884
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH120.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH120.ts
@@ -28,18 +28,18 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 566764
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 566764,
+				tcgplayer: 245871
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH121.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH121.ts
@@ -28,18 +28,17 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 566764
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 566765,
+				tcgplayer: 245872
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH122.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH122.ts
@@ -79,18 +79,22 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 573857
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 573857,
+				tcgplayer: 246931
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH123.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH123.ts
@@ -82,18 +82,22 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 573858
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 573858,
+				tcgplayer: 246927
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH124.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH124.ts
@@ -79,18 +79,22 @@ const card: Card = {
 
 	retreat: 0,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 573859
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 573859,
+				tcgplayer: 246933
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH125.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH125.ts
@@ -79,18 +79,22 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 573860
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 573860,
+				tcgplayer: 246929
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH126.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH126.ts
@@ -73,18 +73,18 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 568798
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 568798,
+				tcgplayer: 247290
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH127.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH127.ts
@@ -68,18 +68,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 568799,
+				tcgplayer: 247291
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH128.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH128.ts
@@ -68,18 +68,18 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 568800
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 568800,
+				tcgplayer: 247292
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH129.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH129.ts
@@ -86,18 +86,21 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 568801
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 568801,
+				tcgplayer: 247294
+			}
+		},
+		{
+			type: "normal"
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH130.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH130.ts
@@ -65,19 +65,26 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 572539
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572539,
+				tcgplayer: 245868
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 574296,
+				tcgplayer: 245870
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH131.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH131.ts
@@ -77,19 +77,26 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 572540
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572540,
+				tcgplayer: 245867
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 574297,
+				tcgplayer: 245869
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH132.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH132.ts
@@ -80,12 +80,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false,
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576731,
+				tcgplayer: 251088
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576905,
+				tcgplayer: 252817
+			}
+		},
+	],
 
 	hp: 150,
 	types: ["Psychic"],
@@ -101,9 +114,6 @@ const card: Card = {
 
 	retreat: 0,
 
-	thirdParty: {
-		cardmarket: 549386
-	}
 };
 
 export default card;

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH133.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH133.ts
@@ -52,21 +52,29 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576732,
+				tcgplayer: 251089
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576906,
+				tcgplayer: 251104
+			}
+		},
+	],
 
 	hp: 220,
 	types: ["Fire"],
-	retreat: 3,
-
-	thirdParty: {
-		cardmarket: 576732,
-		tcgplayer: 251089
-	}
+	retreat: 3
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH134.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH134.ts
@@ -74,21 +74,29 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576733,
+				tcgplayer: 251090
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576907,
+				tcgplayer: 251105
+			}
+		},
+	],
 
 	hp: 180,
 	types: ["Psychic"],
-	retreat: 1,
-
-	thirdParty: {
-		cardmarket: 576733,
-		tcgplayer: 251090
-	}
+	retreat: 1
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH135.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH135.ts
@@ -69,20 +69,20 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576734,
+				tcgplayer: 251091
+			}
+		},
+	],
 
 	hp: 160,
 	types: ["Metal"],
-	retreat: 2,
-
-	thirdParty: {
-		cardmarket: 491179
-	}
+	retreat: 2
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH136.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH136.ts
@@ -11,12 +11,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576735,
+				tcgplayer: 251092
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576908,
+				tcgplayer: 260878
+			}
+		},
+	],
 
 	name: {
 		en: "Mimikyu",
@@ -77,11 +90,7 @@ const card: Card = {
 		damage: 40
 	}],
 
-	retreat: 1,
-
-	thirdParty: {
-		cardmarket: 576735
-	}
+	retreat: 1
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH137.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH137.ts
@@ -11,12 +11,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576736,
+				tcgplayer: 251093
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576909,
+				tcgplayer: 260877
+			}
+		},
+	],
 
 	name: {
 		en: "Light Toxtricity",
@@ -90,10 +103,6 @@ const card: Card = {
 
 	description: {
 		en: "When this Pokémon sounds as if it's strumming a guitar, it's actually clawing at the protrusions on its chest to generate electricity.",
-	},
-
-	thirdParty: {
-		cardmarket: 576736
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH138.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH138.ts
@@ -11,12 +11,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576737,
+				tcgplayer: 251094
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576910,
+				tcgplayer: 260879
+			}
+		},
+	],
 
 	name: {
 		en: "Hydreigon C",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH139.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH139.ts
@@ -78,20 +78,27 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576738,
+				tcgplayer: 251095
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 576911,
+				tcgplayer: 251100
+			}
+		},
+	],
 
 	hp: 300,
 	types: ["Lightning"],
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576738
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH140.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH140.ts
@@ -78,20 +78,19 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576739,
+				tcgplayer: 251096
+			}
+		},
+	],
 
 	hp: 300,
 	types: ["Lightning"],
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576738
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH141.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH141.ts
@@ -78,20 +78,19 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576740,
+				tcgplayer: 251097
+			}
+		},
+	],
 
 	hp: 300,
 	types: ["Lightning"],
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576738
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH142.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH142.ts
@@ -78,20 +78,19 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576741,
+				tcgplayer: 251098
+			}
+		},
+	],
 
 	hp: 300,
 	types: ["Lightning"],
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576738
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH143.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH143.ts
@@ -11,12 +11,18 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576742,
+				tcgplayer: 251101
+			}
+		},
+	],
 
 	name: {
 		en: "Pikachu V",
@@ -59,11 +65,6 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 461594
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH144.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH144.ts
@@ -11,12 +11,16 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576743,
+				tcgplayer: 248731
+			}
+		},
+	],
 
 	name: {
 		en: "Greninja ☆",
@@ -72,11 +76,7 @@ const card: Card = {
 		}
 	}],
 
-	retreat: 1,
-
-	thirdParty: {
-		tcgplayer: 248731
-	}
+	retreat: 1
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH145.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH145.ts
@@ -11,12 +11,18 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576744,
+				tcgplayer: 251102
+			}
+		},
+	],
 
 	name: {
 		en: "Pikachu V",
@@ -59,11 +65,6 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 461594
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH146.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH146.ts
@@ -4,12 +4,16 @@ import Set from '../SWSH Black Star Promos'
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576745,
+				tcgplayer: 251103
+			}
+		},
+	],
 
 	name: {
 		en: "Poké Ball",
@@ -33,11 +37,7 @@ const card: Card = {
 		en: "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
 	},
 
-	trainerType: "Item",
-
-	thirdParty: {
-		cardmarket: 576745
-	}
+	trainerType: "Item"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH147.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH147.ts
@@ -68,20 +68,19 @@ const card: Card = {
 	regulationMark: "E",
 	suffix: "V",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576723,
+				tcgplayer: 250577
+			}
+		},
+	],
 
 	hp: 210,
 	types: ["Dragon"],
-	retreat: 2,
-
-	thirdParty: {
-		cardmarket: 576723
-	}
+	retreat: 2
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH148.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH148.ts
@@ -66,20 +66,19 @@ const card: Card = {
 	regulationMark: "E",
 	suffix: "V",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576724,
+				tcgplayer: 250578
+			}
+		},
+	],
 
 	hp: 200,
 	types: ["Dragon"],
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576724
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH149.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH149.ts
@@ -14,12 +14,21 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576502,
+				tcgplayer: 247295
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"]
+		},
+	],
 
 	name: {
 		en: "Flareon V",
@@ -79,14 +88,8 @@ const card: Card = {
 			it: "Il Pokémon attivo del tuo avversario viene bruciato."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 2,
-
-	thirdParty: {
-		cardmarket: 576502
-	}
+	retreat: 2
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH150.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH150.ts
@@ -14,12 +14,21 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576503,
+				tcgplayer: 247296
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"]
+		},
+	],
 
 	name: {
 		en: "Vaporeon V",
@@ -77,14 +86,8 @@ const card: Card = {
 			it: "Scambia questo Pokémon con uno della tua panchina."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 2,
-
-	thirdParty: {
-		cardmarket: 576503
-	}
+	retreat: 2
 }
 
 export default card


### PR DESCRIPTION
## Changes

Add variants for SWSH Black Star Promos SWSH101 to SWSH150

## Details

- 50 cards get `variants` with Cardmarket and TCGplayer ids
- covers the cosmos, prerelease (set logo and staff), jumbo, 25th celebration and Special Delivery printings