### PR TITLE
Add variants for SWSH Black Star Promos

### DIFF
--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH001.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH001.ts
@@ -58,18 +58,26 @@ const card: Card = {
 
 	dexId: [810],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427081
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 427081,
+				tcgplayer: 200300
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 547426,
+				tcgplayer: 231458
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH002.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH002.ts
@@ -64,18 +64,26 @@ const card: Card = {
 
 	dexId: [813],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427086
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 427086,
+				tcgplayer: 200301
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 547456,
+				tcgplayer: 231466
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH003.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH003.ts
@@ -65,18 +65,26 @@ const card: Card = {
 
 	dexId: [816],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427091
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 427091,
+				tcgplayer: 200302
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 547476,
+				tcgplayer: 231468
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH004.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH004.ts
@@ -77,19 +77,18 @@ const card: Card = {
 	retreat: 2,
 	dexId: [52],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 427096
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 427096,
+				tcgplayer: 205465
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH005.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH005.ts
@@ -71,18 +71,25 @@ const card: Card = {
 	retreat: 2,
 	dexId: [52],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427101
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 427101,
+				tcgplayer: 205466
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 453338,
+				tcgplayer: 205467
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH006.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH006.ts
@@ -91,18 +91,25 @@ const card: Card = {
 
 	dexId: [812],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 437154
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 437154,
+				tcgplayer: 208261
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 208260
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH007.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH007.ts
@@ -89,18 +89,25 @@ const card: Card = {
 
 	dexId: [873],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 437159
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 437159,
+				tcgplayer: 208262
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 208263
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH008.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH008.ts
@@ -97,18 +97,25 @@ const card: Card = {
 
 	dexId: [863],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 437164
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 437164,
+				tcgplayer: 208265
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 208264
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH009.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH009.ts
@@ -95,18 +95,25 @@ const card: Card = {
 
 	dexId: [573],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 437169
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 437169,
+				tcgplayer: 208266
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 208267
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH010.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH010.ts
@@ -63,18 +63,25 @@ const card: Card = {
 
 	dexId: [829],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 439958
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 439958,
+				tcgplayer: 206429
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549416,
+				tcgplayer: 232765
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH011.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH011.ts
@@ -80,18 +80,25 @@ const card: Card = {
 
 	dexId: [831],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 439963
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 439963,
+				tcgplayer: 206427
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549421,
+				tcgplayer: 232769
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH012.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH012.ts
@@ -66,18 +66,25 @@ const card: Card = {
 
 	dexId: [877],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427106
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 427106,
+				tcgplayer: 206428
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549431,
+				tcgplayer: 232766
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH013.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH013.ts
@@ -87,18 +87,25 @@ const card: Card = {
 
 	dexId: [77],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427111
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 427111,
+				tcgplayer: 206430
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549426,
+				tcgplayer: 232767
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH014.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH014.ts
@@ -71,19 +71,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [812],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 450673
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 450673,
+				tcgplayer: 206421
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 610513,
+				tcgplayer: 220754
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH015.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH015.ts
@@ -64,19 +64,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [815],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 450578
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 450578,
+				tcgplayer: 206419
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 610514,
+				tcgplayer: 220755
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH016.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH016.ts
@@ -71,19 +71,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [818],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 450618
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 450618,
+				tcgplayer: 206418
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 609015,
+				tcgplayer: 220753
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH017.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH017.ts
@@ -71,19 +71,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [849],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 450873
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 450873,
+				tcgplayer: 206425
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 453328,
+				tcgplayer: 206426
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH018.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH018.ts
@@ -78,19 +78,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [888],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 465529
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 465529,
+				tcgplayer: 214233
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH019.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH019.ts
@@ -78,19 +78,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [889],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 465534
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 465534,
+				tcgplayer: 214234
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH020.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH020.ts
@@ -68,18 +68,17 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [25],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461594
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 461594,
+				tcgplayer: 214241
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH021.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH021.ts
@@ -78,19 +78,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [855],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 461664
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 461664,
+				tcgplayer: 214235
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 576518,
+				tcgplayer: 214236
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH022.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH022.ts
@@ -87,18 +87,25 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [841],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453448
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 453448,
+				tcgplayer: 213096
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 213097
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH023.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH023.ts
@@ -77,18 +77,25 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [405],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453453
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 453453,
+				tcgplayer: 213144
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 213145
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH024.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH024.ts
@@ -78,18 +78,25 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [839],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453458
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 453458,
+				tcgplayer: 213196
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 213197
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH025.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH025.ts
@@ -78,18 +78,25 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [569],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453463
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 453463,
+				tcgplayer: 213211
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 213212
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH026.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH026.ts
@@ -67,18 +67,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [226],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461669
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 461669,
+				tcgplayer: 214237
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH027.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH027.ts
@@ -81,18 +81,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [164],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461674
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 461674,
+				tcgplayer: 214238
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH028.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH028.ts
@@ -73,18 +73,34 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [884],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453308
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 453308,
+				tcgplayer: 214239
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["eb-games"],
+			thirdParty: {
+				cardmarket: 886516,
+				tcgplayer: 624648
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["gamestop"],
+			thirdParty: {
+				cardmarket: 742039,
+				tcgplayer: 247362
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH029.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH029.ts
@@ -82,19 +82,24 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [384],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453313,
-		tcgplayer: 214240
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 453313,
+				tcgplayer: 214240
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				tcgplayer: 619563
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH030.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH030.ts
@@ -68,19 +68,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [879],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 477159
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 477159,
+				tcgplayer: 214228
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 576519,
+				tcgplayer: 214229
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH031.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH031.ts
@@ -76,19 +76,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [877],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427106,
-		tcgplayer: 210579
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 461679,
+				tcgplayer: 210579
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH032.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH032.ts
@@ -59,18 +59,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [143],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461684
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 461684,
+				tcgplayer: 210578
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH033.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH033.ts
@@ -82,18 +82,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [888],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 465529
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491179,
+				tcgplayer: 220313
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH034.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH034.ts
@@ -74,18 +74,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [889],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 465534
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491184,
+				tcgplayer: 220314
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH035.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH035.ts
@@ -87,18 +87,25 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [724],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 487069
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 487069,
+				tcgplayer: 218579
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 218578
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH036.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH036.ts
@@ -78,18 +78,25 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [881],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 487074
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 487074,
+				tcgplayer: 218580
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 218581
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH037.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH037.ts
@@ -78,18 +78,25 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [635],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 487079
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 487079,
+				tcgplayer: 218583
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 218582
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH038.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH038.ts
@@ -68,18 +68,25 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [115],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 487084
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 487084,
+				tcgplayer: 218574
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 218576
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH039.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH039.ts
@@ -67,18 +67,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [25],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461594
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491189,
+				tcgplayer: 220268
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 549406,
+				tcgplayer: 232764
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH040.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH040.ts
@@ -72,18 +72,25 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [856],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 491194
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491194,
+				tcgplayer: 220269
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549411,
+				tcgplayer: 232768
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH041.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH041.ts
@@ -85,18 +85,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [136],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 491199
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491199,
+				tcgplayer: 220270
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH042.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH042.ts
@@ -76,18 +76,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [133],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 491204,
+				tcgplayer: 220271
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH043.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH043.ts
@@ -73,19 +73,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [865],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 505860
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 505860,
+				tcgplayer: 220273
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 560033,
+				tcgplayer: 220274
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH044.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH044.ts
@@ -72,19 +72,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [890],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 496315
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 496325,
+				tcgplayer: 220279
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH045.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH045.ts
@@ -82,18 +82,25 @@ const card: Card = {
 	stage: "VMAX",
 	dexId: [890],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 496325
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 496320,
+				tcgplayer: 220281
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 496315,
+				tcgplayer: 220282
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH046.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH046.ts
@@ -76,18 +76,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [830],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505865
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505865,
+				tcgplayer: 223751
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH047.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH047.ts
@@ -86,18 +86,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [834],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505870
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505870,
+				tcgplayer: 223750
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH048.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH048.ts
@@ -85,18 +85,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [851],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505875
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505875,
+				tcgplayer: 223749
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH049.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH049.ts
@@ -73,19 +73,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [832],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 505855
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 505855,
+				tcgplayer: 223752
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 574323,
+				tcgplayer: 223753
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH050.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH050.ts
@@ -63,20 +63,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [6],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 505255,
-		tcgplayer: 223754
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 505255,
+				tcgplayer: 223754
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH051.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH051.ts
@@ -56,18 +56,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [131],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505895
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505895,
+				tcgplayer: 222071
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH052.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH052.ts
@@ -92,18 +92,18 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [94],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505880
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505880,
+				tcgplayer: 222072
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH053.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH053.ts
@@ -86,18 +86,18 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [68],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 505885
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505885,
+				tcgplayer: 222073
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH054.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH054.ts
@@ -78,18 +78,18 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [839],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453458
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 505890,
+				tcgplayer: 222074
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH055.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH055.ts
@@ -76,19 +76,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [858],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 510175
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 510180,
+				tcgplayer: 223755
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 510175,
+				tcgplayer: 223756
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH056.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH056.ts
@@ -72,19 +72,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [877],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 510185
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 510185,
+				tcgplayer: 223757
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH057.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH057.ts
@@ -63,19 +63,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [861],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 510190
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 510190,
+				tcgplayer: 223758
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 557272,
+				tcgplayer: 229436
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH058.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH058.ts
@@ -85,18 +85,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [869],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516314
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516314,
+				tcgplayer: 227029
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH059.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH059.ts
@@ -87,18 +87,18 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [862],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516319
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516319,
+				tcgplayer: 227030
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH060.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH060.ts
@@ -73,18 +73,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [884],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 453308
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516324,
+				tcgplayer: 227031
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH061.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH061.ts
@@ -71,20 +71,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [25],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 496545,
-		tcgplayer: 232434
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 540616,
+				tcgplayer: 232434
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 565010,
+				tcgplayer: 232443
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH062.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH062.ts
@@ -11,12 +11,18 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "D",
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576730,
+				tcgplayer: 251086
+			}
+		},
+	],
 
 	name: {
 		en: "Pikachu VMAX",
@@ -67,11 +73,6 @@ const card: Card = {
 	}],
 
 	retreat: 2,
-	regulationMark: "D",
-
-	thirdParty: {
-		cardmarket: 576730
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH063.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH063.ts
@@ -63,19 +63,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [25],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 461594
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 496545,
+				tcgplayer: 220315
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH064.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH064.ts
@@ -72,19 +72,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [890],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 496325
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 496550,
+				tcgplayer: 220316
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH065.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH065.ts
@@ -71,19 +71,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [133],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 496555
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 496555,
+				tcgplayer: 220317
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH066.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH066.ts
@@ -87,18 +87,25 @@ const card: Card = {
 	stage: "Stage2",
 	dexId: [6],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516329
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 516329,
+				tcgplayer: 224365
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 224366
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH067.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH067.ts
@@ -77,18 +77,25 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [232],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516334
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 516334,
+				tcgplayer: 224368
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 224367
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH068.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH068.ts
@@ -78,18 +78,25 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [143],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461684
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 516339,
+				tcgplayer: 224361
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 224362
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH069.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH069.ts
@@ -73,18 +73,25 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [249],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516344
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 516344,
+				tcgplayer: 224364
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 224363
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH070.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH070.ts
@@ -56,18 +56,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [810],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427081
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516349,
+				tcgplayer: 227028
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH071.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH071.ts
@@ -67,18 +67,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [813],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427086
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516354,
+				tcgplayer: 227027
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH072.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH072.ts
@@ -87,18 +87,18 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [134],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516359
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516359,
+				tcgplayer: 221753
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH073.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH073.ts
@@ -67,18 +67,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [816],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427091
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516364,
+				tcgplayer: 221754
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH074.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH074.ts
@@ -51,18 +51,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [25],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 516369
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 516369,
+				tcgplayer: 227646
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH075.ts
@@ -56,13 +56,18 @@ const card: Card = {
 
 	retreat: 3,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
+	regulationMark: "D",
 
-	regulationMark: "D"
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 668172,
+				tcgplayer: 282259
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH076.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH076.ts
@@ -78,19 +78,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [888],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 465529
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 522960,
+				tcgplayer: 228595
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH077.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH077.ts
@@ -78,19 +78,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [889],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 465534
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 522965,
+				tcgplayer: 228596
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH078.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH078.ts
@@ -72,19 +72,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [826],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 522970
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 522970,
+				tcgplayer: 227025
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 522980,
+				tcgplayer: 227026
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH079.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH079.ts
@@ -88,18 +88,18 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 540621
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 540621,
+				tcgplayer: 232450
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH080.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH080.ts
@@ -57,18 +57,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 540626
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 540626,
+				tcgplayer: 232453
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH081.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH081.ts
@@ -93,18 +93,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 461664
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 540631,
+				tcgplayer: 232458
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH082.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH082.ts
@@ -57,18 +57,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 540636
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 540636,
+				tcgplayer: 232461
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH083.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH083.ts
@@ -76,19 +76,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [65],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 530482
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 530487,
+				tcgplayer: 228980
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 530482,
+				tcgplayer: 228981
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH084.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH084.ts
@@ -74,19 +74,26 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 540641
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 540641,
+				tcgplayer: 232481
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 610515,
+				tcgplayer: 251623
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH085.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH085.ts
@@ -72,19 +72,26 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 540646
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 540646,
+				tcgplayer: 232499
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 610516,
+				tcgplayer: 243659
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH086.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH086.ts
@@ -75,19 +75,26 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 540651
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 540651,
+				tcgplayer: 232503
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 610517,
+				tcgplayer: 251622
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH087.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH087.ts
@@ -61,19 +61,17 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 540656,
-		tcgplayer: 232611
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 540656,
+				tcgplayer: 232611
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH088.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH088.ts
@@ -64,12 +64,22 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [421],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 546936,
+				tcgplayer: 234276
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 
 	attacks: [{
 		name: {
@@ -84,12 +94,6 @@ const card: Card = {
 		damage: 70,
 		cost: ["Grass", "Colorless", "Colorless"]
 	}],
-
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 546936
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH089.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH089.ts
@@ -64,12 +64,22 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [224],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 546941,
+				tcgplayer: 234277
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 
 	attacks: [{
 		name: {
@@ -84,12 +94,6 @@ const card: Card = {
 		damage: 50,
 		cost: ["Water", "Colorless", "Colorless"]
 	}],
-
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 546941
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH090.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH090.ts
@@ -78,18 +78,22 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [229],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 546961
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 546961,
+				tcgplayer: 234278
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH091.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH091.ts
@@ -83,18 +83,22 @@ const card: Card = {
 	stage: "Stage1",
 	dexId: [437],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 546966
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 546966,
+				tcgplayer: 234279
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH092.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH092.ts
@@ -68,18 +68,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 547031
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 547031,
+				tcgplayer: 234282
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH093.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH093.ts
@@ -68,18 +68,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 547036
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 547036,
+				tcgplayer: 234283
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH094.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH094.ts
@@ -84,18 +84,18 @@ const card: Card = {
 	retreat: 0,
 	dexId: [135],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 547021
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 547021,
+				tcgplayer: 234284
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH095.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH095.ts
@@ -67,18 +67,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [133],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 547026,
+				tcgplayer: 234287
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH096.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH096.ts
@@ -70,19 +70,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 549386
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549386,
+				tcgplayer: 232610
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH097.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH097.ts
@@ -88,18 +88,25 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 549391
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549391,
+				tcgplayer: 232608
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 556545,
+				tcgplayer: 232609
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH098.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH098.ts
@@ -74,19 +74,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 549396
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549396,
+				tcgplayer: 232612
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH099.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH099.ts
@@ -74,18 +74,25 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 549401
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 549401,
+				tcgplayer: 232613
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 556553,
+				tcgplayer: 232614
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH100.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH100.ts
@@ -74,19 +74,18 @@ const card: Card = {
 
 	retreat: 3,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 538768
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 538768,
+				tcgplayer: 232723
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH101.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH101.ts
@@ -65,19 +65,18 @@ const card: Card = {
 
 	retreat: 3,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 538773
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 538773,
+				tcgplayer: 232724
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH102.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH102.ts
@@ -81,18 +81,25 @@ const card: Card = {
 	stage: "VMAX",
 	dexId: [3],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 546981
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 546981,
+				tcgplayer: 234298
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 557273,
+				tcgplayer: 234375
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH103.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH103.ts
@@ -81,18 +81,25 @@ const card: Card = {
 	stage: "VMAX",
 	dexId: [9],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 546986
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 546986,
+				tcgplayer: 234299
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 557274,
+				tcgplayer: 234376
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH104.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH104.ts
@@ -71,19 +71,18 @@ const card: Card = {
 	retreat: 2,
 	dexId: [494],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 561769
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561769,
+				tcgplayer: 238546
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH105.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH105.ts
@@ -63,19 +63,18 @@ const card: Card = {
 	retreat: 2,
 	dexId: [282],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 561770
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561770,
+				tcgplayer: 238545
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH106.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH106.ts
@@ -63,19 +63,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [892],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 546971
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 546971,
+				tcgplayer: 234296
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 557275,
+				tcgplayer: 234377
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH107.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH107.ts
@@ -63,19 +63,26 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [892],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 546976
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 546976,
+				tcgplayer: 234297
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 557276,
+				tcgplayer: 234378
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH108.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH108.ts
@@ -73,19 +73,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [395],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 547866
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547866,
+				tcgplayer: 238555
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH109.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH109.ts
@@ -72,19 +72,18 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [248],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 547871
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 547871,
+				tcgplayer: 238553
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH110.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH110.ts
@@ -74,19 +74,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 549396
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572538,
+				tcgplayer: 245875
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH111.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH111.ts
@@ -76,19 +76,34 @@ const card: Card = {
 	retreat: 1,
 	dexId: [78],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 561771
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 561771,
+				tcgplayer: 236054
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 561772,
+				tcgplayer: 236055
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 697102,
+				tcgplayer: 476015
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH112.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH112.ts
@@ -88,18 +88,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 450578
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 566760,
+				tcgplayer: 240891
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH113.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH113.ts
@@ -79,18 +79,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 450618
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 566761,
+				tcgplayer: 240892
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH114.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH114.ts
@@ -82,18 +82,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 566762
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 566762,
+				tcgplayer: 240893
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH115.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH115.ts
@@ -77,18 +77,22 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 566763
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 566763,
+				tcgplayer: 240894
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH116.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH116.ts
@@ -77,18 +77,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 427106
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 557973,
+				tcgplayer: 241881
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH117.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH117.ts
@@ -70,18 +70,18 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 557974
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 557974,
+				tcgplayer: 241882
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH118.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH118.ts
@@ -77,18 +77,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 557975,
+				tcgplayer: 241883
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH119.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH119.ts
@@ -70,18 +70,18 @@ const card: Card = {
 
 	retreat: 4,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 461684
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 557976,
+				tcgplayer: 241884
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH120.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH120.ts
@@ -28,18 +28,18 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 566764
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 566764,
+				tcgplayer: 245871
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH121.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH121.ts
@@ -28,18 +28,17 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
 
-	thirdParty: {
-		cardmarket: 566764
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 566765,
+				tcgplayer: 245872
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH122.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH122.ts
@@ -79,18 +79,22 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 573857
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 573857,
+				tcgplayer: 246931
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH123.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH123.ts
@@ -82,18 +82,22 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 573858
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 573858,
+				tcgplayer: 246927
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH124.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH124.ts
@@ -79,18 +79,22 @@ const card: Card = {
 
 	retreat: 0,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 573859
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 573859,
+				tcgplayer: 246933
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH125.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH125.ts
@@ -79,18 +79,22 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 573860
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 573860,
+				tcgplayer: 246929
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH126.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH126.ts
@@ -73,18 +73,18 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 568798
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 568798,
+				tcgplayer: 247290
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH127.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH127.ts
@@ -68,18 +68,18 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 568799,
+				tcgplayer: 247291
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH128.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH128.ts
@@ -68,18 +68,18 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 568800
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 568800,
+				tcgplayer: 247292
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH129.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH129.ts
@@ -86,18 +86,21 @@ const card: Card = {
 
 	retreat: 1,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
 
-	thirdParty: {
-		cardmarket: 568801
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 568801,
+				tcgplayer: 247294
+			}
+		},
+		{
+			type: "normal"
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH130.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH130.ts
@@ -65,19 +65,26 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 572539
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572539,
+				tcgplayer: 245868
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 574296,
+				tcgplayer: 245870
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH131.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH131.ts
@@ -77,19 +77,26 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
-
 	regulationMark: "E",
-	suffix: "V",
 
-	thirdParty: {
-		cardmarket: 572540
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572540,
+				tcgplayer: 245867
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 574297,
+				tcgplayer: 245869
+			}
+		},
+	],
+	suffix: "V"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH132.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH132.ts
@@ -80,12 +80,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false,
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576731,
+				tcgplayer: 251088
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576905,
+				tcgplayer: 252817
+			}
+		},
+	],
 
 	hp: 150,
 	types: ["Psychic"],
@@ -101,9 +114,6 @@ const card: Card = {
 
 	retreat: 0,
 
-	thirdParty: {
-		cardmarket: 549386
-	}
 };
 
 export default card;

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH133.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH133.ts
@@ -52,21 +52,29 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576732,
+				tcgplayer: 251089
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576906,
+				tcgplayer: 251104
+			}
+		},
+	],
 
 	hp: 220,
 	types: ["Fire"],
-	retreat: 3,
-
-	thirdParty: {
-		cardmarket: 576732,
-		tcgplayer: 251089
-	}
+	retreat: 3
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH134.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH134.ts
@@ -74,21 +74,29 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576733,
+				tcgplayer: 251090
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576907,
+				tcgplayer: 251105
+			}
+		},
+	],
 
 	hp: 180,
 	types: ["Psychic"],
-	retreat: 1,
-
-	thirdParty: {
-		cardmarket: 576733,
-		tcgplayer: 251090
-	}
+	retreat: 1
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH135.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH135.ts
@@ -69,20 +69,20 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576734,
+				tcgplayer: 251091
+			}
+		},
+	],
 
 	hp: 160,
 	types: ["Metal"],
-	retreat: 2,
-
-	thirdParty: {
-		cardmarket: 491179
-	}
+	retreat: 2
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH136.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH136.ts
@@ -11,12 +11,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576735,
+				tcgplayer: 251092
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576908,
+				tcgplayer: 260878
+			}
+		},
+	],
 
 	name: {
 		en: "Mimikyu",
@@ -77,11 +90,7 @@ const card: Card = {
 		damage: 40
 	}],
 
-	retreat: 1,
-
-	thirdParty: {
-		cardmarket: 576735
-	}
+	retreat: 1
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH137.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH137.ts
@@ -11,12 +11,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576736,
+				tcgplayer: 251093
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576909,
+				tcgplayer: 260877
+			}
+		},
+	],
 
 	name: {
 		en: "Light Toxtricity",
@@ -90,10 +103,6 @@ const card: Card = {
 
 	description: {
 		en: "When this Pokémon sounds as if it's strumming a guitar, it's actually clawing at the protrusions on its chest to generate electricity.",
-	},
-
-	thirdParty: {
-		cardmarket: 576736
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH138.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH138.ts
@@ -11,12 +11,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576737,
+				tcgplayer: 251094
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576910,
+				tcgplayer: 260879
+			}
+		},
+	],
 
 	name: {
 		en: "Hydreigon C",

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH139.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH139.ts
@@ -78,20 +78,27 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576738,
+				tcgplayer: 251095
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 576911,
+				tcgplayer: 251100
+			}
+		},
+	],
 
 	hp: 300,
 	types: ["Lightning"],
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576738
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH140.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH140.ts
@@ -78,20 +78,19 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576739,
+				tcgplayer: 251096
+			}
+		},
+	],
 
 	hp: 300,
 	types: ["Lightning"],
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576738
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH141.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH141.ts
@@ -78,20 +78,19 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576740,
+				tcgplayer: 251097
+			}
+		},
+	],
 
 	hp: 300,
 	types: ["Lightning"],
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576738
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH142.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH142.ts
@@ -78,20 +78,19 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576741,
+				tcgplayer: 251098
+			}
+		},
+	],
 
 	hp: 300,
 	types: ["Lightning"],
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576738
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH143.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH143.ts
@@ -11,12 +11,18 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576742,
+				tcgplayer: 251101
+			}
+		},
+	],
 
 	name: {
 		en: "Pikachu V",
@@ -59,11 +65,6 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 461594
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH144.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH144.ts
@@ -11,12 +11,16 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576743,
+				tcgplayer: 248731
+			}
+		},
+	],
 
 	name: {
 		en: "Greninja ☆",
@@ -72,11 +76,7 @@ const card: Card = {
 		}
 	}],
 
-	retreat: 1,
-
-	thirdParty: {
-		tcgplayer: 248731
-	}
+	retreat: 1
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH145.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH145.ts
@@ -11,12 +11,18 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576744,
+				tcgplayer: 251102
+			}
+		},
+	],
 
 	name: {
 		en: "Pikachu V",
@@ -59,11 +65,6 @@ const card: Card = {
 	}],
 
 	retreat: 1,
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 461594
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH146.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH146.ts
@@ -4,12 +4,16 @@ import Set from '../SWSH Black Star Promos'
 const card: Card = {
 	set: Set,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576745,
+				tcgplayer: 251103
+			}
+		},
+	],
 
 	name: {
 		en: "Poké Ball",
@@ -33,11 +37,7 @@ const card: Card = {
 		en: "Flip a coin. If heads, search your deck for a Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward."
 	},
 
-	trainerType: "Item",
-
-	thirdParty: {
-		cardmarket: 576745
-	}
+	trainerType: "Item"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH147.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH147.ts
@@ -68,20 +68,19 @@ const card: Card = {
 	regulationMark: "E",
 	suffix: "V",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576723,
+				tcgplayer: 250577
+			}
+		},
+	],
 
 	hp: 210,
 	types: ["Dragon"],
-	retreat: 2,
-
-	thirdParty: {
-		cardmarket: 576723
-	}
+	retreat: 2
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH148.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH148.ts
@@ -66,20 +66,19 @@ const card: Card = {
 	regulationMark: "E",
 	suffix: "V",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576724,
+				tcgplayer: 250578
+			}
+		},
+	],
 
 	hp: 200,
 	types: ["Dragon"],
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576724
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH149.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH149.ts
@@ -14,12 +14,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576502,
+				tcgplayer: 247295
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 697074,
+				tcgplayer: 475984
+			}
+		},
+	],
 
 	name: {
 		en: "Flareon V",
@@ -79,14 +92,8 @@ const card: Card = {
 			it: "Il Pokémon attivo del tuo avversario viene bruciato."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 2,
-
-	thirdParty: {
-		cardmarket: 576502
-	}
+	retreat: 2
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH150.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH150.ts
@@ -14,12 +14,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576503,
+				tcgplayer: 247296
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 697081,
+				tcgplayer: 475992
+			}
+		},
+	],
 
 	name: {
 		en: "Vaporeon V",
@@ -77,14 +90,8 @@ const card: Card = {
 			it: "Scambia questo Pokémon con uno della tua panchina."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 2,
-
-	thirdParty: {
-		cardmarket: 576503
-	}
+	retreat: 2
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH151.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH151.ts
@@ -14,12 +14,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: true,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576504,
+				tcgplayer: 247297
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 697097,
+				tcgplayer: 476009
+			}
+		},
+	],
 
 	name: {
 		en: "Jolteon V",
@@ -77,14 +90,8 @@ const card: Card = {
 			it: "Lancia quattro volte una moneta. Questo attacco infligge 60 danni ogni volta che esce testa."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 576504
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH152.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH152.ts
@@ -36,10 +36,15 @@ const card: Card = {
 
 	trainerType: "Supporter",
 	regulationMark: "D",
-
-	thirdParty: {
-		cardmarket: 569233
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 611309,
+				tcgplayer: 268709
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH153.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH153.ts
@@ -56,10 +56,16 @@ const card: Card = {
 	description: {
 		en: "Pikachu that can generate powerful electricity have cheek sacs that are extra soft and super stretchy."
 	},
-
-	thirdParty: {
-		cardmarket: 461594
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["snowflake"],
+			thirdParty: {
+				cardmarket: 672386,
+				tcgplayer: 283301
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH154.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH154.ts
@@ -5,12 +5,33 @@ const card: Card = {
 	dexId: [149],
 	set: Set,
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 576501,
+				tcgplayer: 247298
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 576726,
+				tcgplayer: 253421
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["shao-tong-yen"],
+			thirdParty: {
+				cardmarket: 833232,
+				tcgplayer: 542073
+			}
+		},
+	],
 
 	name: {
 		en: "Dragonite V",
@@ -75,11 +96,6 @@ const card: Card = {
 	}],
 
 	retreat: 3,
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 576501
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH155.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH155.ts
@@ -14,12 +14,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572155,
+				tcgplayer: 248887
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 576912,
+				tcgplayer: 250251
+			}
+		},
+	],
 
 	name: {
 		en: "Greninja V-UNION",
@@ -116,14 +129,8 @@ const card: Card = {
 			fr: "Pendant le prochain tour de votre adversaire, le Pokémon Défenseur ne peut pas battre en retraite."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572155
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH156.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH156.ts
@@ -14,12 +14,17 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572156,
+				tcgplayer: 248888
+			}
+		},
+	],
 
 	name: {
 		en: "Greninja V-UNION",
@@ -116,14 +121,8 @@ const card: Card = {
 			fr: "Pendant le prochain tour de votre adversaire, le Pokémon Défenseur ne peut pas battre en retraite."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572155
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH157.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH157.ts
@@ -14,12 +14,17 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572157,
+				tcgplayer: 248889
+			}
+		},
+	],
 
 	name: {
 		en: "Greninja V-UNION",
@@ -116,14 +121,8 @@ const card: Card = {
 			fr: "Pendant le prochain tour de votre adversaire, le Pokémon Défenseur ne peut pas battre en retraite."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572155
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH158.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH158.ts
@@ -14,12 +14,17 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572158,
+				tcgplayer: 248890
+			}
+		},
+	],
 
 	name: {
 		en: "Greninja V-UNION",
@@ -116,14 +121,8 @@ const card: Card = {
 			fr: "Pendant le prochain tour de votre adversaire, le Pokémon Défenseur ne peut pas battre en retraite."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572155
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH159.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH159.ts
@@ -20,12 +20,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572159,
+				tcgplayer: 248891
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 576913,
+				tcgplayer: 250252
+			}
+		},
+	],
 
 	name: {
 		en: "Mewtwo V-UNION",
@@ -100,14 +113,8 @@ const card: Card = {
 
 		damage: 300
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572159
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH160.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH160.ts
@@ -20,12 +20,17 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572160,
+				tcgplayer: 248892
+			}
+		},
+	],
 
 	name: {
 		en: "Mewtwo V-UNION",
@@ -100,14 +105,8 @@ const card: Card = {
 
 		damage: 300
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572159
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH161.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH161.ts
@@ -20,12 +20,17 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572161,
+				tcgplayer: 248893
+			}
+		},
+	],
 
 	name: {
 		en: "Mewtwo V-UNION",
@@ -100,14 +105,8 @@ const card: Card = {
 
 		damage: 300
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572159
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH162.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH162.ts
@@ -20,12 +20,17 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572162,
+				tcgplayer: 248894
+			}
+		},
+	],
 
 	name: {
 		en: "Mewtwo V-UNION",
@@ -100,14 +105,8 @@ const card: Card = {
 
 		damage: 300
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572159
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH163.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH163.ts
@@ -20,12 +20,25 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572163,
+				tcgplayer: 247364
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 576915,
+				tcgplayer: 250253
+			}
+		},
+	],
 
 	name: {
 		en: "Zacian V-UNION",
@@ -90,14 +103,8 @@ const card: Card = {
 			fr: "Défaussez 3 Énergies de ce Pokémon."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572163
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH164.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH164.ts
@@ -20,12 +20,17 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572164,
+				tcgplayer: 247365
+			}
+		},
+	],
 
 	name: {
 		en: "Zacian V-UNION",
@@ -90,14 +95,8 @@ const card: Card = {
 			fr: "Défaussez 3 Énergies de ce Pokémon."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572163
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH165.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH165.ts
@@ -20,12 +20,17 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572165,
+				tcgplayer: 247366
+			}
+		},
+	],
 
 	name: {
 		en: "Zacian V-UNION",
@@ -90,14 +95,8 @@ const card: Card = {
 			fr: "Défaussez 3 Énergies de ce Pokémon."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572163
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH166.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH166.ts
@@ -20,12 +20,17 @@ const card: Card = {
 		},
 	],
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 572166,
+				tcgplayer: 247367
+			}
+		},
+	],
 
 	name: {
 		en: "Zacian V-UNION",
@@ -90,14 +95,8 @@ const card: Card = {
 			fr: "Défaussez 3 Énergies de ce Pokémon."
 		}
 	}],
-
-	regulationMark: "E",
 	suffix: "V",
-	retreat: 0,
-
-	thirdParty: {
-		cardmarket: 572163
-	}
+	retreat: 0
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH167.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH167.ts
@@ -6,12 +6,41 @@ const card: Card = {
 	illustrator: "Ryuta Fuse",
 	category: "Trainer",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 749245,
+				tcgplayer: 247299
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["25th-celebration"],
+			thirdParty: {
+				cardmarket: 576725,
+				tcgplayer: 247300
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["professor-program"],
+			thirdParty: {
+				cardmarket: 664818,
+				tcgplayer: 278685
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["gabriel-fernandez"],
+			thirdParty: {
+				cardmarket: 832989,
+				tcgplayer: 541790
+			}
+		},
+	],
 
 	name: {
 		en: "Professor Burnet",
@@ -33,12 +62,6 @@ const card: Card = {
 		pt: "Procure por até 2 cartas no seu baralho e descarte-as. Em seguida, embaralhe o seu baralho.",
 		it: "Cerca nel tuo mazzo fino a due carte e scartale. Poi rimischia le carte del tuo mazzo."
 	},
-
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 576725
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH168.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH168.ts
@@ -76,10 +76,16 @@ const card: Card = {
 	description: {
 		en: "This Oricorio has drunk red nectar. If its Trainer gives the wrong order, this passionate Pokémon becomes fiercely angry."
 	},
-
-	thirdParty: {
-		cardmarket: 580165
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 580165,
+				tcgplayer: 253404
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH169.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH169.ts
@@ -69,10 +69,16 @@ const card: Card = {
 	description: {
 		en: "It's covered in a slime that keeps its skin moist, allowing it to stay on land for days without drying up."
 	},
-
-	thirdParty: {
-		cardmarket: 580166
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 580166,
+				tcgplayer: 253405
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH170.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH170.ts
@@ -62,10 +62,16 @@ const card: Card = {
 	description: {
 		en: "DNA from a space virus mutated and became a Pokémon. It appears where auroras are seen."
 	},
-
-	thirdParty: {
-		cardmarket: 580167
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 580167,
+				tcgplayer: 253406
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH171.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH171.ts
@@ -72,10 +72,16 @@ const card: Card = {
 	description: {
 		en: "It can telepathically communicate with people. It changes its appearance using its down that refracts light."
 	},
-
-	thirdParty: {
-		cardmarket: 580168
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 580168,
+				tcgplayer: 253407
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH172.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH172.ts
@@ -60,10 +60,16 @@ const card: Card = {
 	description: {
 		en: "It loves to eat roasted berries, but sometimes it gets too excited and burns them to a crisp."
 	},
-
-	thirdParty: {
-		cardmarket: 583199
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 583199,
+				tcgplayer: 253408
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH173.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH173.ts
@@ -54,10 +54,16 @@ const card: Card = {
 	description: {
 		en: "Its mane shines when it discharges electricity. They use the frequency and rhythm of these flashes to communicate."
 	},
-
-	thirdParty: {
-		cardmarket: 583200
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 583200,
+				tcgplayer: 253409
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH174.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH174.ts
@@ -94,10 +94,16 @@ const card: Card = {
 	description: {
 		en: "It unleashes psychic power from the orb on its forehead. When its power is exhausted, the orb grows dull and dark."
 	},
-
-	thirdParty: {
-		cardmarket: 583201
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 583201,
+				tcgplayer: 253410
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH175.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH175.ts
@@ -67,10 +67,16 @@ const card: Card = {
 	description: {
 		en: "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions."
 	},
-
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 583202,
+				tcgplayer: 253413
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH176.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH176.ts
@@ -75,10 +75,23 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 583203
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 583203,
+				tcgplayer: 253412
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 583684,
+				tcgplayer: 253420
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH177.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH177.ts
@@ -14,19 +14,24 @@ const card: Card = {
 	],
 	retreat: 2,
 
-
 	description: {
 		en: "It constantly gnaws on logs and rocks to whittle down its front teeth. It nests alongside water."
 	},
 
 	stage: "Basic",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
+	regulationMark: "E",
+
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 571388,
+				tcgplayer: 247386
+			}
+		},
+	],
 
 	name: {
 		en: "Special Delivery Bidoof"
@@ -59,12 +64,6 @@ const card: Card = {
 			en: "Flip a coin. If heads, this attack does 30 more damage."
 		}
 	}],
-
-	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 571388
-	}
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH178.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH178.ts
@@ -28,14 +28,24 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	variants: {
-		normal: false,
-		reverse: false,
-		holo: false,
-		firstEdition: false
-	},
-
 	regulationMark: "D",
+
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 569233,
+				tcgplayer: 246275
+			}
+		},
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 817865,
+				tcgplayer: 278705
+			}
+		},
+	],
 
 	description: {
 		fr: "Professeur Willow",
@@ -44,10 +54,6 @@ const card: Card = {
 		pt: "Prof. Willow",
 		it: "Professor Willow",
 		en: "Professor Willow"
-	},
-
-	thirdParty: {
-		cardmarket: 569233
 	}
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH179.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH179.ts
@@ -75,10 +75,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 491199
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 583204,
+				tcgplayer: 253414
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH180.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH180.ts
@@ -62,10 +62,23 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 583205
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 583205,
+				tcgplayer: 253415
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 605843,
+				tcgplayer: 257709
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH181.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH181.ts
@@ -73,10 +73,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 516359
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 583206,
+				tcgplayer: 253416
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH182.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH182.ts
@@ -82,10 +82,23 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 583207
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 583207,
+				tcgplayer: 253417
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 605844,
+				tcgplayer: 257708
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH183.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH183.ts
@@ -73,10 +73,15 @@ const card: Card = {
 	],
 	retreat: 0,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 547021
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 583208,
+				tcgplayer: 253418
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH184.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH184.ts
@@ -62,10 +62,23 @@ const card: Card = {
 	],
 	retreat: 0,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 583209
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 583209,
+				tcgplayer: 253419
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 605845,
+				tcgplayer: 257710
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH185.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH185.ts
@@ -56,10 +56,20 @@ const card: Card = {
 	description: {
 		en: "It's one of the legendary bird Pokémon. When Moltres flaps its flaming wings, they glimmer with a dazzling red glow."
 	},
-
-	thirdParty: {
-		cardmarket: 606599
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 606599,
+				tcgplayer: 264277
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH186.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH186.ts
@@ -88,10 +88,20 @@ const card: Card = {
 	description: {
 		en: "It controls waves known as auras, which are powerful enough to pulverize huge rocks. It uses these waves to take down its prey."
 	},
-
-	thirdParty: {
-		cardmarket: 606600
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 606600,
+				tcgplayer: 264278
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH187.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH187.ts
@@ -79,10 +79,20 @@ const card: Card = {
 	description: {
 		en: "Don't be fooled by its gorgeous fur and elegant figure. This is a moody and vicious Pokémon."
 	},
-
-	thirdParty: {
-		cardmarket: 606601
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 606601,
+				tcgplayer: 264279
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH188.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH188.ts
@@ -88,10 +88,20 @@ const card: Card = {
 	description: {
 		en: "It makes its nest by damming streams with bark and mud. It is known as an industrious worker."
 	},
-
-	thirdParty: {
-		cardmarket: 606602
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 606602,
+				tcgplayer: 264280
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH189.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH189.ts
@@ -80,10 +80,16 @@ const card: Card = {
 	description: {
 		en: "It flies on wings of apple skin and spits a powerful acid. It can also change its shape into that of an apple."
 	},
-
-	thirdParty: {
-		cardmarket: 453448
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 609463,
+				tcgplayer: 264282
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH190.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH190.ts
@@ -67,10 +67,16 @@ const card: Card = {
 	description: {
 		en: "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions."
 	},
-
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 609464,
+				tcgplayer: 264283
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH191.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH191.ts
@@ -88,10 +88,16 @@ const card: Card = {
 	description: {
 		en: "This Pokémon's tail is blade sharp, with a fantastic cutting edge that can slice right though large trees."
 	},
-
-	thirdParty: {
-		cardmarket: 604996
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 606748,
+				tcgplayer: 264284
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH192.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH192.ts
@@ -86,10 +86,16 @@ const card: Card = {
 	description: {
 		en: "The coldness emanating from Glaceon causes powdery snow to form, making it quite a popular Pokémon at ski resorts."
 	},
-
-	thirdParty: {
-		cardmarket: 604998
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 606749,
+				tcgplayer: 264285
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH193.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH193.ts
@@ -66,10 +66,15 @@ const card: Card = {
 	description: {
 		en: "It evolved after experiencing numerous fights. While crossing its arms, it lets out a shout that would make any opponent flinch."
 	},
-
-	thirdParty: {
-		cardmarket: 516319
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 609465,
+				tcgplayer: 268708
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH194.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH194.ts
@@ -75,10 +75,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 606748
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 604996,
+				tcgplayer: 262563
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH195.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH195.ts
@@ -63,10 +63,31 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 604997
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 604997,
+				tcgplayer: 262566
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 605846,
+				tcgplayer: 263260
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 705128,
+				tcgplayer: 489306
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH196.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH196.ts
@@ -66,10 +66,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 606749
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 604998,
+				tcgplayer: 262571
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH197.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH197.ts
@@ -85,10 +85,31 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 604999
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 604999,
+				tcgplayer: 262569
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 605847,
+				tcgplayer: 263261
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 705117,
+				tcgplayer: 489300
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH198.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH198.ts
@@ -53,10 +53,23 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 461594
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 604984,
+				tcgplayer: 260711
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 605848,
+				tcgplayer: 260712
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH199.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH199.ts
@@ -66,10 +66,15 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 584316
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 584316,
+				tcgplayer: 266616
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH200.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH200.ts
@@ -81,10 +81,15 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 584317
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 584317,
+				tcgplayer: 266627
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH201.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH201.ts
@@ -70,11 +70,15 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 609460,
-		tcgplayer: 268710
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609460,
+				tcgplayer: 268710
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH202.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH202.ts
@@ -66,10 +66,15 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 609461
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609461,
+				tcgplayer: 268711
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH203.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH203.ts
@@ -75,10 +75,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 609462
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609462,
+				tcgplayer: 268712
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH204.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH204.ts
@@ -64,10 +64,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 652086
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 652086,
+				tcgplayer: 271837
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH205.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH205.ts
@@ -79,10 +79,20 @@ const card: Card = {
 	description: {
 		en: "Clads itself in the souls of comrades that perished before fulfilling their goals of journeying upstream. No other species throughout all Hisui's rivers is Basculegion's equal."
 	},
-
-	thirdParty: {
-		cardmarket: 611336
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 611336,
+				tcgplayer: 273154
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH206.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH206.ts
@@ -94,10 +94,20 @@ const card: Card = {
 	description: {
 		en: "The black orbs shine with an uncanny light when the Pokémon is erecting invisible barriers. The fur shed from its beard retains heat well and is a highly useful material for winter clothing."
 	},
-
-	thirdParty: {
-		cardmarket: 611337
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 611337,
+				tcgplayer: 273155
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH207.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH207.ts
@@ -88,10 +88,20 @@ const card: Card = {
 	description: {
 		en: "Hard of heart and deft of blade, this rare form of Samurott is a product of the Pokémon's evolution in the region of Hisui. Its turbulent blows crash into foes like ceaseless pounding waves."
 	},
-
-	thirdParty: {
-		cardmarket: 611338
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 611338,
+				tcgplayer: 273156
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH208.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH208.ts
@@ -85,10 +85,20 @@ const card: Card = {
 	description: {
 		en: "Some say that Magnezone receives signals from space via the antenna on its head and that it's being controlled by some mysterious being."
 	},
-
-	thirdParty: {
-		cardmarket: 611339
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 611339,
+				tcgplayer: 273158
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH209.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH209.ts
@@ -67,10 +67,16 @@ const card: Card = {
 	description: {
 		en: "It manipulates the chemical makeup of its poison to produce electricity. The voltage is weak, but it can cause a tingling paralysis."
 	},
-
-	thirdParty: {
-		cardmarket: 659061
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 659061,
+				tcgplayer: 273583
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH210.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH210.ts
@@ -73,10 +73,16 @@ const card: Card = {
 	description: {
 		en: "This Oricorio has sipped purple nectar. Some dancers use its graceful, elegant dancing as inspiration."
 	},
-
-	thirdParty: {
-		cardmarket: 580165
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 659062,
+				tcgplayer: 273585
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH211.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH211.ts
@@ -88,10 +88,16 @@ const card: Card = {
 	description: {
 		en: "There's a Galarian fairy tale that describes a beautiful Sylveon vanquishing a dreadful dragon Pokémon."
 	},
-
-	thirdParty: {
-		cardmarket: 609461
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 659063,
+				tcgplayer: 273588
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH212.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH212.ts
@@ -67,10 +67,16 @@ const card: Card = {
 	description: {
 		en: "Thanks to its unstable genetic makeup, this special Pokémon conceals many different possible evolutions."
 	},
-
-	thirdParty: {
-		cardmarket: 491204
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 659064,
+				tcgplayer: 273590
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH213.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH213.ts
@@ -66,10 +66,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 606783
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606783,
+				tcgplayer: 268306
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH214.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH214.ts
@@ -85,10 +85,23 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 606784
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 606784,
+				tcgplayer: 268304
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 606785,
+				tcgplayer: 268305
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH215.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH215.ts
@@ -26,10 +26,23 @@ const card: Card = {
 	],
 	retreat: 0,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 651353
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651353,
+				tcgplayer: 268444
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 651357,
+				tcgplayer: 268449
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH216.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH216.ts
@@ -26,10 +26,15 @@ const card: Card = {
 	],
 	retreat: 0,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 651353
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651354,
+				tcgplayer: 268445
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH217.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH217.ts
@@ -26,10 +26,15 @@ const card: Card = {
 	],
 	retreat: 0,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 651353
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651355,
+				tcgplayer: 268446
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH218.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH218.ts
@@ -26,10 +26,15 @@ const card: Card = {
 	],
 	retreat: 0,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 651353
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 651356,
+				tcgplayer: 268447
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH219.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH219.ts
@@ -75,10 +75,23 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "E",
-
-	thirdParty: {
-		cardmarket: 540646
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 608109,
+				tcgplayer: 270468
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 608110,
+				tcgplayer: 276051
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH220.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH220.ts
@@ -56,10 +56,22 @@ const card: Card = {
 	description: {
 		en: "Flies noiselessly on delicate wings. It has mastered the art of deftly launching dagger-sharp feathers from those same wings."
 	},
-
-	thirdParty: {
-		cardmarket: 609466
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609466,
+				tcgplayer: 268705
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				tcgplayer: 490300
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH221.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH221.ts
@@ -67,10 +67,22 @@ const card: Card = {
 	description: {
 		en: "Hails from the Johto region. Though usually curled into a ball due to its timid disposition, it harbors tremendous firepower."
 	},
-
-	thirdParty: {
-		cardmarket: 609467
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609467,
+				tcgplayer: 268706
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				tcgplayer: 489390
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH222.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH222.ts
@@ -47,10 +47,22 @@ const card: Card = {
 	description: {
 		en: "This Pokémon from the Unova region uses the shell on its belly as a weapon to cut down its foes. Thus, I've conferred upon this shell the name \"scalchop.\""
 	},
-
-	thirdParty: {
-		cardmarket: 609468
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 609468,
+				tcgplayer: 268707
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				tcgplayer: 594750
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH223.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH223.ts
@@ -72,10 +72,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 572159
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 653691,
+				tcgplayer: 270718
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH224.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH224.ts
@@ -72,10 +72,15 @@ const card: Card = {
 	],
 	retreat: 3,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 653692
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 653692,
+				tcgplayer: 270719
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH225.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH225.ts
@@ -71,10 +71,24 @@ const card: Card = {
 	],
 	retreat: 3,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 653693
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 653693,
+				tcgplayer: 270723
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 668989,
+				tcgplayer: 279028
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH226.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH226.ts
@@ -27,10 +27,20 @@ const card: Card = {
 
 	trainerType: "Supporter",
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 653694
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 653694,
+				tcgplayer: 270720
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			languages: ["pt"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH227.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH227.ts
@@ -27,10 +27,20 @@ const card: Card = {
 
 	trainerType: "Supporter",
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 653695
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 653695,
+				tcgplayer: 270721
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			languages: ["pt"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH228.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH228.ts
@@ -27,10 +27,20 @@ const card: Card = {
 
 	trainerType: "Supporter",
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 653696
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 653696,
+				tcgplayer: 270722
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			languages: ["pt"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH229.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH229.ts
@@ -72,11 +72,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 653691,
-		tcgplayer: 277040
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 665982,
+				tcgplayer: 277040
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH230.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH230.ts
@@ -67,10 +67,20 @@ const card: Card = {
 	description: {
 		en: "It has the ability to alter the composition of its body to suit its surrounding environment."
 	},
-
-	thirdParty: {
-		cardmarket: 653697
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 653697,
+				tcgplayer: 270724
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			languages: ["pt"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH231.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH231.ts
@@ -60,11 +60,16 @@ const card: Card = {
 	description: {
 		en: "There is a plant seed on its back right from the day this Pokémon is born. The seed slowly grows larger."
 	},
-
-	thirdParty: {
-		cardmarket: 664337,
-		tcgplayer: 275828
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 664337,
+				tcgplayer: 275828
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH232.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH232.ts
@@ -56,10 +56,16 @@ const card: Card = {
 	description: {
 		en: "It has a preference for hot things. When it rains, steam is said to spout from the tip of its tail."
 	},
-
-	thirdParty: {
-		cardmarket: 547031
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 664338,
+				tcgplayer: 275829
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH233.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH233.ts
@@ -47,10 +47,16 @@ const card: Card = {
 	description: {
 		en: "When it retracts its long neck into its shell, it squirts out water with vigorous force."
 	},
-
-	thirdParty: {
-		cardmarket: 664339
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 664339,
+				tcgplayer: 275830
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH234.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH234.ts
@@ -67,11 +67,16 @@ const card: Card = {
 	description: {
 		en: "Pikachu that can generate powerful electricity have cheek sacs that are extra soft and super stretchy."
 	},
-
-	thirdParty: {
-		cardmarket: 461594,
-		tcgplayer: 277039
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 653698,
+				tcgplayer: 277039
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH235.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH235.ts
@@ -60,10 +60,15 @@ const card: Card = {
 
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 576501
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 664340,
+				tcgplayer: 275844
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH236.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH236.ts
@@ -77,10 +77,15 @@ const card: Card = {
 
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 664341
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 664341,
+				tcgplayer: 275843
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH237.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH237.ts
@@ -77,10 +77,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 650947
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 650947,
+				tcgplayer: 275167
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH238.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH238.ts
@@ -73,10 +73,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 650948
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 650948,
+				tcgplayer: 275166
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH239.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH239.ts
@@ -73,10 +73,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 650949
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 650949,
+				tcgplayer: 275165
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH240.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH240.ts
@@ -69,10 +69,23 @@ const card: Card = {
 	description: {
 		en: "It lures in prey with its shining tail fins. It stays near the surface during the day and moves to the depths when night falls."
 	},
-
-	thirdParty: {
-		cardmarket: 665983
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 665983,
+				tcgplayer: 285254
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 680245
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH241.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH241.ts
@@ -92,10 +92,23 @@ const card: Card = {
 	description: {
 		en: "On the night of a full moon, if shadows move on their own and laugh, it must be Gengar's doing."
 	},
-
-	thirdParty: {
-		cardmarket: 505880
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 665984,
+				tcgplayer: 285257
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 607368
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH242.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH242.ts
@@ -69,10 +69,20 @@ const card: Card = {
 	description: {
 		en: "Comfey picks flowers with its vine and decorates itself with them. For some reason, flowers won't wither once they're attached to a Comfey."
 	},
-
-	thirdParty: {
-		cardmarket: 665985
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 665985,
+				tcgplayer: 285253
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH243.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH243.ts
@@ -88,10 +88,20 @@ const card: Card = {
 	description: {
 		en: "It quickly swings its four arms to rock its opponents with ceaseless punches and chops from all angles."
 	},
-
-	thirdParty: {
-		cardmarket: 505885
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 665986,
+				tcgplayer: 285251
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH244.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH244.ts
@@ -67,10 +67,16 @@ const card: Card = {
 	description: {
 		en: "It has special pads on the backs of its feet, and one on its nose. Once it's raring to fight, these pads radiate tremendous heat."
 	},
-
-	thirdParty: {
-		cardmarket: 427086
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 665987,
+				tcgplayer: 285264
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH245.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH245.ts
@@ -47,11 +47,16 @@ const card: Card = {
 	description: {
 		en: "Once diluted, its poison becomes medicinal. This Pokémon came into popularity after a pharmaceutical company chose it as a mascot."
 	},
-
-	thirdParty: {
-		cardmarket: 665988,
-		tcgplayer: 285259
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 665988,
+				tcgplayer: 285259
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH246.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH246.ts
@@ -77,10 +77,16 @@ const card: Card = {
 	description: {
 		en: "They attack their quarry in packs. Prey as large as Mamoswine easily fall to the teamwork of a group of Weavile."
 	},
-
-	thirdParty: {
-		cardmarket: 665989
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 665989,
+				tcgplayer: 285262
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH247.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH247.ts
@@ -78,10 +78,16 @@ const card: Card = {
 	description: {
 		en: "There is an enduring legend that states this Pokémon towed continents with ropes."
 	},
-
-	thirdParty: {
-		cardmarket: 665990
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 665990,
+				tcgplayer: 285258
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH248.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH248.ts
@@ -66,10 +66,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 660941
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 660941,
+				tcgplayer: 273938
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH249.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH249.ts
@@ -85,10 +85,23 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 660942
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 660942,
+				tcgplayer: 273939
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 660943,
+				tcgplayer: 276050
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH250.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH250.ts
@@ -75,10 +75,15 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 665991
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 665991,
+				tcgplayer: 279141
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH251.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH251.ts
@@ -29,12 +29,15 @@ const card: Card = {
     regulationMark: "F",
     illustrator: "Mitsuhiro Arita",
 
-    variants: {
-        normal: false,
-        reverse: false,
-        holo: true,
-        firstEdition: false
-    }
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 691252,
+				tcgplayer: 489944
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH252.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH252.ts
@@ -75,10 +75,23 @@ const card: Card = {
 	],
 	retreat: 0,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 665992
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 665992,
+				tcgplayer: 283369
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 665993,
+				tcgplayer: 284499
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH253.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH253.ts
@@ -73,10 +73,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669480
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669480,
+				tcgplayer: 449512
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH254.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH254.ts
@@ -63,10 +63,23 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669481
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669481,
+				tcgplayer: 449511
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 669482,
+				tcgplayer: 449514
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH255.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH255.ts
@@ -70,10 +70,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669483
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669483,
+				tcgplayer: 449510
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH256.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH256.ts
@@ -91,10 +91,23 @@ const card: Card = {
 	],
 	retreat: 3,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669484
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669484,
+				tcgplayer: 449509
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 669485,
+				tcgplayer: 449513
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH257.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH257.ts
@@ -73,10 +73,15 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 674373
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674373,
+				tcgplayer: 450653
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH258.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH258.ts
@@ -75,10 +75,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 674374
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674374,
+				tcgplayer: 450656
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH259.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH259.ts
@@ -67,10 +67,15 @@ const card: Card = {
 
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 674375
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674375,
+				tcgplayer: 450657
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH260.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH260.ts
@@ -66,10 +66,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 505255
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674368,
+				tcgplayer: 285384
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH261.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH261.ts
@@ -75,11 +75,15 @@ const card: Card = {
 	],
 	retreat: 3,
 	regulationMark: "D",
-
-	thirdParty: {
-		cardmarket: 674369,
-		tcgplayer: 285378
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674369,
+				tcgplayer: 285378
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH262.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH262.ts
@@ -85,10 +85,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 674370
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 674370,
+				tcgplayer: 285396
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH263.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH263.ts
@@ -66,10 +66,15 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669838
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669838,
+				tcgplayer: 449518
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH264.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH264.ts
@@ -84,10 +84,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669839
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669839,
+				tcgplayer: 449519
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH265.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH265.ts
@@ -83,10 +83,23 @@ const card: Card = {
 	],
 	retreat: 0,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669840
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669840,
+				tcgplayer: 449520
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 669841,
+				tcgplayer: 449524
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH266.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH266.ts
@@ -72,10 +72,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669842
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669842,
+				tcgplayer: 449521
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH267.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH267.ts
@@ -90,10 +90,15 @@ const card: Card = {
 	],
 	retreat: 3,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669843
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669843,
+				tcgplayer: 449522
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH268.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH268.ts
@@ -91,10 +91,23 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669844
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669844,
+				tcgplayer: 449523
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 669845,
+				tcgplayer: 449525
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH269.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH269.ts
@@ -66,10 +66,23 @@ const card: Card = {
 	description: {
 		en: "It gets energy from warm sunlight and is known for its habit of moving in pursuit of it."
 	},
-
-	thirdParty: {
-		cardmarket: 681798
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 681798,
+				tcgplayer: 451844
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 451884
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH270.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH270.ts
@@ -79,10 +79,23 @@ const card: Card = {
 	description: {
 		en: "This Pokémon can be seen galloping through fields at speeds of up to 150 mph, its fiery mane fluttering in the wind."
 	},
-
-	thirdParty: {
-		cardmarket: 681799
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 681799,
+				tcgplayer: 451845
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 451885
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH271.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH271.ts
@@ -79,10 +79,23 @@ const card: Card = {
 	description: {
 		en: "If its Trainer becomes happy, it overflows with energy, dancing joyously while spinning about."
 	},
-
-	thirdParty: {
-		cardmarket: 681800
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 681800,
+				tcgplayer: 451846
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 451886
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH272.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH272.ts
@@ -85,10 +85,23 @@ const card: Card = {
 	description: {
 		en: "It needs a running start to take off. If Archeops wants to fly, it first needs to run nearly 25 mph, building speed over a course of about 2.5 miles."
 	},
-
-	thirdParty: {
-		cardmarket: 681801
-	}
+	variants: [
+		{
+			type: "holo",
+			stamp: ["set-logo"],
+			thirdParty: {
+				cardmarket: 681801,
+				tcgplayer: 451847
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["set-logo", "staff"],
+			thirdParty: {
+				tcgplayer: 451887
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH273.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH273.ts
@@ -67,10 +67,16 @@ const card: Card = {
 	description: {
 		en: "Though it differs from other Basculin in several respects, including demeanor—this one is gentle—I have categorized it as a regional form given the vast array of shared qualities."
 	},
-
-	thirdParty: {
-		cardmarket: 684385
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 684385,
+				tcgplayer: 454228
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH274.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH274.ts
@@ -79,11 +79,16 @@ const card: Card = {
 	description: {
 		en: "Its hard skull is its distinguishing feature. It snapped trees by headbutting them, and then it fed on their ripe berries."
 	},
-
-	thirdParty: {
-		cardmarket: 684386,
-		tcgplayer: 454227
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 684386,
+				tcgplayer: 454227
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH275.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH275.ts
@@ -76,10 +76,16 @@ const card: Card = {
 	description: {
 		en: "It starts its life with a wondrous power that permits it to bond with any kind of Pokémon."
 	},
-
-	thirdParty: {
-		cardmarket: 684387
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 684387,
+				tcgplayer: 454226
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH276.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH276.ts
@@ -79,10 +79,16 @@ const card: Card = {
 	description: {
 		en: "They say that it will appear before kindhearted, caring people and shower them with happiness."
 	},
-
-	thirdParty: {
-		cardmarket: 684388
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 684388,
+				tcgplayer: 454225
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH277.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH277.ts
@@ -88,10 +88,16 @@ const card: Card = {
 	description: {
 		en: "The one with the best drumming techniques becomes the boss of the troop. It has a gentle disposition and values harmony among its group.",
 	},
-
-	thirdParty: {
-		cardmarket: 437154
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 682974,
+				tcgplayer: 475621
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH278.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH278.ts
@@ -88,10 +88,16 @@ const card: Card = {
 	description: {
 		en: "It's skilled at both offense and defense, and it gets pumped up when cheered on. But if it starts showboating, it could put itself in a tough spot.",
 	},
-
-	thirdParty: {
-		cardmarket: 566760
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 682975,
+				tcgplayer: 475622
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH279.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH279.ts
@@ -79,10 +79,16 @@ const card: Card = {
 	description: {
 		en: "Its nictitating membranes let it pick out foes' weak points so it can precisely blast them with water that shoots from its fingertips at Mach 3.",
 	},
-
-	thirdParty: {
-		cardmarket: 566761
-	}
+	variants: [
+		{
+			type: "holo",
+			foil: "cosmos",
+			thirdParty: {
+				cardmarket: 682976,
+				tcgplayer: 475623
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH280.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH280.ts
@@ -75,10 +75,23 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 682984
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 682984,
+				tcgplayer: 453483
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 682985,
+				tcgplayer: 479879
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH281.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH281.ts
@@ -67,10 +67,23 @@ const card: Card = {
 
 	retreat: 3,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 682986
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 682987,
+				tcgplayer: 453485
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 682986,
+				tcgplayer: 479880
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH282.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH282.ts
@@ -82,17 +82,17 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
-
 	regulationMark: "E",
 
-	thirdParty: {
-		tcgplayer: 488271
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692425,
+				tcgplayer: 488271
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH283.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH283.ts
@@ -79,17 +79,17 @@ const card: Card = {
 
 	retreat: 0,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
-
 	regulationMark: "E",
 
-	thirdParty: {
-		tcgplayer: 488274
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692426,
+				tcgplayer: 488274
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH284.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH284.ts
@@ -79,17 +79,17 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
-
 	regulationMark: "E",
 
-	thirdParty: {
-		tcgplayer: 488275
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692427,
+				tcgplayer: 488275
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH285.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH285.ts
@@ -53,11 +53,15 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 461594,
-		tcgplayer: 478423
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692429,
+				tcgplayer: 478423
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH286.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH286.ts
@@ -75,11 +75,23 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 461594,
-		tcgplayer: 478424
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692432,
+				tcgplayer: 478424
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 701242,
+				tcgplayer: 478425
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH287.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH287.ts
@@ -43,13 +43,25 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
+	regulationMark: "E",
 
-	regulationMark: "E"
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 682977,
+				tcgplayer: 477065
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 682981,
+				tcgplayer: 477069
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH288.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH288.ts
@@ -43,13 +43,17 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
+	regulationMark: "E",
 
-	regulationMark: "E"
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 682978,
+				tcgplayer: 477066
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH289.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH289.ts
@@ -45,13 +45,17 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
+	regulationMark: "E",
 
-	regulationMark: "E"
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 682979,
+				tcgplayer: 477067
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH290.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH290.ts
@@ -40,13 +40,17 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
+	regulationMark: "E",
 
-	regulationMark: "E"
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 682980,
+				tcgplayer: 477068
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH291.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH291.ts
@@ -85,11 +85,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 606600,
-		tcgplayer: 475642
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 692433,
+				tcgplayer: 475642
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH292.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH292.ts
@@ -78,13 +78,22 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [888],
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
-
 	regulationMark: "D",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 682982,
+				tcgplayer: 477063
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			languages: ["pt"]
+		},
+	],
 	suffix: "V"
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH293.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH293.ts
@@ -78,13 +78,22 @@ const card: Card = {
 	stage: "Basic",
 	dexId: [889],
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
-
 	regulationMark: "D",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 682983,
+				tcgplayer: 477064
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			languages: ["pt"]
+		},
+	],
 	suffix: "V"
 }
 

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH294.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH294.ts
@@ -73,10 +73,23 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 671806
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 671806,
+				tcgplayer: 451115
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 671807,
+				tcgplayer: 451116
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH295.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH295.ts
@@ -75,10 +75,23 @@ const card: Card = {
 	],
 	retreat: 1,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 669623
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 669623,
+				tcgplayer: 449515
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 669624,
+				tcgplayer: 449517
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH296.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH296.ts
@@ -26,10 +26,48 @@ const card: Card = {
 	},
 
 	trainerType: "Stadium",
-
-	thirdParty: {
-		cardmarket: 671798
-	}
+	variants: [
+		{
+			type: "normal",
+			stamp: ["worlds-2022"],
+			thirdParty: {
+				cardmarket: 671798,
+				tcgplayer: 575154
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2022", "champion"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2022", "finalist"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2022", "quarter-finalist"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2022", "semi-finalist"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2022", "staff"],
+			thirdParty: {
+				cardmarket: 672087,
+				tcgplayer: 503454
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2022", "top-sixteen"]
+		},
+		{
+			type: "normal",
+			stamp: ["worlds-2022", "top-thirty-two"]
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH297.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH297.ts
@@ -73,10 +73,15 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 671762
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 671762,
+				tcgplayer: 449526
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH298.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH298.ts
@@ -63,10 +63,23 @@ const card: Card = {
 	],
 	retreat: 2,
 	regulationMark: "F",
-
-	thirdParty: {
-		cardmarket: 671765
-	}
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 671765,
+				tcgplayer: 449527
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 671772,
+				tcgplayer: 449528
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH299.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH299.ts
@@ -1,0 +1,105 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [385],
+	set: Set,
+
+	name: {
+		en: "Jirachi V",
+		fr: "Jirachi V",
+		es: "Jirachi V",
+		it: "Jirachi V",
+		pt: "Jirachi V",
+		de: "Jirachi V"
+	},
+
+	illustrator: "N-DESIGN Inc.",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+	stage: "Basic",
+	suffix: "V",
+
+	abilities: [{
+		type: "Ability",
+
+		name: {
+			en: "Wish Connector",
+			fr: "Connecteur de Souhaits",
+			es: "Conector Deseo",
+			it: "Connettore di Desideri",
+			pt: "Conector de Desejos",
+			de: "Wunschbrücke"
+		},
+
+		effect: {
+			en: "When 1 of your Basic Pokémon V is Knocked Out by damage from an attack from your opponent's Pokémon, you may move a basic Energy card from that Pokémon to another of your Pokémon.",
+			fr: "Lorsque l'un de vos Pokémon-V de base est mis K.O. par les dégâts d'une attaque d'un Pokémon de votre adversaire, vous pouvez déplacer une carte Énergie de base de ce Pokémon-là vers un autre de vos Pokémon.",
+			es: "Cuando 1 de tus Pokémon V Básicos queda Fuera de Combate por el daño de un ataque de los Pokémon de tu rival, puedes mover 1 carta de Energía Básica de ese Pokémon a otro de tus Pokémon.",
+			it: "Quando uno dei tuoi Pokémon-V Base viene messo KO dai danni inflitti da un attacco di un Pokémon del tuo avversario, puoi spostare una carta Energia base da quel Pokémon a un altro dei tuoi Pokémon.",
+			pt: "Quando 1 dos seus Pokémon V Básicos for Nocauteado pelo dano de um ataque dos Pokémon do seu oponente, você poderá mover 1 carta de Energia básica daquele Pokémon para outro Pokémon seu.",
+			de: "Wenn 1 deiner Basis-Pokémon-V durch Schaden einer Attacke der Pokémon deines Gegners kampfunfähig wird, kannst du 1 Basis-Energiekarte von jenem Pokémon auf ein anderes deiner Pokémon verschieben."
+		}
+	}],
+
+	attacks: [{
+		cost: ["Psychic", "Colorless"],
+
+		name: {
+			en: "Hypnostrike",
+			fr: "Choc Sommeil",
+			es: "Hipnogolpe",
+			it: "Ipnocolpo",
+			pt: "Hipnogolpe",
+			de: "Hypnostoß"
+		},
+
+		effect: {
+			en: "Both Active Pokémon are now Asleep.",
+			fr: "Les deux Pokémon Actifs sont maintenant Endormis.",
+			es: "Ambos Pokémon Activos pasan a estar Dormidos.",
+			it: "Entrambi i Pokémon attivi vengono addormentati.",
+			pt: "Ambos os Pokémon Ativos agora estão Adormecidos.",
+			de: "Beide Aktiven Pokémon schlafen jetzt."
+		},
+
+		damage: 60
+	}],
+
+	weaknesses: [
+		{
+			type: "Darkness",
+			value: "×2",
+		},
+	],
+	resistances: [
+		{
+			type: "Fighting",
+			value: "-30",
+		},
+	],
+	retreat: 1,
+	regulationMark: "F",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 731416,
+				tcgplayer: 544371
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 731417,
+				tcgplayer: 584511
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH300.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH300.ts
@@ -1,0 +1,95 @@
+import { Card } from "../../../interfaces"
+import Set from "../SWSH Black Star Promos"
+
+const card: Card = {
+	dexId: [201],
+	set: Set,
+
+	name: {
+		en: "Unown V",
+		fr: "Zarbi V",
+		es: "Unown V",
+		it: "Unown V",
+		pt: "Unown V",
+		de: "Icognito V"
+	},
+
+	illustrator: "PLANETA Mochizuki",
+	rarity: "Promo",
+	category: "Pokemon",
+	hp: 180,
+	types: ["Psychic"],
+	stage: "Basic",
+	suffix: "V",
+
+	attacks: [{
+		cost: ["Psychic"],
+
+		name: {
+			en: "Shady Stamp",
+			fr: "Coup Louche",
+			es: "Impresión Sombría",
+			it: "Ombraimpronta",
+			pt: "Timbre de Sombra",
+			de: "Zwielichtstampfer"
+		},
+
+		effect: {
+			en: "Your opponent's Active Pokémon is now Confused.",
+			fr: "Le Pokémon Actif de votre adversaire est maintenant Confus.",
+			es: "El Pokémon Activo de tu rival pasa a estar Confundido.",
+			it: "Il Pokémon attivo del tuo avversario viene confuso.",
+			pt: "O Pokémon Ativo do seu oponente agora está Confuso.",
+			de: "Das Aktive Pokémon deines Gegners ist jetzt verwirrt."
+		},
+
+		damage: 30
+	}, {
+		cost: ["Colorless", "Colorless", "Colorless"],
+
+		name: {
+			en: "Victory Symbol",
+			fr: "Symbole Victorieux",
+			es: "Símbolo de Victoria",
+			it: "Simbolo di Vittoria",
+			pt: "Símbolo da Vitória",
+			de: "Siegessymbol"
+		},
+
+		effect: {
+			en: "If you use this attack when you have only 1 Prize card remaining, you win this game.",
+			fr: "Si vous utilisez cette attaque alors qu'il ne vous reste qu'une seule carte Récompense, vous gagnez cette partie.",
+			es: "Si usas este ataque cuando te queda solo 1 carta de Premio, ganas esta partida.",
+			it: "Se usi questo attacco quando hai solo una carta Premio rimanente, vinci la partita.",
+			pt: "Se você usar este ataque quando tiver apenas 1 carta de Prêmio restante, você vencerá esta partida.",
+			de: "Wenn du diese Attacke einsetzt und nur 1 verbleibende Preiskarte hast, gewinnst du dieses Spiel."
+		}
+	}],
+
+	weaknesses: [
+		{
+			type: "Darkness",
+			value: "×2",
+		},
+	],
+	resistances: [
+		{
+			type: "Fighting",
+			value: "-30",
+		},
+	],
+	retreat: 1,
+	regulationMark: "F",
+
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719675,
+				tcgplayer: 505968
+			}
+		},
+	],
+}
+
+export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH301.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH301.ts
@@ -78,13 +78,25 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
+	regulationMark: "F",
 
-	regulationMark: "F"
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 719676,
+				tcgplayer: 505996
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 719677,
+				tcgplayer: 506006
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH302.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH302.ts
@@ -28,13 +28,17 @@ const card: Card = {
 
 	trainerType: "Supporter",
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
+	regulationMark: "E",
 
-	regulationMark: "E"
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 703140,
+				tcgplayer: 489692
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH303.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH303.ts
@@ -40,17 +40,18 @@ const card: Card = {
 		en: "There is a aplant seed on its back right from the day this Pokémon is born. THe seed slowly grows larger.",
 	},
 
+	regulationMark: "F",
+
 	variants: [
 		{
 			type: "normal",
 			stamp: ["illustration-contest-2022"],
 			thirdParty: {
+				cardmarket: 690365,
 				tcgplayer: 485843
-			},
+			}
 		},
 	],
-
-	regulationMark: "F"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH304.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH304.ts
@@ -45,17 +45,18 @@ const card: Card = {
 		en: "The sight of it running over 6,200 miles in a single day and night has captivated many people.",
 	},
 
+	regulationMark: "F",
+
 	variants: [
 		{
 			type: "normal",
 			stamp: ["illustration-contest-2022"],
 			thirdParty: {
+				cardmarket: 690366,
 				tcgplayer: 485844
-			},
+			}
 		},
 	],
-
-	regulationMark: "F"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH305.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH305.ts
@@ -45,17 +45,18 @@ const card: Card = {
 		en: "It creates throwing stars out of compressed water. When it spins them and throws them at high speed, these stars can split metal into two.",
 	},
 
+	regulationMark: "F",
+
 	variants: [
 		{
 			type: "normal",
 			stamp: ["illustration-contest-2022"],
 			thirdParty: {
+				cardmarket: 690367,
 				tcgplayer: 485845
-			},
+			}
 		},
 	],
-
-	regulationMark: "F"
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH306.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH306.ts
@@ -64,13 +64,17 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
+	regulationMark: "F",
 
-	regulationMark: "F"
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 703213,
+				tcgplayer: 499989
+			}
+		},
+	],
 }
 
 export default card

--- a/data/Sword & Shield/SWSH Black Star Promos/SWSH307.ts
+++ b/data/Sword & Shield/SWSH Black Star Promos/SWSH307.ts
@@ -85,13 +85,17 @@ const card: Card = {
 
 	retreat: 2,
 
-	variants: [
-			{
-				type: "holo",
-			}
-		],
+	regulationMark: "F",
 
-	regulationMark: "F"
+	variants: [
+		{
+			type: "holo",
+			thirdParty: {
+				cardmarket: 703214,
+				tcgplayer: 499984
+			}
+		},
+	],
 }
 
 export default card

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -35,7 +35,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'illustration-contest-2022' | 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "poke-ball-league" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
 	| "international-championship-europe" | "international-championship-latin-america" | "international-championship-north-america" | 'ace-trainer'
 	| 'pikachu' | 'bulbasaur' | 'squirtle' | 'charmander' | 'pokeball' | '30th-pokeday' | 'mcdonalds' | 'pokemon-together' | 'rain-city' | 'tournament-collection' | 'fossil-museum'
-	| 'worlds-2024' | 'worlds-2023' | 'asia-2023-24' | 'thank-you' | 'jr-stamp-rally' | 'grey-star' | 'pop-tournament' | 'chase-moloney' | 'chicago-2009' | 'scrye' | 'inquest-gamer'
+	| 'worlds-2024' | 'worlds-2023' | 'worlds-2022' | 'asia-2023-24' | 'thank-you' | 'jr-stamp-rally' | 'grey-star' | 'pop-tournament' | 'chase-moloney' | 'chicago-2009' | 'scrye' | 'inquest-gamer'
 	| 'jesse-parker' | 'gabriel-fernandez' | 'sakuya-ota' | 'shao-tong-yen' | 'poketour-99'
 
 export interface variant_detailed {

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -257,6 +257,7 @@
 		"rain-city": "rain-city",
 		"tournament-collection": "tournament-collection",
 		"worlds-2024": "worlds-2024",
+		"worlds-2022": "worlds-2022",
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
 		"thank-you": "thank-you",

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -257,6 +257,7 @@
 		"rain-city": "rain-city",
 		"tournament-collection": "tournament-collection",
 		"worlds-2024": "worlds-2024",
+		"worlds-2022": "worlds-2022",
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
 		"thank-you": "thank-you",

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -256,6 +256,7 @@
 		"rain-city": "rain-city",
 		"tournament-collection": "tournament-collection",
 		"worlds-2024": "worlds-2024",
+		"worlds-2022": "worlds-2022",
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
 		"thank-you": "thank-you",

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -257,6 +257,7 @@
 		"rain-city": "rain-city",
 		"tournament-collection": "tournament-collection",
 		"worlds-2024": "worlds-2024",
+		"worlds-2022": "worlds-2022",
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
 		"thank-you": "thank-you",

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -256,6 +256,7 @@
 		"rain-city": "rain-city",
 		"tournament-collection": "tournament-collection",
 		"worlds-2024": "worlds-2024",
+		"worlds-2022": "worlds-2022",
 		"worlds-2023": "worlds-2023",
 		"asia-2023-24": "asia-2023-24",
 		"thank-you": "thank-you",


### PR DESCRIPTION
## Changes

Add variants for all SWSH Black Star Promos, SWSH001 to SWSH307

## Details

- 305 cards get `variants` with Cardmarket and TCGplayer ids
- covers the cosmos, prerelease (set logo and staff), jumbo, 25th celebration, Special Delivery, Professor Program, Play! Pokemon and World Championships printings
- adds the `worlds-2022` stamp to `interfaces.d.ts` and the translation files
- SWSH299 and SWSH300 are not in the database yet and are not part of this PR