### PR TITLE
fix(fr): Correct the blue-border variantSubtype key

### DIFF
--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -292,7 +292,7 @@
 		"no-e-reader": "Sans e-Reader",
 		"rarity-error": "Erreur de rareté",
 		"cosmos": "cosmos",
-		"blue border": "bordure bleue",
+		"blue-border": "bordure bleue",
 		"glossy": "brillante",
 		"shadowless-red-cheek": "Sans ombre aux joues rouges",
 		"2019-copyright": "Copyright 2019",


### PR DESCRIPTION
> **made by AI** — this PR was prepared with an AI agent (Claude Opus 5) and reviewed before submission.

Claude found this inconsistency itself

`meta/translations/fr.json` declared the subtype as `"blue border"` (space), while `interfaces.d.ts` and the card data both use `"blue-border"`.

`translate()` does not fall back on a miss — it throws — so the entry was unreachable:

```
Could not find translation for fr.variantSubtype.blue-border
```

### Why the build is green today

By accident. All 8 cards carrying the subtype are in `mfb` (My First Battle), which has no French card names yet, so they never reach the French compile. Adding French names to that set would have broken it.

Reproduced by running every card in `data/` through `formatVariant()` for `fr`, including the untranslated ones:

| | before | after |
|---|---|---|
| cards with a French name (today's build) | 0 failures | 0 failures |
| all 23 639 cards (what a translated `mfb` would hit) | 8 failures | 0 failures |

`npm run validate` passes.

### Not fixed here

- `de`, `es`, `it` and `pt` have **no** key for this subtype at all and fail on the same 8 cards. I did not want to invent the wording in four languages I don't speak — those need native speakers.
- `pt` is additionally missing `variantSubtype.missing-retreat-cost`, used by `ex2-68`.
- `meta/translations/schema.json` only describes 8 of the 13 translatable categories; `variantSubtype` is not among them, which is why this typo went unnoticed.

tcgdex is a pizza and this pr is a slice -> I verified the slice don't worry
