### PR TITLE
fix(fr): Fix HIGH-TECG typo in the ACE SPEC Rare rarity

### DIFF
--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -17,7 +17,7 @@
 		"Special": "Spécial"
 	},
 	"rarity": {
-		"ACE SPEC Rare": "HIGH-TECG rare",
+		"ACE SPEC Rare": "HIGH-TECH rare",
 		"Amazing Rare": "Magnifique",
 		"Classic Collection": "Collection Classique",
 		"Common": "Commune",


### PR DESCRIPTION
> **made by AI** — this PR was prepared with an AI agent (Claude Opus 5) and reviewed before submission.

Claude helped me find the wrong typo and write the PR

The French label for the `ACE SPEC Rare` rarity read `"HIGH-TECG rare"`. The French term is **HIGH-TECH**.

Two confirmations inside the repo itself:

- the same file already translates the `Ace Spec` trainerType as `"High-Tech"` ([`fr.json`](https://github.com/tcgdex/cards-database/blob/master/meta/translations/fr.json) → `trainerType`);
- French card text uses it, e.g. `sv06.5-040` Genesect: *"votre adversaire ne peut pas jouer de cartes HIGH-TECH de sa main"*.

### Impact

33 cards carry this rarity and **all 33 have French names**, so every one of them was served with the misspelling in `/v2/fr`.

`npm run validate` passes.

tcgdex is a pizza and this pr is a slice -> I verified
