### PR TITLE
fix(data): Restore the energy symbols lost from EX Unseen Forces French text

### DIFF
--- a/data/EX/Unseen Forces/1.ts
+++ b/data/EX/Unseen Forces/1.ts
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may discard all Lightning Energy attached to Ampharos. If you do, the Defending Pokémon is now Burned and Confused.",
-				fr: "Vous pouvez défausser toutes les Énergies  attachées à Pharamp. Le Pokémon Défenseur est alors Brûlé et Confus.",
+				fr: "Vous pouvez défausser toutes les Énergies {L} attachées à Pharamp. Le Pokémon Défenseur est alors Brûlé et Confus.",
 				de: "You may discard all  Energy cards attached to Ampharos. If you do, the Defending Pokémon is now Burned and Confused."
 			},
 			damage: 50,

--- a/data/EX/Unseen Forces/105.ts
+++ b/data/EX/Unseen Forces/105.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy, Water Energy, and Lightning Energy attached to Lugia ex.",
-				fr: "Défaussez une Énergie , une Énergie  et une Énergie  attachée à Lugia ex.",
+				fr: "Défaussez une Énergie {R}, une Énergie {W} et une Énergie {L} attachée à Lugia ex.",
 				de: "Discard a  Energy,  Energy, and  Energy attached to Lugia ex."
 			},
 			damage: 200,

--- a/data/EX/Unseen Forces/106.ts
+++ b/data/EX/Unseen Forces/106.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may attach a Grass Energy card from your hand to 1 of your Pokémon. If you do, remove 1 damage counter from that Pokémon. This power can't be used if Meganium ex is affected by a Special Condition.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez attacher à 1 de vos Pokémon une carte Énergie  de votre main. Retirez alors à ce Pokémon 1 marqueur de dégât. Ce pouvoir ne peut pas être utilisé si Meganium ex est affecté par un État Spécial.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez attacher à 1 de vos Pokémon une carte Énergie {G} de votre main. Retirez alors à ce Pokémon 1 marqueur de dégât. Ce pouvoir ne peut pas être utilisé si Meganium ex est affecté par un État Spécial.",
 				de: "Once during your turn (before your attack), you may attach a  Energy card from your hand to 1 of your Pokémon. If you do, remove 1 damage counter from that Pokémon. This power can't be used if Meganium ex is affected by a Special Condition"
 			},
 		},

--- a/data/EX/Unseen Forces/109.ts
+++ b/data/EX/Unseen Forces/109.ts
@@ -80,7 +80,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 2 Fighting Energy attached to Steelix ex and choose 1 of your opponent's Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Défaussez 2 Énergies  attachées à Steelix ex et choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 100 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
+				fr: "Défaussez 2 Énergies {F} attachées à Steelix ex et choisissez 1 des Pokémon de votre adversaire. Cette attaque lui inflige 100 dégâts. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc.)",
 				de: "Discard 2  Energy attached to Steelix ex and choose 1 of your opponent's Pokémon. This attack does 100 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)"
 			},
 

--- a/data/EX/Unseen Forces/11.ts
+++ b/data/EX/Unseen Forces/11.ts
@@ -59,7 +59,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If the Defending Pokémon is a Darkness Pokémon or has Dark in its name, this attack does 40 damage plus 30 more damage.",
-				fr: "Si le Pokémon Défenseur est un Pokémon  ou si son nom comporte Obscur, cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires.",
+				fr: "Si le Pokémon Défenseur est un Pokémon {D} ou si son nom comporte Obscur, cette attaque inflige 40 dégâts plus 30 dégâts supplémentaires.",
 				de: "If the Defending Pokémon is a  Pokémon or has Dark in its name, this attack does 40 damage plus 30 more damage."
 			},
 			damage: "40+",

--- a/data/EX/Unseen Forces/110.ts
+++ b/data/EX/Unseen Forces/110.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn, when you play Typhlosion ex from your hand to evolve 1 of your Pokémon, count the number of your opponent's Benched Pokémon. You may search your deck for up to that number of Fire Energy cards and attach them to 1 of your Fire Pokémon. Shuffle your deck afterward.",
-				fr: "Une seule fois lors de votre tour, lorsque vous jouez Typhlosion ex de votre main pour faire évoluer 1 de vos Pokémon, comptez le nombre de Pokémon de Banc de votre adversaire. Vous pouvez chercher dans votre deck autant de cartes Énergie  et les attacher à 1 de vos Pokémon . Ensuite, mélangez votre deck.",
+				fr: "Une seule fois lors de votre tour, lorsque vous jouez Typhlosion ex de votre main pour faire évoluer 1 de vos Pokémon, comptez le nombre de Pokémon de Banc de votre adversaire. Vous pouvez chercher dans votre deck autant de cartes Énergie {R} et les attacher à 1 de vos Pokémon {R}. Ensuite, mélangez votre deck.",
 				de: "Once during your turn, when you play Thyplosion ex from your hand to evoled q of your Pokémon, count the number of your opponent's Benched Pokémon. You may search your deck for up to that number of  Energy cards and attach them to 1 of your  Pokémon. Shuffle your deck afterward."
 			},
 		},

--- a/data/EX/Unseen Forces/13.ts
+++ b/data/EX/Unseen Forces/13.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Slowbro has any Psychic Energy attached to it, Slowbro is both Water and Psychic type.",
-				fr: "Tant que Flagadoss possède des Énergies , il est à la fois de type  et .",
+				fr: "Tant que Flagadoss possède des Énergies {P}, il est à la fois de type {W} et {P}.",
 				de: "As long as Slowbro has any  Energy attached to it, Slowbro is both  and  type."
 			},
 		},

--- a/data/EX/Unseen Forces/16.ts
+++ b/data/EX/Unseen Forces/16.ts
@@ -59,7 +59,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Grass Energy attached to all of your Pokémon.",
-				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à tous vos Pokémon.",
+				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {G} attachée à tous vos Pokémon.",
 				de: "Does 20 damage plus 10 more damage for each  Energy attached to all of your Pokémon."
 			},
 			damage: "20+",

--- a/data/EX/Unseen Forces/3.ts
+++ b/data/EX/Unseen Forces/3.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for up to 2 Grass Pokémon, show them to your opponent, and put them into your hand. Shuffle your deck afterward. If you put any Grass Pokémon into your hand, you may switch Bellossom with 1 of your Benched Pokémon.",
-				fr: "Choisissez dans votre deck jusqu'à 2 Pokémon , montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck. Si vous placez un Pokémon  dans votre main, vous pouvez échanger Joliflor avec 1 des Pokémon de votre Banc.",
+				fr: "Choisissez dans votre deck jusqu'à 2 Pokémon {G}, montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck. Si vous placez un Pokémon {G} dans votre main, vous pouvez échanger Joliflor avec 1 des Pokémon de votre Banc.",
 				de: "Search your deck for up to 2  Pokémon, show them to your opponent, and put them into your hand. Shuffle your deck afterward. If you put any  Pokémon into your hand, you may switch Bellossom with 1 of your Benched Pokémon."
 			},
 

--- a/data/EX/Unseen Forces/37.ts
+++ b/data/EX/Unseen Forces/37.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for a Water or Fighting Pokémon (excluding Pokémon-ex), show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
-				fr: "Choisissez dans votre deck un Pokémon  ou  (Pokémon-ex exclus), montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
+				fr: "Choisissez dans votre deck un Pokémon {W} ou {F} (Pokémon-ex exclus), montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
 				de: "Search your deck for a  or  Pokémon (excluding Pokémon-ex), show it to your opponent, any put it into your hand. Shuffle your deck afterward."
 			},
 

--- a/data/EX/Unseen Forces/41.ts
+++ b/data/EX/Unseen Forces/41.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Magcargo has any Fighting Energy attached to it, Magcargo is both Fire and Fighting type.",
-				fr: "Tant que Volcaropod possède des Énergies , il est de type  et .",
+				fr: "Tant que Volcaropod possède des Énergies {F}, il est de type {R} et {F}.",
 				de: "As long as Magcargo has any  Energy attached to it, Magcargo is both  and  type."
 			},
 		},

--- a/data/EX/Unseen Forces/42.ts
+++ b/data/EX/Unseen Forces/42.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Any damage done to Miltank by attacks from Fire Pokémon and Water Pokémon is reduced by 30 (after applying Weakness and Resistance).",
-				fr: "Les dégâts infligés à Ecremeuh par des attaques de Pokémon  et  sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
+				fr: "Les dégâts infligés à Ecremeuh par des attaques de Pokémon {R} et {W} sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
 				de: "Any damage done to Miltank by attacks from  Pokémon and  Pokémon is reduced by 30 (after applying Weakness and Resistance)."
 			},
 		},

--- a/data/EX/Unseen Forces/5.ts
+++ b/data/EX/Unseen Forces/5.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your discard pile for a Fire Energy card and attach it to 1 of your Pokémon.",
-				fr: "Choisissez dans votre pile de défausse une carte Énergie  et attachez-la à un 1 de vos Pokémon.",
+				fr: "Choisissez dans votre pile de défausse une carte Énergie {R} et attachez-la à un 1 de vos Pokémon.",
 				de: "Search your discard pile for a  Energy card and attach it to 1 of your Pokémon."
 			},
 			damage: 20,

--- a/data/EX/Unseen Forces/54.ts
+++ b/data/EX/Unseen Forces/54.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy card attached to Cyndaquil.",
-				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie  attachée à Héricendre.",
+				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie {R} attachée à Héricendre.",
 				de: "Flip a coin. If tails, discard a  Energy card attached to Cyndaquil."
 			},
 			damage: 30,

--- a/data/EX/Unseen Forces/7.ts
+++ b/data/EX/Unseen Forces/7.ts
@@ -78,7 +78,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to Houndoom.",
-				fr: "Défaussez une Énergie  attachée à Demolosse.",
+				fr: "Défaussez une Énergie {R} attachée à Demolosse.",
 				de: "Discard a  Energy attached to Houndoom."
 			},
 			damage: 70,

--- a/data/EX/Unseen Forces/8.ts
+++ b/data/EX/Unseen Forces/8.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your deck for a Lightning Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
-				fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck une carte Énergie  et attachez-la à 1 de vos Pokémon. Ensuite, mélangez votre deck.",
+				fr: "Lancez une pièce. Si c'est face, choisissez dans votre deck une carte Énergie {L} et attachez-la à 1 de vos Pokémon. Ensuite, mélangez votre deck.",
 				de: "Flip a coin. If heads, search your deck for a  Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward."
 			},
 			damage: 20,

--- a/data/EX/Unseen Forces/80.ts
+++ b/data/EX/Unseen Forces/80.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "Attach Curse Powder to 1 of your Evolved Pokémon (excluding Pokémon-ex) that doesn't already have a Pokémon Tool attached to it. If the Pokémon Curse Powder is attached to is a Basic Pokémon or Pokémon-ex, discard Curse Powder. If the Pokémon that Curse Powder is attached to is your Active Pokémon and is Knocked Out by damage from an opponent's attack, put 3 damage counters on the Attacking Pokémon.",
-		fr: "Attachez Poudre maléfique à un de vos Pokémon Évolués (Pokémon-ex exclus) qui ne possède pas déjà d'Outil Pokémon. Si le Pokémon auquel Poudre maléfique est attachée est un Pokémon de base ou un Pokémon-ex , défaussez Poudre maléfique.\n\nSi le Pokémon auquel Poudre maléfique est attachée est votre Pokémon Actif et est mis K.O. par les dégâts d'une attaque de votre adversaire, placez 3 marqueurs de dégât sur le Pokémon Attaquant.",
+		fr: "Attachez Poudre maléfique à un de vos Pokémon Évolués (Pokémon-ex exclus) qui ne possède pas déjà d'Outil Pokémon. Si le Pokémon auquel Poudre maléfique est attachée est un Pokémon de base ou un Pokémon-ex, défaussez Poudre maléfique.\n\nSi le Pokémon auquel Poudre maléfique est attachée est votre Pokémon Actif et est mis K.O. par les dégâts d'une attaque de votre adversaire, placez 3 marqueurs de dégât sur le Pokémon Attaquant.",
 		de: "If the Pokémon that Curse Powder is attached to is your Active Pokémon and is Knocked Out by damage from an opponent's attack, put 3 damage counters on the Attacking Pokémon."
 	},
 


### PR DESCRIPTION
## Changes

Same loss as #2273 to #2283 and #2308, this time in EX Unseen Forces (`ex10`): the inline energy symbols were dropped from the French rules text, leaving only the space they sat in.

```
en: "Discard a Fire Energy, Water Energy, and Lightning Energy attached to Lugia ex."
fr: "Défaussez une Énergie , une Énergie  et une Énergie  attachée à Lugia ex."
de: "Discard a  Energy,  Energy, and  Energy attached to Lugia ex."
```

**26 symbols** restored, in **16 strings** across **16 cards**. One further card carries a different defect, below. Only `fr` values change — 17 lines in, 17 lines out.

## Sources

Unlike the earlier sets in this series, **there is no German to cross-check against**. As the block above shows, every `de` field in this set holds a copy of the English string, with the same symbols already missing — visible on all 17 fields touched here. So the English is the only textual source, and it names the type in all 16 strings.

To compensate, three were read off the French scans on Poképédia. I picked the three where the symbol is *not* the card's own type, since those are where a mistranscribed English string would do the most damage:

- `11` Tartard, *Combat* → `{D}` on a `{F}` Pokémon — [scan](https://www.pokepedia.fr/Tartard_(EX_Forces_Cachées_11))
- `105` Lugia ex, *Explosion élémentaire* → `{R}`, `{W}`, `{L}` in that order, matching the attack cost — [scan](https://www.pokepedia.fr/Lugia_ex_(EX_Forces_Cachées_105))
- `109` Steelix ex, *Coulée de boue* → `{F}` on a `{M}` Pokémon, matching the attack cost — [scan](https://www.pokepedia.fr/Steelix_ex_(EX_Forces_Cachées_109))

All three agree with the English. The remaining 13 strings rest on the English alone.

## Details

Three strings hold several symbols and needed the English word order rather than a mechanical fill.

`13` Flagadoss and `41` Volcaropod share a shape where the first symbol differs from the two that follow: *"As long as Slowbro has any **Psychic** Energy attached to it, Slowbro is both **Water** and **Psychic** type"* gives `{P}`, then `{W}` and `{P}`; *"any **Fighting** Energy … both **Fire** and **Fighting** type"* gives `{F}`, then `{R}` and `{F}`.

`42` Écrémeuh takes `{R}` then `{W}` from *"attacks from Fire Pokémon and Water Pokémon"*, and `37` Corayon `{W}` then `{F}` from *"a Water or Fighting Pokémon"*.

`80` Poudre maléfique is the odd one out: it shows the same whitespace signature, `un Pokémon-ex , défaussez`, but nothing is missing — the English reads `Basic Pokémon or Pokémon-ex, discard Curse Powder`. The stray space is simply removed.

`npm run validate` passes. No English string was modified, and no `de` field was touched — the English-text-in-German-field problem is left for a separate PR.

Twelfth set of the series, after #2273 to #2283 and #2308, one PR each.
