### PR TITLE
fix(data): Restore the energy symbols lost from EX Delta Species French text

### DIFF
--- a/data/EX/Delta Species/10.ts
+++ b/data/EX/Delta Species/10.ts
@@ -62,7 +62,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If the Defending Pokémon is Metal Pokémon, this attack's base damage is 90.",
-				fr: "Si le Pokémon Défenseur est un Pokémon , les dégâts de base de cette attaque sont de 90.",
+				fr: "Si le Pokémon Défenseur est un Pokémon {M}, les dégâts de base de cette attaque sont de 90.",
 				de: "Wenn das Verteidigende Pokémon ein -Pokémon ist, fügt dieser Angriff 90 Schadenspunkte zu."
 			},
 			damage: 50,

--- a/data/EX/Delta Species/109.ts
+++ b/data/EX/Delta Species/109.ts
@@ -78,7 +78,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Lightning Energy card attached to Jolteon ex.",
-				fr: "Défaussez une carte Énergie  attachée à Voltali ex.",
+				fr: "Défaussez une carte Énergie {L} attachée à Voltali ex.",
 				de: "Lege eine an Blitza angelegte -Energiekarte auf den Ablegestapel."
 			},
 			damage: 70,

--- a/data/EX/Delta Species/111.ts
+++ b/data/EX/Delta Species/111.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Count the number of Prize cards your opponent has taken. Search your discard pile for up to that many Fighting Energy cards and attach them to Groudon Star.",
-				fr: "Comptabilisez le nombre de cartes Récompense récoltées par votre adversaire. Cherchez dans votre pile de défausse le même nombre de cartes Énergie  et attachez-les à Groudon .",
+				fr: "Comptabilisez le nombre de cartes Récompense récoltées par votre adversaire. Cherchez dans votre pile de défausse le même nombre de cartes Énergie {F} et attachez-les à Groudon ☆.",
 				de: "Count the number of Prize cards your opponent has taken. Search your discard pile for up to that many  Energy cards and attach them to Groudon *."
 			},
 			damage: 10,
@@ -58,7 +58,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fighting Energy card attached to Groudon Star.",
-				fr: "Défaussez une carte Énergie  attachée à Groudon .",
+				fr: "Défaussez une carte Énergie {F} attachée à Groudon ☆.",
 				de: "Discard a Energy card attached to Groudon *."
 			},
 			damage: 80,

--- a/data/EX/Delta Species/112.ts
+++ b/data/EX/Delta Species/112.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Count the number of Prize cards your opponent has taken. Search your discard pile for up to that many Water Energy cards and attach them to Kyogre Star.",
-				fr: "Comptabilisez le nombre de cartes Récompense récoltées par votre adversaire. Cherchez dans votre pile de défausse le même nombre de cartes Énergie  et attachez-les à Kyogre .",
+				fr: "Comptabilisez le nombre de cartes Récompense récoltées par votre adversaire. Cherchez dans votre pile de défausse le même nombre de cartes Énergie {W} et attachez-les à Kyogre ☆.",
 				de: "Count the number of Prize cards your opponent has taken. Search your discard pile for up to that many [W] Energy cards and attach them to Kyogre *."
 			},
 			damage: 10,

--- a/data/EX/Delta Species/113.ts
+++ b/data/EX/Delta Species/113.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Count the number of Prize cards your opponent has taken. Search your discard pile for up to that many Metal Energy cards and attach them to Metagross Star.",
-				fr: "Comptabilisez le nombre de cartes Récompense récoltées par votre adversaire. Cherchez dans votre pile de défausse le même nombre de cartes Énergie  et attachez-les à Metalosse .",
+				fr: "Comptabilisez le nombre de cartes Récompense récoltées par votre adversaire. Cherchez dans votre pile de défausse le même nombre de cartes Énergie {M} et attachez-les à Metalosse ☆.",
 				de: "Count the number of Prize cards your opponent has taken. Search your discard pile for up to that many  Energy cards and attach them to Metagross *."
 			},
 			damage: 10,

--- a/data/EX/Delta Species/114.ts
+++ b/data/EX/Delta Species/114.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Any damage done to Azumarill by attacks from Fire Pokémon and Water Pokémon is reduced by 30 (after applying Weakness and Resistance).",
-				fr: "Tous dégâts infligés à Azumarill par des attaques de Pokémon  et  sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
+				fr: "Tous dégâts infligés à Azumarill par des attaques de Pokémon {R} et {W} sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
 				de: "Any damage done to Azumarill by attacks from  Pokémon and  Pokémon is reduced by 30 (after applying Weakness and Resistance)."
 			},
 		},

--- a/data/EX/Delta Species/14.ts
+++ b/data/EX/Delta Species/14.ts
@@ -44,7 +44,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your discard pile for a Fire Energy card and attach it to 1 of your Pokémon.",
-				fr: "Cherchez dans votre pile de défausse une carte Énergie  et attachez-la à 1 de vos Pokémon.",
+				fr: "Cherchez dans votre pile de défausse une carte Énergie {R} et attachez-la à 1 de vos Pokémon.",
 				de: "Durchsuche deinen Ablagestapel nach einer -Energiekarte und lege sie an 1 deiner Pokémon an."
 			},
 			damage: 30,
@@ -64,7 +64,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Metal Energy card attached to Salamence.",
-				fr: "Défaussez une carte Énergie  attachée à Drattak.",
+				fr: "Défaussez une carte Énergie {M} attachée à Drattak.",
 				de: "Lege 1 an Brutalanda angelegte -Energiekarte auf deinen Ablagestapel."
 			},
 			damage: 100,

--- a/data/EX/Delta Species/15.ts
+++ b/data/EX/Delta Species/15.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may search your deck for a Metal Energy card and attach it to Starmie. Shuffle your deck afterward. This power can't be used if Starmie is affected by a Special Condition.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez chercher dans votre deck une carte Énergie  et l'attacher à Staross. Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Staross est affecté par un État Spécial.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez chercher dans votre deck une carte Énergie {M} et l'attacher à Staross. Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Staross est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach einer -Energiekarte durchsuchen und diese an Starmie anlegen. Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Starmie von einem Speziellen Zustand betroffen ist."
 			},
 		},

--- a/data/EX/Delta Species/24.ts
+++ b/data/EX/Delta Species/24.ts
@@ -62,7 +62,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 10 damage times the number of Darkness Pokémon and Metal Pokémon you have in play.",
-				fr: "Inflige 10 dégâts multipliés par le nombre de Pokémon  et  que vous avez en jeu.",
+				fr: "Inflige 10 dégâts multipliés par le nombre de Pokémon {D} et {M} que vous avez en jeu.",
 				de: "Dieser Angriff fügt 10 Schadenspunkte mal der Anzahl der  und -Pokémon zu, die du im Spiel hast."
 			},
 			damage: "10x",

--- a/data/EX/Delta Species/28.ts
+++ b/data/EX/Delta Species/28.ts
@@ -59,7 +59,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Slowking has a Water Energy card attached to it, this attack does 20 damage plus 20 more damage. If Slowking has a Psychic Energy card attached to it, discard a Special Energy card attached to the Defending Pokémon, if any.",
-				fr: "Si Roigada possède une carte Énergie , cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires. Si Roigada possède une carte Énergie , défaussez une carte Énergie spéciale attachée au Pokémon Défenseur, s'il en a.",
+				fr: "Si Roigada possède une carte Énergie {W}, cette attaque inflige 20 dégâts plus 20 dégâts supplémentaires. Si Roigada possède une carte Énergie {P}, défaussez une carte Énergie spéciale attachée au Pokémon Défenseur, s'il en a.",
 				de: "Wenn an Laschoking eine -Energiekarte angelegt ist, fügt dieser Angriff 20 Schadenspunkte plus 20 weitere Schadenspunkte zu. Wenn an Laschoking eine -Energiekarte angelegt ist, lege eine an dem Verteidigenden Pokémon angelegte Spezialenergiekarte auf den Ablagestapel."
 			},
 			damage: "20+",

--- a/data/EX/Delta Species/3.ts
+++ b/data/EX/Delta Species/3.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may attach a Lightning Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Dragonite is affected by a Special Condition.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez attacher une carte Énergie  de votre pile de défausse à 1 de vos Pokémon de Banc. Ce pouvoir ne peut pas être utilisé si Dracolosse est affecté par un État Spécial.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez attacher une carte Énergie {L} de votre pile de défausse à 1 de vos Pokémon de Banc. Ce pouvoir ne peut pas être utilisé si Dracolosse est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du eine -Energiekarte von deinem Ablagestapel nehmen und an 1 Pokémon auf deiner Bank anlegen. Diese Poké-Power kann nicht verwendet werden, falls Dragoran von einem Speziellen Zustand betroffen ist."
 			},
 		},

--- a/data/EX/Delta Species/55.ts
+++ b/data/EX/Delta Species/55.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for a Metal Pokémon (excluding Pokémon-ex), show it to your opponent, and put it into your hand. Shuffle your deck afterward.",
-				fr: "Choisissez dans votre deck un Pokémon  (Pokémon-ex exclus), montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
+				fr: "Choisissez dans votre deck un Pokémon {M} (Pokémon-ex exclus), montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck.",
 				de: "Search your deck for a  Pokémon (excluding Pokémon-ex), show it to your opponent, and put it into your hand. Shuffle your deck afterward."
 			},
 

--- a/data/EX/Delta Species/58.ts
+++ b/data/EX/Delta Species/58.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy card attached to Bagon.",
-				fr: "Défaussez une carte Énergie  attachée à Draby.",
+				fr: "Défaussez une carte Énergie {R} attachée à Draby.",
 				de: "Discard a  Energy card attached to Bagon."
 			},
 			damage: 30,

--- a/data/EX/Delta Species/59.ts
+++ b/data/EX/Delta Species/59.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You pay Colorless to retreat Beldum for each Beldum on your Bench.",
-				fr: "Tant que Terhal est votre Pokémon Actif, vous payez un  de moins pour faire battre Terhal en retraite pour chaque Terhal se trouvant sur votre Banc.",
+				fr: "Tant que Terhal est votre Pokémon Actif, vous payez un {C} de moins pour faire battre Terhal en retraite pour chaque Terhal se trouvant sur votre Banc.",
 				de: "As long as Beldum is your Active Pokémon, you pay  less to retreat Beldum for each Beldum on your Bench."
 			},
 		},

--- a/data/EX/Delta Species/61.ts
+++ b/data/EX/Delta Species/61.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy card attached to Ditto.",
-				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie  attachée à Metamorph.",
+				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie {R} attachée à Metamorph.",
 				de: "Flip a coin. If tails, discard a  Energy card attached to Ditto."
 			},
 			damage: 30,

--- a/data/EX/Delta Species/68.ts
+++ b/data/EX/Delta Species/68.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your discard pile for a Metal Energy card and attach it to Eevee.",
-				fr: "Choisissez dans votre pile de défausse une carte Énergie  et attachez-la à Evoli.",
+				fr: "Choisissez dans votre pile de défausse une carte Énergie {M} et attachez-la à Evoli.",
 				de: "Search your discard pile for a  Energy card and attach it to Eevee."
 			},
 			damage: 10,

--- a/data/EX/Delta Species/8.ts
+++ b/data/EX/Delta Species/8.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If you have Latios or Latios ex in play, the attack cost of Latias's Extra Crush is now Lightning Metal Colorless.",
-				fr: "Si vous avez un Latios ou un Latios ex en jeu, le Coût de l'attaque Extra broyage de Latias est maintenant .",
+				fr: "Si vous avez un Latios ou un Latios ex en jeu, le Coût de l'attaque Extra broyage de Latias est maintenant {L}{M}{C}.",
 				de: "Wenn du Latios oder Latios ex im Spiel hast, kostet Latias Extra Zerschmettern nur noch   ."
 			},
 		},

--- a/data/EX/Delta Species/85.ts
+++ b/data/EX/Delta Species/85.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Water Energy card attached to Staryu and remove 4 damage counters from Staryu (all if there are less than 4).",
-				fr: "Défaussez une carte Énergie  attachée à Stari et retirez-lui 4 marqueurs de dégât (retirez-les lui tous s'il en a moins de 4).",
+				fr: "Défaussez une carte Énergie {W} attachée à Stari et retirez-lui 4 marqueurs de dégât (retirez-les lui tous s'il en a moins de 4).",
 				de: "Discard a  Energy attached to Staryu and remove 4 damage counters from Staryu (all if there als less than 4)."
 			},
 

--- a/data/EX/Delta Species/9.ts
+++ b/data/EX/Delta Species/9.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If you have Latias or Latias ex in play, the attack cost of Latios's Psychic Force is now Lightning Metal Colorless.",
-				fr: "Si vous avez un Latias ou un Latias ex en jeu, le Coût de l'attaque Force psychique de Latios est maintenant .",
+				fr: "Si vous avez un Latias ou un Latias ex en jeu, le Coût de l'attaque Force psychique de Latios est maintenant {L}{M}{C}.",
 				de: "Wenn du Latias oder Latias ex im Spiel hast, kostet Latios Psychomacht nur noch   ."
 			},
 		},


### PR DESCRIPTION
## Changes

Same loss as #2273 to #2283, #2308 and #2309, this time in EX Delta Species (`ex11`): the inline energy symbols were dropped from the French rules text, leaving only the space they sat in.

```
en: "If you have Latios or Latios ex in play, the attack cost of Latias's Extra Crush is now Lightning Metal Colorless."
fr: "Si vous avez un Latios ou un Latios ex en jeu, le Coût de l'attaque Extra broyage de Latias est maintenant ."
de: "Wenn du Latios oder Latios ex im Spiel hast, kostet Latias Extra Zerschmettern nur noch   ."
```

**28 symbols** restored, in **21 strings** across **19 cards**, plus **4 stars** — see Details. Only `fr` values change — 21 lines in, 21 lines out.

## Sources

**No German token survives anywhere in this set.** Half the `de` fields hold real German that lost the same symbols (as in the block above, where the three spaces after `nur noch` are the three missing ones); the other half hold a copy of the English. So the English is the only textual source, and it names the type in all 21 strings.

Three were additionally read off the French scans on Poképédia, picked as the three least mechanical:

- `8` Latias δ — the whole attack cost sits inside the sentence. The scan shows `{L}{M}{C}`, matching the English `Lightning Metal Colorless` and the German's three blanks — [scan](https://www.pokepedia.fr/Latias_δ_(EX_Espèces_Delta_8)). `9` Latios δ is the mirrored card and takes the same three.
- `28` Roigada — two symbols in one string that are *different* types on a `{W}` Pokémon: `{W}` then `{P}`, per `a Water Energy card` … `a Psychic Energy card` — [scan](https://www.pokepedia.fr/Roigada_(EX_Espèces_Delta_28))
- `111` Groudon ☆ — carries both defects at once, `{F}` and the lost star — [scan](https://www.pokepedia.fr/Groudon_☆_(EX_Espèces_Delta_111))

The remaining strings rest on the English alone. One weak corroboration worth noting: the `de` field of `112` Kyogre ☆ spells its symbol out as the literal text `[W]`, which agrees with the English.

## Details

`111` Groudon ☆, `112` Kyogre ☆ and `113` Metalosse ☆ each lost **two** glyphs per string — the energy symbol *and* the star after the Pokémon's name, `attachez-les à Groudon .` The English reads `Groudon Star` and the German `Groudon *`. Restored as `Groudon ☆`, matching how the other star cards in the database already write it, e.g. `Noctali ☆` and `Mentali ☆`.

`8` Latias δ and `9` Latios δ are the only strings here where a full attack cost was lost rather than a single type. Written `{L}{M}{C}` with no separator, following the existing convention for consecutive symbols in French text (`{C}{C}`, `{C}{C}{C}`).

`24` Grahyena δ takes `{D}` then `{M}` from `Darkness Pokémon and Metal Pokémon`, and `114` Azumarill `{R}` then `{W}` from `attacks from Fire Pokémon and Water Pokémon`.

`npm run validate` passes. No English or German string was modified.

Thirteenth set of the series, after #2273 to #2283, #2308 and #2309, one PR each.
