### PR TITLE
fix(data): Restore the energy symbols lost from EX Ruby & Sapphire French text

### DIFF
--- a/data/EX/Ruby & Sapphire/13.ts
+++ b/data/EX/Ruby & Sapphire/13.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may attach a Water Energy card from your hand to your Active Pokémon. This power can't be used if Swampert is affected by a Special Condition.",
-				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie  de votre main à votre Pokémon Actif. Ce pouvoir ne peut être utilisé si Laggron est affecté par un État Spécial.",
+				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une carte Énergie {W} de votre main à votre Pokémon Actif. Ce pouvoir ne peut être utilisé si Laggron est affecté par un État Spécial.",
 				de: "Während deines Zuges (vor deinem Angriff) kannst du einmal eine {W}-Energiekarte von deiner Hand an dein Aktives Pokémon anlegen. Diese Poké-Power kann nicht verwendet werden, falls Sumpex von einem Speziellen Zustand betroffen ist."
 			}
 		},

--- a/data/EX/Ruby & Sapphire/15.ts
+++ b/data/EX/Ruby & Sapphire/15.ts
@@ -62,7 +62,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy card attached to Blaziken.",
-				fr: "Défaussez une carte Énergie  attachée à Brasegali.",
+				fr: "Défaussez une carte Énergie {R} attachée à Brasegali.",
 				de: "Lege 1 an Lohgock angelegte {R}-Energiekarte auf deinen Ablagestapel."
 			},
 			damage: 80,

--- a/data/EX/Ruby & Sapphire/16.ts
+++ b/data/EX/Ruby & Sapphire/16.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Fighting Energy attached to Breloom.",
-				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Chapignon.",
+				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {F} attachée à Chapignon.",
 				de: "Dieser Angriff fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Kapilz angelegte {F}-Energie zu."
 			},
 			damage: "40+",

--- a/data/EX/Ruby & Sapphire/20.ts
+++ b/data/EX/Ruby & Sapphire/20.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), move a Grass Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Sceptile is affected by a Special Condition.",
-				fr: "Pendant votre tour (avant votre attaque), vous pouvez déplacer autant de fois que vous le voulez une carte Énergie  attachée à un de vos Pokémon sur un autre de vos Pokémon. Ce pouvoir ne peut être utilisé si Jungko est affecté par un État Spécial.",
+				fr: "Pendant votre tour (avant votre attaque), vous pouvez déplacer autant de fois que vous le voulez une carte Énergie {G} attachée à un de vos Pokémon sur un autre de vos Pokémon. Ce pouvoir ne peut être utilisé si Jungko est affecté par un État Spécial.",
 				de: "Während deines Zuges kannst du (vor deinem Angriff) beliebig oft eine an 1 deiner Pokémon angelegte -Energiekarte nehmen und an 1 anderes anlegen. Diese Poké-Power kann nicht verwendet werden, falls Gewaldro von einem Speziellen Zustand betroffen ist."
 			}
 		},

--- a/data/EX/Ruby & Sapphire/22.ts
+++ b/data/EX/Ruby & Sapphire/22.ts
@@ -59,7 +59,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may discard a Darkness Energy card attached to Sharpedo. If you do, this attack does 40 damage plus 30 more damage.",
-				fr: "Vous pouvez défausser une carte Énergie  attachée à Sharpedo. Les dégâts de base de cette attaque sont de 70 au lieu de 40.",
+				fr: "Vous pouvez défausser une carte Énergie {D} attachée à Sharpedo. Les dégâts de base de cette attaque sont de 70 au lieu de 40.",
 				de: "Du kannst eine {W}-Energiekarte, die an Tohaido angelegt ist, auf den Ablagestapel legen. Wenn du das machst, beträgt der Grundschaden dieses Angriffs 70 Schadenspunkte anstelle von 40."
 			},
 			damage: "40+",

--- a/data/EX/Ruby & Sapphire/23.ts
+++ b/data/EX/Ruby & Sapphire/23.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), when you attach a Water Energy card from your hand to Swampert, remove 1 damage counter from Swampert.",
-				fr: "Une seule fois pendant votre tour (avant votre attaque), si vous attachez une carte Énergie  de votre main à Laggron, retirez-lui un marqueur de dégât.",
+				fr: "Une seule fois pendant votre tour (avant votre attaque), si vous attachez une carte Énergie {W} de votre main à Laggron, retirez-lui un marqueur de dégât.",
 				de: "Einmal in deinem Zug (vor deinem Angriff), wenn du eine {W}-Energiekarte von der Hand an Sumpex anlegst, entferne 1 Schadensmarke von Sumpex."
 			}
 		},

--- a/data/EX/Ruby & Sapphire/28.ts
+++ b/data/EX/Ruby & Sapphire/28.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "When you attach a Fire Energy card from your hand to Combusken, remove all Special Conditions from Combusken.",
-				fr: "Lorsque vous attachez une carte Énergie  à Galifeu, retirez-lui tous ses États Spéciaux.",
+				fr: "Lorsque vous attachez une carte Énergie {R} à Galifeu, retirez-lui tous ses États Spéciaux.",
 				de: "Wenn du eine {R}-Energiekarte an Jungglut anlegst, verlieren alle Speziellen Zustände auf Jungglut ihre Wirkung."
 			}
 		},

--- a/data/EX/Ruby & Sapphire/3.ts
+++ b/data/EX/Ruby & Sapphire/3.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may attach a Fire Energy card from your discard pile to 1 of your Benched Pokémon. This power can't be used if Blaziken is affected by a Special Condition.",
-				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une Carte Énergie  de votre pile de défausse à un des Pokémon de votre Banc. Ce pouvoir ne peut être utilisé si Brasegali est affecté par un État Spécial.",
+				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez attacher une Carte Énergie {R} de votre pile de défausse à un des Pokémon de votre Banc. Ce pouvoir ne peut être utilisé si Brasegali est affecté par un État Spécial.",
 				de: "Während deines Zuges (vor deinem Angriff) kannst du einmal eine {R}-Energiekarte von deinem Ablagestapel nehmen und an 1 Pokémon auf deiner Bank anlegen. Diese Poké-Power kann nicht verwendet werden, falls Lohgock von einem Speziellen Zustand betroffen ist."
 			}
 		},
@@ -59,7 +59,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy card attached to Blaziken. If you do, this attack does 10 damage to each of your opponent's Benched Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Vous pouvez défausser une Carte Énergie  attachée à Brasegali. Cette attaque inflige alors 10 dégâts à chacun des Pokémon du Banc de votre adversaire. (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
+				fr: "Vous pouvez défausser une Carte Énergie {R} attachée à Brasegali. Cette attaque inflige alors 10 dégâts à chacun des Pokémon du Banc de votre adversaire. (Ne pas appliquer la Faiblesse et la Résistance aux Pokémon du Banc.)",
 				de: "Entferne eine {R}-Energiekarte von Lohgock und lege sie auf den Ablagestapel. Wenn du das machst, fügt dieser Angriff jedem gegnerischen Pokémon auf der Bank 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 			damage: 50,

--- a/data/EX/Ruby & Sapphire/30.ts
+++ b/data/EX/Ruby & Sapphire/30.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Attach a Lightning Energy card from your discard pile to Electrike.",
-				fr: "Attachez une carte Énergie  de votre pile de défausse à Dynavolt.",
+				fr: "Attachez une carte Énergie {L} de votre pile de défausse à Dynavolt.",
 				de: "Nimm eine {L}-Energiekarte von deinem Ablagestapel und lege sie an Frizelbliz an."
 			},
 

--- a/data/EX/Ruby & Sapphire/32.ts
+++ b/data/EX/Ruby & Sapphire/32.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "When you attach a Grass Energy card from your hand to Grovyle, remove all Special Conditions from Grovyle.",
-				fr: "Lorsque vous attachez une carte Énergie  de votre main à Massko, retirez-lui tous ses États Spéciaux.",
+				fr: "Lorsque vous attachez une carte Énergie {G} de votre main à Massko, retirez-lui tous ses États Spéciaux.",
 				de: "Wenn du eine {G}-Energiekarte von der Hand an Reptain anlegst, verlieren alle Speziellen Zustände auf Reptain ihre Wirkung."
 			}
 		},

--- a/data/EX/Ruby & Sapphire/41.ts
+++ b/data/EX/Ruby & Sapphire/41.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "When you attach a Water Energy card from your hand to Marshtomp, remove all Special Conditions from Marshtomp.",
-				fr: "Lorsque vous attachez une carte Énergie  de votre main à Flobio, retirez-lui tous ses États Spéciaux.",
+				fr: "Lorsque vous attachez une carte Énergie {W} de votre main à Flobio, retirez-lui tous ses États Spéciaux.",
 				de: "Wenn du eine {W}-Energiekarte an Moorabbel anlegst, verlieren alle Speziellen Zustände auf Moorabbel ihre Wirkung."
 			}
 		},

--- a/data/EX/Ruby & Sapphire/48.ts
+++ b/data/EX/Ruby & Sapphire/48.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "This attack does 20 damage plus 10 more damage for each Water Energy attached to Wailmer but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
-				fr: "Cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Wailmer qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
+				fr: "Cette attaque inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {W} attachée à Wailmer qui n'a pas été utilisée pour payer le coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
 				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Wailmer angelegt {W}-Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 20 Schadenspunkte hinzufügen."
 			},
 			damage: "20+",

--- a/data/EX/Ruby & Sapphire/7.ts
+++ b/data/EX/Ruby & Sapphire/7.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may search your deck for a Psychic Energy card and attach it to 1 of your Pokémon. Put 2 damage counters on that Pokémon. Shuffle your deck afterward. This power can't be used if Gardevoir is affected by a Special Condition.",
-				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez choisir dans votre deck une carte Énergie  et l'attacher à un de vos Pokémon. Placez deux marqueurs de dégât sur ce Pokémon. Mélangez ensuite votre deck. Ce pouvoir ne peut être utilisé si Gardevoir est affecté par un État Spécial.",
+				fr: "Une seule fois pendant votre tour (avant votre attaque), vous pouvez choisir dans votre deck une carte Énergie {P} et l'attacher à un de vos Pokémon. Placez deux marqueurs de dégât sur ce Pokémon. Mélangez ensuite votre deck. Ce pouvoir ne peut être utilisé si Gardevoir est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach einer {P}-Energiekarte durchsuchen und an 1 deiner Pokémon anlegen. Lege 2 Schadensmarken auf dieses Pokémon. Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Guardevoir von einem Speziellen Zustand betroffen ist."
 			}
 		},

--- a/data/EX/Ruby & Sapphire/73.ts
+++ b/data/EX/Ruby & Sapphire/73.ts
@@ -49,7 +49,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy card attached to Torchic.",
-				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie  attachée à Poussifeu.",
+				fr: "Lancez une pièce. Si c'est pile, défaussez une carte Énergie {R} attachée à Poussifeu.",
 				de: "Wirf eine Münze. Entferne bei „Zahl“ eine {R}-Energiekarte von Flemmli."
 			},
 			damage: 30,

--- a/data/EX/Ruby & Sapphire/9.ts
+++ b/data/EX/Ruby & Sapphire/9.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for a Lightning Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward.",
-				fr: "Choisissez dans votre deck une carte Énergie  et attachez-la à un de vos Pokémon. Mélangez ensuite votre deck.",
+				fr: "Choisissez dans votre deck une carte Énergie {L} et attachez-la à un de vos Pokémon. Mélangez ensuite votre deck.",
 				de: "Durchsuche dein Deck nach einer {L}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische dein Deck danach."
 			},
 			damage: 10,


### PR DESCRIPTION
## Changes

Same loss as #2273 to #2283 and #2308 to #2310, this time in EX Ruby & Sapphire (`ex1`): the inline energy symbols were dropped from the French rules text, leaving only the space they sat in.

```
en: "Search your deck for a Lightning Energy card and attach it to 1 of your Pokémon. Shuffle your deck afterward."
fr: "Choisissez dans votre deck une carte Énergie  et attachez-la à un de vos Pokémon. Mélangez ensuite votre deck."
de: "Durchsuche dein Deck nach einer {L}-Energiekarte und lege sie an 1 deiner Pokémon an. Mische dein Deck danach."
```

**16 symbols** restored, in **16 strings** across **15 cards**. Only `fr` values change — 16 lines in, 16 lines out.

## Sources

This set still carries real German, and unlike `ex10` and `ex11` most of it kept its tokens.

- **14 strings** — the English names the type *and* the German still has its `{X}`. Cross-checked, they agree: `3` (both fields), `7`, `9`, `13`, `15`, `16`, `23`, `28`, `30`, `32`, `41`, `48`, `73`.
- **1 string** — `20` Jungko, where the German lost its token too (`eine an 1 deiner Pokémon angelegte -Energiekarte`). English alone: `a Grass Energy card` → `{G}`.
- **1 string** — `22` Sharpedo, where **the two sources disagree**. See below.

Two were also read off the French scans on Poképédia, the disagreement and the one whose symbol is not the card's own type:

- `22` Sharpedo → `{D}` — [scan](https://www.pokepedia.fr/Sharpedo_(EX_Rubis_&_Saphir_22))
- `16` Chapignon → `{F}` on a `{G}` Pokémon — [scan](https://www.pokepedia.fr/Chapignon_(EX_Rubis_&_Saphir_16)), agreeing with both the English and the German

## Details

`22` Sharpedo is worth a look. The English reads `discard a Darkness Energy card attached to Sharpedo`, the German reads `eine {W}-Energiekarte`. They cannot both be right, and the French sentence structure follows the German's (`Les dégâts de base … sont de 70 au lieu de 40` against `beträgt der Grundschaden 70 anstelle von 40`), which is what made the German the tempting source.

The scan shows the black-with-crescent Darkness symbol, so the English is correct and `{D}` is what goes in. The German `{W}` on that card is wrong, but fixing German text is outside this PR — I have not touched it.

Two fields on card `3` Braségali both read `une Carte Énergie` with a capital C, unlike every other string in the set. Left as found; only the missing symbol was added.

`npm run validate` passes. No English or German string was modified.

Fourteenth set of the series, after #2273 to #2283 and #2308 to #2310, one PR each.
