### PR TITLE
fix(data): Restore the energy symbols lost from EX Hidden Legends French text

### DIFF
--- a/data/EX/Hidden Legends/11.ts
+++ b/data/EX/Hidden Legends/11.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may move a Metal Energy card attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Metagross is affected by a Special Condition.",
-				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez déplacer une carte Énergie  attachée à 1 des Pokémon de votre Banc sur votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Metalosse est affecté par un État Spécial.",
+				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez déplacer une carte Énergie {M} attachée à 1 des Pokémon de votre Banc sur votre Pokémon Actif. Ce pouvoir ne peut pas être utilisé si Metalosse est affecté par un État Spécial.",
 				de: "As often you like during your turn (before your attack), you may move a  Energy card attached to 1 of your Benched Pokémon to your Active Pokémon. This power can't be used if Metagross is affected by a Special Condition."
 			}
 		},

--- a/data/EX/Hidden Legends/18.ts
+++ b/data/EX/Hidden Legends/18.ts
@@ -58,7 +58,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Psychic Energy in play.",
-				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  en jeu.",
+				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {P} en jeu.",
 				de: "Does 20 damage plus 10 more damage for each  Energy in play."
 			},
 			damage: "20+",

--- a/data/EX/Hidden Legends/19.ts
+++ b/data/EX/Hidden Legends/19.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Darkness Pokémon in play.",
-				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Pokémon  en jeu.",
+				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Pokémon {D} en jeu.",
 				de: "Does 40 damage plus 10 more damage for each  Energy in play."
 			},
 			damage: "40+",

--- a/data/EX/Hidden Legends/2.ts
+++ b/data/EX/Hidden Legends/2.ts
@@ -38,7 +38,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Claydol is your Active Pokémon, each player's Evolved Pokémon pays Colorless more Energy to use its attacks.",
-				fr: "Tant que Kaorine est votre Pokémon Actif, le Pokémon Évolué de chaque joueur paye 1 Énergie  supplémentaire pour utiliser ses attaques.",
+				fr: "Tant que Kaorine est votre Pokémon Actif, le Pokémon Évolué de chaque joueur paye 1 Énergie {C} supplémentaire pour utiliser ses attaques.",
 				de: "As long as Claydol is your Active Pokémon, each player's Evolved Pokémon pays  more Energy to use its attacks."
 			}
 		},

--- a/data/EX/Hidden Legends/21.ts
+++ b/data/EX/Hidden Legends/21.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your discard pile for a Metal Energy card and attach it to Metang.",
-				fr: "Choisissez une carte Énergie  dans votre pile de défausse et attachez-la à Metang.",
+				fr: "Choisissez une carte Énergie {M} dans votre pile de défausse et attachez-la à Metang.",
 				de: "Search your discard pile for a  Energy card and attach it to Metang."
 			},
 

--- a/data/EX/Hidden Legends/29.ts
+++ b/data/EX/Hidden Legends/29.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for a Metal Basic Pokémon and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Beldum is affected by a Special Condition.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, cherchez un Pokémon de base  dans votre deck et placez-le sur votre Banc. Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Terhal est affecté par un État Spécial.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez lancer une pièce. Si c'est face, cherchez un Pokémon de base {M} dans votre deck et placez-le sur votre Banc. Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Terhal est affecté par un État Spécial.",
 				de: "Once during your turn (before your attack), you may flip a coin. If heads, search your deck for a  Basic Pokémon and put it onto your Bench. Shuffle your deck afterward. This power can't be used if Beldum is affected by a Special Condition."
 			}
 		},

--- a/data/EX/Hidden Legends/38.ts
+++ b/data/EX/Hidden Legends/38.ts
@@ -58,7 +58,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may discard all Lightning Energy attached to Lanturn. If you do, this attack's base damage is 90 instead of 50.",
-				fr: "Vous pouvez défausser toutes les Énergies  attachées à Lanturn. Les dégâts de base de cette attaque sont alors de 90 au lieu de 50.",
+				fr: "Vous pouvez défausser toutes les Énergies {L} attachées à Lanturn. Les dégâts de base de cette attaque sont alors de 90 au lieu de 50.",
 				de: "You may discard all  Energy attached to Lanturn. If you do, this attack's base damage is 90 instead of 50."
 			},
 			damage: 50,

--- a/data/EX/Hidden Legends/4.ts
+++ b/data/EX/Hidden Legends/4.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Attach up to 1 Grass or Darkness Energy card from your hand to your Pokémon.",
-				fr: "Attachez à votre Pokémon jusqu'à 1 carte Énergie  ou  de votre main.",
+				fr: "Attachez à votre Pokémon jusqu'à 1 carte Énergie {G} ou {D} de votre main.",
 				de: "Attack up to 1  or  Energy card from your hand to your Pokémon."
 			},
 

--- a/data/EX/Hidden Legends/69.ts
+++ b/data/EX/Hidden Legends/69.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, attach a Lightning Energy card from your hand to any of your Pokémon.",
-				fr: "Lancez une pièce. Si c'est face, attachez une carte Énergie  de votre main à un de vos Pokémon.",
+				fr: "Lancez une pièce. Si c'est face, attachez une carte Énergie {L} de votre main à un de vos Pokémon.",
 				de: "Flip a coin. If heads, attach a  Energy card from your hand to any of your Pokémon."
 			},
 

--- a/data/EX/Hidden Legends/7.ts
+++ b/data/EX/Hidden Legends/7.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If your opponent has any Pokémon-ex in play, search your deck for up to 2 Grass Energy cards and attach them to Heracross. Shuffle your deck afterward.",
-				fr: "Si votre adversaire a des Pokémon-ex en jeu, cherchez dans votre deck jusqu'à 2 cartes Énergie  et attachez-les à Scarhino. Ensuite, mélangez votre deck.",
+				fr: "Si votre adversaire a des Pokémon-ex en jeu, cherchez dans votre deck jusqu'à 2 cartes Énergie {G} et attachez-les à Scarhino. Ensuite, mélangez votre deck.",
 				de: "If your opponent has any Pokémon-ex in play, search your deck for up to 2  Energy cards and attach them to Heracross. Shuffle your deck afterward."
 			},
 

--- a/data/EX/Hidden Legends/71.ts
+++ b/data/EX/Hidden Legends/71.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Attach a Grass Energy card from your hand to Seedot.",
-				fr: "Attachez une carte Énergie  de votre main à Grainipiot.",
+				fr: "Attachez une carte Énergie {G} de votre main à Grainipiot.",
 				de: "Attach a  Energy card from your hand to Seedot."
 			},
 

--- a/data/EX/Hidden Legends/72.ts
+++ b/data/EX/Hidden Legends/72.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may discard 1 Psychic Energy card attached to Shuppet. If you do, your opponent discards 1 Energy card attached to the Defending Pokémon.",
-				fr: "Vous pouvez défausser 1 carte Énergie  attachée à Polichombr. Votre adversaire défausse alors 1 carte Énergie attachée au Pokémon Défenseur.",
+				fr: "Vous pouvez défausser 1 carte Énergie {P} attachée à Polichombr. Votre adversaire défausse alors 1 carte Énergie attachée au Pokémon Défenseur.",
 				de: "You may discard 1  Energy card attached to Shuppet. If you do, your opponent discards 1 Energy card attached to the Defending Pokémon."
 			},
 			damage: 10,

--- a/data/EX/Hidden Legends/75.ts
+++ b/data/EX/Hidden Legends/75.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Staryu has any Psychic Energy attached to it, damage done to Staryu by any attack is reduced by 10 (after applying Weakness and Resistance).",
-				fr: "Si Stari possède des Énergies , les dégâts qui lui sont infligés par une attaque sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
+				fr: "Si Stari possède des Énergies {P}, les dégâts qui lui sont infligés par une attaque sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
 				de: "If Staryu has any  Energy attached to it, damage done to Staryu by any attack is reduced by 10 (after applying Weakness and Resistance)."
 			}
 		},

--- a/data/EX/Hidden Legends/80.ts
+++ b/data/EX/Hidden Legends/80.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for a Lightning Energy card and attach it to Voltorb. Shuffle your deck afterward.",
-				fr: "Choisissez dans votre deck une carte Énergie  et attachez-la à Voltorbe. Ensuite, mélangez votre deck.",
+				fr: "Choisissez dans votre deck une carte Énergie {L} et attachez-la à Voltorbe. Ensuite, mélangez votre deck.",
 				de: "Search your deck for a  Energy card and attach it to Voltorb. Shuffle your deck afterward."
 			},
 

--- a/data/EX/Hidden Legends/96.ts
+++ b/data/EX/Hidden Legends/96.ts
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to Ninetales ex.",
-				fr: "Défaussez une Énergie  attachée à Feunard ex.",
+				fr: "Défaussez une Énergie {R} attachée à Feunard ex.",
 				de: "Discard a  Energy card attached to Ninetales ex."
 			},
 			damage: 100,


### PR DESCRIPTION
## Changes

Same loss as #2273 to #2283 and #2308 to #2311, this time in EX Hidden Legends (`ex5`): the inline energy symbols were dropped from the French rules text, leaving only the space they sat in.

```
en: "Does 20 damage plus 10 more damage for each Psychic Energy in play."
fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  en jeu."
de: "Does 20 damage plus 10 more damage for each  Energy in play."
```

**16 symbols** restored, in **15 strings** across **15 cards**. Only `fr` values change — 15 lines in, 15 lines out.

## Sources

As in #2309 and #2310, **there is no German to cross-check against**: every `de` field in this set holds a copy of the English, with the same symbols already missing — visible on all 15 fields touched here. The English names the type in all 15 strings and is the only textual source.

Three were read off the French scans on Poképédia. I picked the three `{W}` Pokémon whose symbol is a different type, since a mistranscribed English string would be invisible there:

- `18` Rosabyss, *Eau mystique* → `{P}` — [scan](https://www.pokepedia.fr/Rosabyss_(EX_Légendes_Oubliées_18))
- `19` Serpang, *Éclaboussure obscure* → `{D}` — [scan](https://www.pokepedia.fr/Serpang_(EX_Légendes_Oubliées_19))
- `75` Stari, *Protection principale* → `{P}` — [scan](https://www.pokepedia.fr/Stari_(EX_Légendes_Oubliées_75))

All three confirm the English. The remaining 12 strings rest on the English alone.

## Details

`19` Serpang is the one where the English copy in the `de` field diverges from the English itself: `de` reads `for each  Energy in play`, `en` reads `for each Darkness Pokémon in play`. The French says `pour chaque Pokémon  en jeu`, and the scan shows `Pokémon {D}`, so the English is the one to follow and the `de` copy is corrupt on that card as well as symbol-less.

Three strings are not the plain `carte Énergie {X}` shape. `2` Kaorine takes `{C}` from `pays Colorless more Energy`. `29` Terhal puts its symbol on a Pokémon rather than an Energy, `un Pokémon de base {M}`, from `a Metal Basic Pokémon`. `4` Celebi Obscur is the only string here with two symbols, `{G}` then `{D}`, from `1 Grass or Darkness Energy card`.

`npm run validate` passes. No English string was modified.

Fifteenth set of the series, after #2273 to #2283 and #2308 to #2311, one PR each.
