### PR TITLE
fix(data): Restore the SP suffixes and type symbols lost from Rising Rivals French text

### DIFF
--- a/data/Platinum/Rising Rivals/1.ts
+++ b/data/Platinum/Rising Rivals/1.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Arcanine has any Fire Energy attached to it, Arcanine has no Weakness.",
-				fr: "Tant qu'Arcanin possède de l'Énergie Fire, il ne possède pas de Faiblesse.",
+				fr: "Tant qu'Arcanin possède de l'Énergie {R}, il ne possède pas de Faiblesse.",
 				de: "Solange an Arkani mindestens 1 {R}-Energie angelegt ist, hat Arkani keine Schwäche."
 			}
 		},
@@ -77,7 +77,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to Arcanine. This attack does 60 damage plus 10 more damage for each damage counter on Arcanine.",
-				fr: "Défaussez une Énergie Fire attachée à Arcanin. Cette attaque inflige alors 60 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégât sur Arcanin.",
+				fr: "Défaussez une Énergie {R} attachée à Arcanin. Cette attaque inflige alors 60 dégâts plus 10 dégâts supplémentaires pour chaque marqueur de dégât sur Arcanin.",
 				de: "Lege 1 {R}-Energie, die an Arkani angelegt ist, auf deinen Ablagestapel. Dieser Angriff fügt 60 Schadenspunkte plus 10 weitere Schadenspunkte für jede Schadensmarke auf Arkani zu."
 			},
 			damage: "60+",

--- a/data/Platinum/Rising Rivals/10.ts
+++ b/data/Platinum/Rising Rivals/10.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Mismagius GL",
-		fr: "Magirêve  Niv. 26",
+		fr: "Magirêve GL Niv. 26",
 		de: "Traunmagil GL"
 	},
 

--- a/data/Platinum/Rising Rivals/100.ts
+++ b/data/Platinum/Rising Rivals/100.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		en: "Damage done by attacks to the Pokémon that Metal Energy is attached to is reduced by 10 (after applying Weakness and Resistance). Ignore this effect if the Pokémon that Metal Energy is attached to isn't Metal. Metal Energy provides Metal Energy. (Doesn't count as a basic Energy card.)",
-		fr: "Les dégâts infligés par des attaques au Pokémon auquel Énergie Métal est attachée sont réduits de 10 (après application de la Faiblesse et de la Résistance). Ignorez cet effet si le Pokémon auquel Énergie Métal est attachée n'est pas Metal. Énergie Métal fournit de l'Énergie Metal. (Elle ne compte pas comme carte Énergie de base).",
+		fr: "Les dégâts infligés par des attaques au Pokémon auquel Énergie Métal est attachée sont réduits de 10 (après application de la Faiblesse et de la Résistance). Ignorez cet effet si le Pokémon auquel Énergie Métal est attachée n'est pas {M}. Énergie Métal fournit de l'Énergie {M}. (Elle ne compte pas comme carte Énergie de base).",
 		de: "Schaden, der dem Pokémon, an das Metall-Energie angelegt ist, durch Angriffe zugefügt wird, wird um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden). Dieser Effekt wirkt nur, wenn die Metall-Energie an einem Pokémon vom Typ {M} angelegt ist. Metall-Energie liefert {M}-Energie. (Zählt nicht als Basis-Energiekarte.)"
 	},
 

--- a/data/Platinum/Rising Rivals/101.ts
+++ b/data/Platinum/Rising Rivals/101.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		en: "SP Energy provides Colorless Energy. If the Pokémon SP Energy is attached to is a Pokémon SP, SP Energy provides every type of Energy buy provides only 1 Energy at a time. (Doesn't count as a basic Energy card.)",
-		fr: "Énergie SP fournit de l'Énergie Colorless. Si le Pokémon auquel Énergie SP est attachée est un Pokémon SP, Énergie SP fournit tous les types d'Énergie mais fournit 1 Énergie à la fois. (Elle ne compte pas comme carte Énergie de base).",
+		fr: "Énergie SP fournit de l'Énergie {C}. Si le Pokémon auquel Énergie SP est attachée est un Pokémon SP, Énergie SP fournit tous les types d'Énergie mais fournit 1 Énergie à la fois. (Elle ne compte pas comme carte Énergie de base).",
 		de: "SP-Energie liefert {C}-Energie. Solange das Pokémon, an dem SP-Energie angelegt ist, ein Pokémon SP ist, zählt SP-Energie als jeder beliebige Energietyp, spendet aber immer nur eine Energie auf einmal. (Zählt nicht als Basis-Energiekarte.)"
 	},
 

--- a/data/Platinum/Rising Rivals/102.ts
+++ b/data/Platinum/Rising Rivals/102.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		en: "Upper Energy provides Colorless Energy. If you have more Prize cards left than your opponent and this card is attached to a Pokémon (excluding Pokémon LV.X), Upper Energy provides ColorlessColorless.",
-		fr: "Énergie Sup fournit de l'Énergie Colorless. Si vous possédez plus de cartes Récompense que votre adversaire et que cette carte est attachée à un Pokémon (Pokémon LV.X exclus), Énergie Sup fournit de l'Énergie ColorlessColorless.",
+		fr: "Énergie Sup fournit de l'Énergie {C}. Si vous possédez plus de cartes Récompense que votre adversaire et que cette carte est attachée à un Pokémon (Pokémon LV.X exclus), Énergie Sup fournit de l'Énergie {C}{C}.",
 		de: "Aufputsch-Energie liefert {C}-Energie. Solange du mehr Preise übrig hast als dein Gegner und diese Karte an ein Pokémon (außer Pokémon LV.X) angelegt ist, liefert Aufputsch-Energie {C}{C}-Energie."
 	},
 

--- a/data/Platinum/Rising Rivals/103.ts
+++ b/data/Platinum/Rising Rivals/103.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Alakazam E4 LV.X",
-		fr: "Alakazam  Niv. X",
+		fr: "Alakazam 4 Niv. X",
 		de: "Simsala 4"
 	},
 	illustrator: "Ryo Ueda",
@@ -30,7 +30,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may move 1 damage counter from 1 of your Pokémon SP to another of your Pokémon SP. This power can't be used if Alakazam E4 is affected by a Special Condition.",
-				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez déplacer 1 marqueur de dégât d'1 de vos Pokémon SP sur un autre de vos Pokémon SP. Ce pouvoir ne peut pas être utilisé si Alakazam  est affecté par un État Spécial.",
+				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez déplacer 1 marqueur de dégât d'1 de vos Pokémon SP sur un autre de vos Pokémon SP. Ce pouvoir ne peut pas être utilisé si Alakazam 4 est affecté par un État Spécial.",
 				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 Schadensmarke von 1 deiner Pokémon SP entfernen und auf 1 anderes deiner Pokémon SP legen. Diese Poké-Power kann nicht benutzt werden, wenn Simsala 4 von einem Speziellen Zustand betroffen ist."
 			}
 		},

--- a/data/Platinum/Rising Rivals/104.ts
+++ b/data/Platinum/Rising Rivals/104.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Whenever any of your Water Pokémon (excluding any Floatzel GL) is Knocked Out by damage from your opponent's attack, you may put that Pokémon and all cards that were attached to it from your discard pile into your hand.",
-				fr: "Lorsque que n'importe lequel de vos Pokémon Water (tous les Mustéflott GL mis K.O par les dégâts d'une attaque de votre adversaire exclus), vous pouvez placer ce Pokémon ainsi que toutes les cartes qui lui sont attachées de votre pile de défausse à votre main.",
+				fr: "Lorsque que n'importe lequel de vos Pokémon {W} (tous les Mustéflott GL mis K.O par les dégâts d'une attaque de votre adversaire exclus), vous pouvez placer ce Pokémon ainsi que toutes les cartes qui lui sont attachées de votre pile de défausse à votre main.",
 				de: "Jedes Mal, wenn 1 deiner {W}-Pokémon (außer allen Bojelin GL) durch einen Angriff deines Gegners kampfunfähig wird, kannst du dieses Pokémon und alle Karten, die an es angelegt waren, aus deinem Ablagestapel auf deine Hand nehmen."
 			}
 		},

--- a/data/Platinum/Rising Rivals/104.ts
+++ b/data/Platinum/Rising Rivals/104.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Floatzel GL LV.X",
-		fr: "Mustéflott  Niv. X",
+		fr: "Mustéflott GL Niv. X",
 		de: "Bojelin GL"
 	},
 
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Whenever any of your Water Pokémon (excluding any Floatzel GL) is Knocked Out by damage from your opponent's attack, you may put that Pokémon and all cards that were attached to it from your discard pile into your hand.",
-				fr: "Lorsque que n'importe lequel de vos Pokémon Water (tous les Mustéflott  mis K.O par les dégâts d'une attaque de votre adversaire exclus), vous pouvez placer ce Pokémon ainsi que toutes les cartes qui lui sont attachées de votre pile de défausse à votre main.",
+				fr: "Lorsque que n'importe lequel de vos Pokémon Water (tous les Mustéflott GL mis K.O par les dégâts d'une attaque de votre adversaire exclus), vous pouvez placer ce Pokémon ainsi que toutes les cartes qui lui sont attachées de votre pile de défausse à votre main.",
 				de: "Jedes Mal, wenn 1 deiner {W}-Pokémon (außer allen Bojelin GL) durch einen Angriff deines Gegners kampfunfähig wird, kannst du dieses Pokémon und alle Karten, die an es angelegt waren, aus deinem Ablagestapel auf deine Hand nehmen."
 			}
 		},

--- a/data/Platinum/Rising Rivals/106.ts
+++ b/data/Platinum/Rising Rivals/106.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Gallade E4 LV.X",
-		fr: "Gallame  Niv. X",
+		fr: "Gallame 4 Niv. X",
 		de: "Galagladi 4"
 	},
 	illustrator: "Ryo Ueda",
@@ -30,7 +30,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), when you put Gallade E4 LV.X from your hand onto your Active Gallade E4, you may put 1 damage counter on each of your opponent's Pokémon.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous placez Gallame  LV.X de votre main sur votre Gallame  Actif, vous pouvez placer 1 marqueur de dégât sur chacun des Pokémon de votre adversaire.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous placez Gallame 4 LV.X de votre main sur votre Gallame 4 Actif, vous pouvez placer 1 marqueur de dégât sur chacun des Pokémon de votre adversaire.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn du Galagladi 4 LV.X von deiner Hand auf dein Aktives Galagladi 4 legst, 1 Schadensmarke auf jedes Pokémon deines Gegners legen."
 			}
 		},

--- a/data/Platinum/Rising Rivals/107.ts
+++ b/data/Platinum/Rising Rivals/107.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 2 Fighting Energy attached to Hippowdon and choose 2 of your opponent's Benched Pokémon. This attack does 40 damage to each of them. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Défaussez 2 Énergies Fighting attachées à Hippodocus et choisissez 2 des Pokémon de Banc de votre adversaire. Cette attaque leur inflige 40 dégâts à chacun. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc).",
+				fr: "Défaussez 2 Énergies {F} attachées à Hippodocus et choisissez 2 des Pokémon de Banc de votre adversaire. Cette attaque leur inflige 40 dégâts à chacun. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc).",
 				de: "Lege 2 an Hippoterus angelegte {F}-Energien auf deinen Ablagestapel und wähle 2 Pokémon auf der Bank deines Gegners. Dieser Angriff fügt den gewählten Pokémon 40 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.)"
 			},
 

--- a/data/Platinum/Rising Rivals/108.ts
+++ b/data/Platinum/Rising Rivals/108.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Infernape E4 LV.X",
-		fr: "Simiabraz  Niv. X",
+		fr: "Simiabraz 4 Niv. X",
 		de: "Panferno 4"
 	},
 	illustrator: "Ryo Ueda",
@@ -30,7 +30,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may have your opponent switch his or her Active Pokémon with 1 of his or her Benched Pokémon. This power can't be used if Infernape E4 is affected by a Special Condition.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez demander à votre adversaire d'échanger son Pokémon Actif avec 1 des Pokémon de son Banc. Ce pouvoir ne peut pas être utilisé si Simiabraz  est affecté par un État Spécial.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez demander à votre adversaire d'échanger son Pokémon Actif avec 1 des Pokémon de son Banc. Ce pouvoir ne peut pas être utilisé si Simiabraz 4 est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du deinen Gegner das Verteidigende Pokémon gegen 1 Pokémon auf seiner Bank austauschen lassen. Diese Poké-Power kann nicht benutzt werden, wenn Panferno 4 von einem Speziellen Zustand betroffen ist."
 			}
 		},
@@ -49,7 +49,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 2 Energy attached to Infernape E4.",
-				fr: "Défaussez 2 Énergies attachées à Simiabraz .",
+				fr: "Défaussez 2 Énergies attachées à Simiabraz 4.",
 				de: "Lege 2 an Panferno E4 angelegte Energien auf deinen Ablagestapel."
 			},
 			damage: 100,

--- a/data/Platinum/Rising Rivals/109.ts
+++ b/data/Platinum/Rising Rivals/109.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Luxray GL LV.X",
-		fr: "Luxray  Niv. X",
+		fr: "Luxray GL Niv. X",
 		de: "Luxtra GL"
 	},
 
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), when you put Luxray GL LV.X from your hand onto your Active Luxray GL, you may switch the Defending Pokémon with 1 of your opponent's Benched Pokémon.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous placez Luxray  LV.X de votre main sur votre Luxray  Actif, vous pouvez échanger le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous placez Luxray GL LV.X de votre main sur votre Luxray GL Actif, vous pouvez échanger le Pokémon Défenseur avec 1 des Pokémon de Banc de votre adversaire.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn du Luxtra GL LV.X von deiner Hand auf dein Aktives Luxtra GL legst, das Verteidigende Pokémon gegen 1 Pokémon auf der Bank deines Gegners austauschen."
 			}
 		},

--- a/data/Platinum/Rising Rivals/11.ts
+++ b/data/Platinum/Rising Rivals/11.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Rampardos GL",
-		fr: "Charkos  Niv. 63",
+		fr: "Charkos GL Niv. 63",
 		de: "Rameidon GL"
 	},
 

--- a/data/Platinum/Rising Rivals/110.ts
+++ b/data/Platinum/Rising Rivals/110.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Mismagius GL LV.X",
-		fr: "Magirêve  Niv. X",
+		fr: "Magirêve GL Niv. X",
 		de: "Traunmagil GL"
 	},
 
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may return a Pokémon Tool or Technical Machine card attached to your Pokémon to your hand. This power can't be used if Mismagius GL is affected by a Special Condition.",
-				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez reprendre dans votre main une carte Outil Pokémon ou une carte Machine Technique attachée à votre Pokémon. Ce pouvoir ne peut pas être utilisé si Magirêve  est affecté par un État Spécial.",
+				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez reprendre dans votre main une carte Outil Pokémon ou une carte Machine Technique attachée à votre Pokémon. Ce pouvoir ne peut pas être utilisé si Magirêve GL est affecté par un État Spécial.",
 				de: "Beliebig oft während deines Zuges (vor deinem Angriff) kannst du 1 Pokémon-Ausrüstung oder Technische Maschine, die an 1 deiner Pokémon angelegt ist, auf deine Hand nehmen. Diese Poké-Power kann nicht benutzt werden, wenn Traunmagil GL von einem Speziellen Zustand betroffen ist."
 			}
 		},

--- a/data/Platinum/Rising Rivals/12.ts
+++ b/data/Platinum/Rising Rivals/12.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Roserade GL",
-		fr: "Roserade  Niv. 22",
+		fr: "Roserade GL Niv. 22",
 		de: "Roserade GL"
 	},
 

--- a/data/Platinum/Rising Rivals/15.ts
+++ b/data/Platinum/Rising Rivals/15.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may search your deck for a Grass Pokémon, show it to your opponent, and put it into your hand. Shuffle your deck afterward. This power can't be used if Beedrill is affected by a Special Condition.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez chercher dans votre deck un Pokémon Grass. Montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Dardargnan est affecté par un État Spécial.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez chercher dans votre deck un Pokémon {G}. Montrez-le à votre adversaire et placez-le dans votre main. Ensuite, mélangez votre deck. Ce pouvoir ne peut pas être utilisé si Dardargnan est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du dein Deck nach 1 {G}-Pokémon-Karte durchsuchen, sie deinem Gegner zeigen und auf die Hand nehmen. Mische dein Deck danach. Diese Poké-Power kann nicht benutzt werden, wenn Bibor von einem Speziellen Zustand betroffen ist."
 			}
 		},

--- a/data/Platinum/Rising Rivals/16.ts
+++ b/data/Platinum/Rising Rivals/16.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Bronzong E4",
-		fr: "Archéodong  Niv. 54",
+		fr: "Archéodong 4 Niv. 54",
 		de: "Bronzong 4"
 	},
 	illustrator: "Mitsuhiro Arita",

--- a/data/Platinum/Rising Rivals/17.ts
+++ b/data/Platinum/Rising Rivals/17.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Drapion E4",
-		fr: "Drascore  Niv. 53",
+		fr: "Drascore 4 Niv. 53",
 		de: "Piondragi 4"
 	},
 	illustrator: "Kouki Saitou",

--- a/data/Platinum/Rising Rivals/18.ts
+++ b/data/Platinum/Rising Rivals/18.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Espeon E4",
-		fr: "Mentali  Niv. 55",
+		fr: "Mentali 4 Niv. 55",
 		de: "Psiana 4"
 	},
 	illustrator: "Mitsuhiro Arita",

--- a/data/Platinum/Rising Rivals/2.ts
+++ b/data/Platinum/Rising Rivals/2.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Bastiodon GL",
-		fr: "Bastiodon  Niv. 41",
+		fr: "Bastiodon GL Niv. 41",
 		de: "Bollterus GL"
 	},
 
@@ -57,7 +57,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Remove 1 damage counter from Bastiodon GL.",
-				fr: "Retirez à Bastiodon  1 marqueur de dégât.",
+				fr: "Retirez à Bastiodon GL 1 marqueur de dégât.",
 				de: "Entferne 1 Schadensmarke von Bollterus GL."
 			},
 			damage: 60,

--- a/data/Platinum/Rising Rivals/20.ts
+++ b/data/Platinum/Rising Rivals/20.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Gallade E4",
-		fr: "Gallame  Niv. 59",
+		fr: "Gallame 4 Niv. 59",
 		de: "Galagladi 4"
 	},
 	illustrator: "Mitsuhiro Arita",

--- a/data/Platinum/Rising Rivals/23.ts
+++ b/data/Platinum/Rising Rivals/23.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Golem E4",
-		fr: "Grolem  Niv. 52",
+		fr: "Grolem 4 Niv. 52",
 		de: "Geowaz 4"
 	},
 	illustrator: "Kagemaru Himeno",
@@ -55,7 +55,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Golem E4 does 60 damage to itself.",
-				fr: "Grolem  s'inflige 60 dégâts.",
+				fr: "Grolem 4 s'inflige 60 dégâts.",
 				de: "Geowaz 4 fügt sich selbst 60 Schadenspunkte zu."
 			},
 			damage: 100,

--- a/data/Platinum/Rising Rivals/24.ts
+++ b/data/Platinum/Rising Rivals/24.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Heracross E4",
-		fr: "Scarhino  Niv. 51",
+		fr: "Scarhino 4 Niv. 51",
 		de: "Skaraborn 4"
 	},
 	illustrator: "Kouki Saitou",
@@ -31,7 +31,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "During your next turn, Heracross E4's Megahorn attack's base damage is 100.",
-				fr: "Lors de votre prochain tour, les dégâts de base de l'attaque Megacorne de Scarhino  sont de 100.",
+				fr: "Lors de votre prochain tour, les dégâts de base de l'attaque Megacorne de Scarhino 4 sont de 100.",
 				de: "In deinem nächsten Zug beträgt der Grundschaden des Angriffs Vielender von Skaraborn 4 100 Schadenspunkte."
 			},
 

--- a/data/Platinum/Rising Rivals/25.ts
+++ b/data/Platinum/Rising Rivals/25.ts
@@ -57,7 +57,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Energy attached to Hippowdon. Before doing damage, you may search your discard pile for a Fighting Energy card and attach it to Hippowdon.",
-				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée à Hippodocus. Avant d'infliger des dégâts, vous pouvez chercher une carte Énergie Fighting dans votre pile de défausse et l'attacher à Hippodocus.",
+				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie attachée à Hippodocus. Avant d'infliger des dégâts, vous pouvez chercher une carte Énergie {F} dans votre pile de défausse et l'attacher à Hippodocus.",
 				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an Hippoterus angelegte Energie zu. Bevor der Schaden zugefügt wird kannst du deinen Ablagestapel nach einer {F}-Energiekarte durchsuchen und sie an Hippoterus anlegen."
 			},
 			damage: "20+",

--- a/data/Platinum/Rising Rivals/27.ts
+++ b/data/Platinum/Rising Rivals/27.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Mamoswine GL is your Active Pokémon, put 1 damage counter on each Active Pokémon (excluding Water Pokémon) (both yours and your opponent's) between turns.",
-				fr: "Tant que Mammochon GL est votre Pokémon Actif, placez 1 marqueur de dégât sur chaque Pokémon Actif (Pokémon Water exclus) (les vôtres et ceux de votre adversaire) entre deux tours.",
+				fr: "Tant que Mammochon GL est votre Pokémon Actif, placez 1 marqueur de dégât sur chaque Pokémon Actif (Pokémon {W} exclus) (les vôtres et ceux de votre adversaire) entre deux tours.",
 				de: "Solange Mamutel GL dein Aktives Pokémon ist, lege zwischen den Zügen 1 Schadensmarke auf jedes Aktive Pokémon (außer {W}-Pokémon) (deine und die deines Gegners)."
 			}
 		},

--- a/data/Platinum/Rising Rivals/27.ts
+++ b/data/Platinum/Rising Rivals/27.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Mamoswine GL",
-		fr: "Mammochon  Niv. 61",
+		fr: "Mammochon GL Niv. 61",
 		de: "Mamutel GL"
 	},
 
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Mamoswine GL is your Active Pokémon, put 1 damage counter on each Active Pokémon (excluding Water Pokémon) (both yours and your opponent's) between turns.",
-				fr: "Tant que Mammochon  est votre Pokémon Actif, placez 1 marqueur de dégât sur chaque Pokémon Actif (Pokémon Water exclus) (les vôtres et ceux de votre adversaire) entre deux tours.",
+				fr: "Tant que Mammochon GL est votre Pokémon Actif, placez 1 marqueur de dégât sur chaque Pokémon Actif (Pokémon Water exclus) (les vôtres et ceux de votre adversaire) entre deux tours.",
 				de: "Solange Mamutel GL dein Aktives Pokémon ist, lege zwischen den Zügen 1 Schadensmarke auf jedes Aktive Pokémon (außer {W}-Pokémon) (deine und die deines Gegners)."
 			}
 		},

--- a/data/Platinum/Rising Rivals/28.ts
+++ b/data/Platinum/Rising Rivals/28.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Mr. Mime E4",
-		fr: "M. Mime  Niv. 53",
+		fr: "M. Mime 4 Niv. 53",
 		de: "Pantimos 4"
 	},
 	illustrator: "Mitsuhiro Arita",
@@ -48,7 +48,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "During your opponent's next turn, any damage done to Mr. Mime E4 by attacks is reduced by 10 (after applying Weakness and Resistance).",
-				fr: "Lors du prochain tour de votre adversaire, tous dégâts infligés à M. Mime  par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
+				fr: "Lors du prochain tour de votre adversaire, tous dégâts infligés à M. Mime 4 par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
 				de: "Während des nächsten Zuges deines Gegners wird Schaden, der Pantimos 4 durch Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 			damage: 30,

--- a/data/Platinum/Rising Rivals/3.ts
+++ b/data/Platinum/Rising Rivals/3.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Darkrai G",
-		fr: "Darkrai  Niv. 58",
+		fr: "Darkrai G Niv. 58",
 		de: "Darkrai G"
 	},
 

--- a/data/Platinum/Rising Rivals/31.ts
+++ b/data/Platinum/Rising Rivals/31.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Raichu GL",
-		fr: "Raichu  Niv. 46",
+		fr: "Raichu GL Niv. 46",
 		de: "Raichu GL"
 	},
 

--- a/data/Platinum/Rising Rivals/32.ts
+++ b/data/Platinum/Rising Rivals/32.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Rhyperior E4",
-		fr: "Rhinastoc  Niv. 55",
+		fr: "Rhinastoc 4 Niv. 55",
 		de: "Rihornior 4"
 	},
 	illustrator: "Kagemaru Himeno",

--- a/data/Platinum/Rising Rivals/35.ts
+++ b/data/Platinum/Rising Rivals/35.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Vespiquen E4",
-		fr: "Apireine  Niv. 50",
+		fr: "Apireine 4 Niv. 50",
 		de: "Honweisel 4"
 	},
 	illustrator: "Kouki Saitou",
@@ -30,7 +30,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "When you attach a Grass Energy card from your hand to Vespiquen E4, remove 1 damage counter from Vespiquen E4.",
-				fr: "Lorsque vous attachez une carte Énergie Grass à Apireine , retirez-lui 1 marqueur de dégât.",
+				fr: "Lorsque vous attachez une carte Énergie Grass à Apireine 4, retirez-lui 1 marqueur de dégât.",
 				de: "Wenn du 1 {G}-Energiekarte von deiner Hand an Honweisel 4 anlegst, entferne 1 Schadensmarke von Honweisel 4."
 			}
 		},
@@ -49,7 +49,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin for each Grass Energy attached to Vespiquen E4. This attack does 30 damage plus 20 more damage for each heads.",
-				fr: "Lancez une pièce pour chaque Énergie Grass attachée à Apireine . Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
+				fr: "Lancez une pièce pour chaque Énergie Grass attachée à Apireine 4. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
 				de: "Wirf 1 Münze für jede an Honweisel 4 angelegte {G}-Energie. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30+",

--- a/data/Platinum/Rising Rivals/35.ts
+++ b/data/Platinum/Rising Rivals/35.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "When you attach a Grass Energy card from your hand to Vespiquen E4, remove 1 damage counter from Vespiquen E4.",
-				fr: "Lorsque vous attachez une carte Énergie Grass à Apireine 4, retirez-lui 1 marqueur de dégât.",
+				fr: "Lorsque vous attachez une carte Énergie {G} à Apireine 4, retirez-lui 1 marqueur de dégât.",
 				de: "Wenn du 1 {G}-Energiekarte von deiner Hand an Honweisel 4 anlegst, entferne 1 Schadensmarke von Honweisel 4."
 			}
 		},
@@ -49,7 +49,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin for each Grass Energy attached to Vespiquen E4. This attack does 30 damage plus 20 more damage for each heads.",
-				fr: "Lancez une pièce pour chaque Énergie Grass attachée à Apireine 4. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
+				fr: "Lancez une pièce pour chaque Énergie {G} attachée à Apireine 4. Cette attaque inflige 30 dégâts plus 20 dégâts supplémentaires pour chaque face.",
 				de: "Wirf 1 Münze für jede an Honweisel 4 angelegte {G}-Energie. Dieser Angriff fügt 30 Schadenspunkte plus 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "30+",

--- a/data/Platinum/Rising Rivals/36.ts
+++ b/data/Platinum/Rising Rivals/36.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), when you play Walrein from your hand to evolve 1 of your Pokémon, you may attach as many Water Energy cards from your hand to Walrein as you like.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous jouez Kaimorse de votre main pour faire évoluer 1 de vos Pokémon, vous pouvez attacher autant de cartes Énergie Water de votre main sur Kaimorse que vous le voulez.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), lorsque vous jouez Kaimorse de votre main pour faire évoluer 1 de vos Pokémon, vous pouvez attacher autant de cartes Énergie {W} de votre main sur Kaimorse que vous le voulez.",
 				de: "Einmal während deines Zuges (vor deinem Angriff), wenn du Walraisa von deiner Hand spielst, um 1 deiner -Energiekarten von deiner Hand an Walraisa anlegen"
 			}
 		},

--- a/data/Platinum/Rising Rivals/37.ts
+++ b/data/Platinum/Rising Rivals/37.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Yanmega E4",
-		fr: "Yanmega  Niv. 49",
+		fr: "Yanmega 4 Niv. 49",
 		de: "Yanmega 4"
 	},
 	illustrator: "Kouki Saitou",

--- a/data/Platinum/Rising Rivals/38.ts
+++ b/data/Platinum/Rising Rivals/38.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Alakazam E4",
-		fr: "Alakazam  Niv. 56",
+		fr: "Alakazam 4 Niv. 56",
 		de: "Simsala 4"
 	},
 	illustrator: "Mitsuhiro Arita",
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Psychic Energy attached to Alakazam E4 and remove 4 damage counters from Alakazam E4.",
-				fr: "Défaussez une carte Énergie Psychic attachée à Alakazam  et retirez-lui 4 marqueurs de dégât.",
+				fr: "Défaussez une carte Énergie Psychic attachée à Alakazam 4 et retirez-lui 4 marqueurs de dégât.",
 				de: "Lege 1 an Simsala 4 angelegte {P}-Energie auf deinen Ablagestapel und entferne 4 Schadensmarken von Simsala 4."
 			},
 

--- a/data/Platinum/Rising Rivals/38.ts
+++ b/data/Platinum/Rising Rivals/38.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Psychic Energy attached to Alakazam E4 and remove 4 damage counters from Alakazam E4.",
-				fr: "Défaussez une carte Énergie Psychic attachée à Alakazam 4 et retirez-lui 4 marqueurs de dégât.",
+				fr: "Défaussez une carte Énergie {P} attachée à Alakazam 4 et retirez-lui 4 marqueurs de dégât.",
 				de: "Lege 1 an Simsala 4 angelegte {P}-Energie auf deinen Ablagestapel und entferne 4 Schadensmarken von Simsala 4."
 			},
 

--- a/data/Platinum/Rising Rivals/39.ts
+++ b/data/Platinum/Rising Rivals/39.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Electrode G",
-		fr: "Electrode  Niv. 38",
+		fr: "Electrode G Niv. 38",
 		de: "Lektrobal G"
 	},
 
@@ -36,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "This attack does 20 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Electrode G does 100 damage to itself.",
-				fr: "Cette attaque inflige 20 dégâts à chacun des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc). Electrode  s'inflige 100 dégâts.",
+				fr: "Cette attaque inflige 20 dégâts à chacun des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc). Electrode G s'inflige 100 dégâts.",
 				de: "Dieser Angriff fügt jedem Pokémon deines Gegners 20 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Lektrobal G fügt sich selbst 100 Schadenspunkte zu."
 			},
 
@@ -53,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Move an Energy card attached to Electrode G to 1 of your Benched Pokémon.",
-				fr: "Déplacez une carte Énergie attachée à Electrode  sur 1 des Pokémon de votre Banc.",
+				fr: "Déplacez une carte Énergie attachée à Electrode G sur 1 des Pokémon de votre Banc.",
 				de: "Entferne 1 an Lektrobal G angelegte Energiekarte und lege sie an 1 Pokémon auf deiner Bank an."
 			},
 			damage: 30,

--- a/data/Platinum/Rising Rivals/4.ts
+++ b/data/Platinum/Rising Rivals/4.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Floatzel GL",
-		fr: "Mustéflott  Niv. 37",
+		fr: "Mustéflott GL Niv. 37",
 		de: "Bojelin GL"
 	},
 
@@ -50,7 +50,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Floatzel GL can't use Giant Wave during your next turn.",
-				fr: "Mustéflott  ne peut pas utiliser Vague géante lors de votre prochain tour.",
+				fr: "Mustéflott GL ne peut pas utiliser Vague géante lors de votre prochain tour.",
 				de: "Bojelin GL kann Riesenwelle in deinem nächsten Zug nicht einsetzen."
 			},
 			damage: 50,

--- a/data/Platinum/Rising Rivals/40.ts
+++ b/data/Platinum/Rising Rivals/40.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Gengar GL",
-		fr: "Ectoplasma  Niv. 65",
+		fr: "Ectoplasma GL Niv. 65",
 		de: "Gengar GL"
 	},
 
@@ -54,7 +54,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Put 3 damage counters on 1 of your opponent's Pokémon. You may shuffle Gengar GL and all cards attached to it back into your deck.",
-				fr: "Placez 3 marqueurs de dégât sur 1 des Pokémon de votre adversaire. Vous pouvez mélanger Ectoplasma  ainsi que toutes les cartes qui lui sont attachées avec votre deck.",
+				fr: "Placez 3 marqueurs de dégât sur 1 des Pokémon de votre adversaire. Vous pouvez mélanger Ectoplasma GL ainsi que toutes les cartes qui lui sont attachées avec votre deck.",
 				de: "Lege 3 Schadensmarken auf 1 Pokémon deines Gegners. Du kannst Gengar GL und alle Karten, die an es angelegt sind, in dein Deck mischen."
 			},
 

--- a/data/Platinum/Rising Rivals/42.ts
+++ b/data/Platinum/Rising Rivals/42.ts
@@ -30,7 +30,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Hippowdon E4 has any Fighting Energy attached to it, any damage done to Hippowdon E4 by attacks is reduced by 10 (after applying Weakness and Resistance).",
-				fr: "Si Hippodocus 4 possède de l'Énergie Fighting, tous dégâts qui lui sont infligés par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
+				fr: "Si Hippodocus 4 possède de l'Énergie {F}, tous dégâts qui lui sont infligés par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
 				de: "Wenn an Hippoterus 4 mindestens 1 {F}-Energie angelegt ist, wird Schaden, der Hippoterus 4 durch Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			}
 		},

--- a/data/Platinum/Rising Rivals/42.ts
+++ b/data/Platinum/Rising Rivals/42.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Hippowdon E4",
-		fr: "Hippodocus  Niv. 52",
+		fr: "Hippodocus 4 Niv. 52",
 		de: "Hippoterus 4"
 	},
 	illustrator: "Kagemaru Himeno",
@@ -30,7 +30,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Hippowdon E4 has any Fighting Energy attached to it, any damage done to Hippowdon E4 by attacks is reduced by 10 (after applying Weakness and Resistance).",
-				fr: "Si  Hippodocus  possède de l'Énergie Fighting, tous dégâts qui lui sont infligés par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
+				fr: "Si Hippodocus 4 possède de l'Énergie Fighting, tous dégâts qui lui sont infligés par des attaques sont réduits de 10 (après application de la Faiblesse et de la Résistance).",
 				de: "Wenn an Hippoterus 4 mindestens 1 {F}-Energie angelegt ist, wird Schaden, der Hippoterus 4 durch Angriffe zugefügt wird, um 10 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			}
 		},

--- a/data/Platinum/Rising Rivals/43.ts
+++ b/data/Platinum/Rising Rivals/43.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Infernape E4",
-		fr: "Simiabraz  Niv. 55",
+		fr: "Simiabraz 4 Niv. 55",
 		de: "Panferno 4"
 	},
 	illustrator: "Masakazu Fukuda",

--- a/data/Platinum/Rising Rivals/44.ts
+++ b/data/Platinum/Rising Rivals/44.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin for each Metal Energy attached to Lairon. This attack does 10 damage plus 20 more damage for each heads.",
-				fr: "Lancez une pièce pour chaque Énergie Metal attachée à Galegon. Cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires pour chaque face.",
+				fr: "Lancez une pièce pour chaque Énergie {M} attachée à Galegon. Cette attaque inflige 10 dégâts plus 20 dégâts supplémentaires pour chaque face.",
 				de: "Wirf 1 Münze für jede an Stollrak angelegte {M}-Energie. Dieser Angriff fügt 10 Schadenspunkte plus 20 weitere Schadenspunkte mal der Anzahl „Kopf“ zu."
 			},
 			damage: "10+",

--- a/data/Platinum/Rising Rivals/46.ts
+++ b/data/Platinum/Rising Rivals/46.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Machamp GL",
-		fr: "Mackogneur  Niv. 64",
+		fr: "Mackogneur GL Niv. 64",
 		de: "Machomei GL"
 	},
 

--- a/data/Platinum/Rising Rivals/47.ts
+++ b/data/Platinum/Rising Rivals/47.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Rapidash E4",
-		fr: "Galopa  Niv. 53",
+		fr: "Galopa 4 Niv. 53",
 		de: "Gallopa 4"
 	},
 	illustrator: "Masakazu Fukuda",

--- a/data/Platinum/Rising Rivals/48.ts
+++ b/data/Platinum/Rising Rivals/48.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Scizor E4",
-		fr: "Cizayox  Niv. 49",
+		fr: "Cizayox 4 Niv. 49",
 		de: "Scherox 4"
 	},
 	illustrator: "Kouki Saitou",

--- a/data/Platinum/Rising Rivals/50.ts
+++ b/data/Platinum/Rising Rivals/50.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may search your discard pile for a Water Energy card, show it to your opponent, and put it into your hand. This power can't be used if Starmie is affected by a Special Condition.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez chercher dans votre pile de défausse une carte Énergie Water. Montrez-la à votre adversaire et placez-la dans votre main. Ce pouvoir ne peut pas être utilisé si Staross est affecté par un État Spécial.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez chercher dans votre pile de défausse une carte Énergie {W}. Montrez-la à votre adversaire et placez-la dans votre main. Ce pouvoir ne peut pas être utilisé si Staross est affecté par un État Spécial.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du deinen Ablagestapel nach 1 {W}-Energiekarte durchsuchen, sie deinem Gegner zeigen und auf die Hand nehmen. Diese Poké-Power kann nicht benutzt werden, wenn Starmie von einem Speziellen Zustand betroffen ist."
 			}
 		},

--- a/data/Platinum/Rising Rivals/51.ts
+++ b/data/Platinum/Rising Rivals/51.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Steelix GL",
-		fr: "Steelix  Niv. 38",
+		fr: "Steelix GL Niv. 38",
 		de: "Stahlos GL"
 	},
 
@@ -36,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your discard pile for a Metal Energy card and attach it to Steelix GL. If you do, remove 1 damage counter from Steelix GL.",
-				fr: "Choisissez dans votre pile de défausse une carte Énergie Metal et attachez-la à Steelix . Retirez alors à Steelix  1 marqueur de dégât.",
+				fr: "Choisissez dans votre pile de défausse une carte Énergie Metal et attachez-la à Steelix GL. Retirez alors à Steelix GL 1 marqueur de dégât.",
 				de: "Durchsuche deinen Ablagestapel nach 1 {M}-Energiekarte und lege sie an Stahlos GL an. Wenn du das machst, entferne 1 Schadensmarke von Stahlos GL."
 			},
 

--- a/data/Platinum/Rising Rivals/51.ts
+++ b/data/Platinum/Rising Rivals/51.ts
@@ -36,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your discard pile for a Metal Energy card and attach it to Steelix GL. If you do, remove 1 damage counter from Steelix GL.",
-				fr: "Choisissez dans votre pile de défausse une carte Énergie Metal et attachez-la à Steelix GL. Retirez alors à Steelix GL 1 marqueur de dégât.",
+				fr: "Choisissez dans votre pile de défausse une carte Énergie {M} et attachez-la à Steelix GL. Retirez alors à Steelix GL 1 marqueur de dégât.",
 				de: "Durchsuche deinen Ablagestapel nach 1 {M}-Energiekarte und lege sie an Stahlos GL an. Wenn du das machst, entferne 1 Schadensmarke von Stahlos GL."
 			},
 

--- a/data/Platinum/Rising Rivals/52.ts
+++ b/data/Platinum/Rising Rivals/52.ts
@@ -53,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Remove all damage counters from 1 of your Benched Grass Pokémon.",
-				fr: "Retirez à 1 de vos Pokémon de Banc Grass tous ses marqueurs de dégât.",
+				fr: "Retirez à 1 de vos Pokémon de Banc {G} tous ses marqueurs de dégât.",
 				de: "Entferne alle Schadensmarken von 1 {G}-Pokémon auf deiner Bank."
 			},
 

--- a/data/Platinum/Rising Rivals/54.ts
+++ b/data/Platinum/Rising Rivals/54.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Whiscash E4",
-		fr: "Barbicha  Niv. 50",
+		fr: "Barbicha 4 Niv. 50",
 		de: "Welsar 4"
 	},
 	illustrator: "Kagemaru Himeno",

--- a/data/Platinum/Rising Rivals/55.ts
+++ b/data/Platinum/Rising Rivals/55.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Aerodactyl GL",
-		fr: "Ptera  Niv. 62",
+		fr: "Ptera GL Niv. 62",
 		de: "Aerodactyl GL"
 	},
 

--- a/data/Platinum/Rising Rivals/56.ts
+++ b/data/Platinum/Rising Rivals/56.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Ambipom G",
-		fr: "Capidextre  Niv. 40",
+		fr: "Capidextre G Niv. 40",
 		de: "Ambidiffel G"
 	},
 

--- a/data/Platinum/Rising Rivals/6.ts
+++ b/data/Platinum/Rising Rivals/6.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Froslass GL",
-		fr: "Momartik  Niv. 44",
+		fr: "Momartik GL Niv. 44",
 		de: "Frosdeje GL"
 	},
 

--- a/data/Platinum/Rising Rivals/60.ts
+++ b/data/Platinum/Rising Rivals/60.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Flareon .",
-				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie Fire attachée à Pyroli 4.",
+				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie {R} attachée à Pyroli 4.",
 				de: "Wirf 1 Münze. Bei „Zahl“ entferne 1 {R}-Energie, die an Flamara 4 angelegt ist, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 40,

--- a/data/Platinum/Rising Rivals/60.ts
+++ b/data/Platinum/Rising Rivals/60.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Flareon E4",
-		fr: "Pyroli  Niv. 55",
+		fr: "Pyroli 4 Niv. 55",
 		de: "Flamara 4"
 	},
 	illustrator: "Masakazu Fukuda",
@@ -47,7 +47,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If tails, discard a Fire Energy attached to Flareon .",
-				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie Fire attachée à Pyroli .",
+				fr: "Lancez une pièce. Si c'est pile, défaussez une Énergie Fire attachée à Pyroli 4.",
 				de: "Wirf 1 Münze. Bei „Zahl“ entferne 1 {R}-Energie, die an Flamara 4 angelegt ist, und lege sie auf deinen Ablagestapel."
 			},
 			damage: 40,

--- a/data/Platinum/Rising Rivals/61.ts
+++ b/data/Platinum/Rising Rivals/61.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Forretress G",
-		fr: "Forretress  Niv. 35",
+		fr: "Forretress G Niv. 35",
 		de: "Forstellka G"
 	},
 
@@ -36,7 +36,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "This attack does 10 damage to each of your opponent's Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.) Forretress G can't use Shell Scatter during your next turn.",
-				fr: "Cette attaque inflige 10 dégâts à chacun des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc). Forretress  ne peut pas utiliser Écras'coquille lors de votre prochain tour.",
+				fr: "Cette attaque inflige 10 dégâts à chacun des Pokémon de votre adversaire. (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc). Forretress G ne peut pas utiliser Écras'coquille lors de votre prochain tour.",
 				de: "Dieser Angriff fügt jedem Pokémon deines Gegners 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Forstellka G kann Streugranate in deinem nächsten Zug nicht einsetzen."
 			},
 
@@ -54,7 +54,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 10 damage to each Benched Pokémon (both yours and your opponent's). (Don't apply Weakness and Resistance for Benched Pokémon.) Flip a coin. If tails, Forretress G does 80 damage to itself.",
-				fr: "Inflige 10 dégâts à chaque Pokémon de Banc (les vôtres et ceux de votre adversaire). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc). Lancez une pièce. Si c'est pile, Forretress  s'inflige 80 dégâts.",
+				fr: "Inflige 10 dégâts à chaque Pokémon de Banc (les vôtres et ceux de votre adversaire). (Vous ne pouvez pas appliquer la Faiblesse et la Résistance aux Pokémon de Banc). Lancez une pièce. Si c'est pile, Forretress G s'inflige 80 dégâts.",
 				de: "Dieser Angriff fügt jedem Pokémon auf der Bank (deinen und denen deines Gegners) 10 Schadenspunkte zu. (Wende Schwäche und Resistenz bei Pokémon auf der Bank nicht an.) Wirf 1 Münze. Bei „Zahl“ fügt Forstellka G sich selbst 80 Schadenspunkte zu."
 			},
 			damage: 80,

--- a/data/Platinum/Rising Rivals/62.ts
+++ b/data/Platinum/Rising Rivals/62.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Gliscor E4",
-		fr: "Scorvol  Niv. 53",
+		fr: "Scorvol 4 Niv. 53",
 		de: "Skorgo 4"
 	},
 	illustrator: "Kagemaru Himeno",

--- a/data/Platinum/Rising Rivals/63.ts
+++ b/data/Platinum/Rising Rivals/63.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for a Fire Energy card and attach it to Growlithe. Shuffle your deck afterward.",
-				fr: "Cherchez dans votre deck une carte Énergie Fire et attachez-la à Caninos. Ensuite, mélangez votre deck.",
+				fr: "Cherchez dans votre deck une carte Énergie {R} et attachez-la à Caninos. Ensuite, mélangez votre deck.",
 				de: "Durchsuche dein Deck nach 1 {R}-Energiekarte und lege sie an Fukano an. Mische dein Deck danach."
 			},
 

--- a/data/Platinum/Rising Rivals/65.ts
+++ b/data/Platinum/Rising Rivals/65.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Houndoom E4",
-		fr: "Demolosse  Niv. 52",
+		fr: "Demolosse 4 Niv. 52",
 		de: "Hundemon 4"
 	},
 	illustrator: "Masakazu Fukuda",
@@ -34,7 +34,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "The Defending Pokémon can't retreat during your opponent's next turn.",
-				fr: "Le  Pokémon Défenseur ne peut pas battre en retraite lors du prochain tour de votre adversaire.",
+				fr: "Le Pokémon Défenseur ne peut pas battre en retraite lors du prochain tour de votre adversaire.",
 				de: "Das Verteidigende Pokémon kann sich im nächsten Zug deines Gegners nicht zurückziehen."
 			},
 			damage: 20,

--- a/data/Platinum/Rising Rivals/67.ts
+++ b/data/Platinum/Rising Rivals/67.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Kecleon's type is Grass Fire Water Lightning Psychic Fighting Darkness Metal Colorless.",
-				fr: "Kecleon est de type GrassFireWaterLightningPsychicFightingDarknessMetalColorless.",
+				fr: "Kecleon est de type {G}{R}{W}{L}{P}{F}{D}{M}{C}.",
 				de: "Kecleons Typ ist {G}{R}{W}{L}{P}{F}{D}{M}{C}."
 			}
 		},

--- a/data/Platinum/Rising Rivals/76.ts
+++ b/data/Platinum/Rising Rivals/76.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Quagsire GL",
-		fr: "Maraiste  Niv. 34",
+		fr: "Maraiste GL Niv. 34",
 		de: "Morlord GL"
 	},
 
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Quagsire GL is on your Bench, prevent all damage done to Quagsire GL by attacks (both yours and your opponent's).",
-				fr: "Tant que Maraiste  est sur votre Banc, prévenez tous les dégâts qui lui sont infligés par des attaques (de vos Pokémon et des Pokémon de votre adversaire).",
+				fr: "Tant que Maraiste GL est sur votre Banc, prévenez tous les dégâts qui lui sont infligés par des attaques (de vos Pokémon et des Pokémon de votre adversaire).",
 				de: "Solange Morlord GL auf deiner Bank ist, verhindere allen Schaden, der Morlord GL durch Angriffe (deine und die deines Gegners) zugefügt würde."
 			}
 		},
@@ -53,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may switch Quagsire GL with 1 of your Benched Pokémon.",
-				fr: "Vous pouvez échanger Maraiste  avec 1 des Pokémon de votre Banc.",
+				fr: "Vous pouvez échanger Maraiste GL avec 1 des Pokémon de votre Banc.",
 				de: "Du kannst Morlord GL gegen 1 Pokémon auf deiner Bank austauschen."
 			},
 			damage: 40,

--- a/data/Platinum/Rising Rivals/77.ts
+++ b/data/Platinum/Rising Rivals/77.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for up to 2 Water Energy cards, show them to your opponent, and put them into your hand. Shuffle your deck afterward.",
-				fr: "Cherchez dans votre deck 2 cartes Énergie Water, montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck.",
+				fr: "Cherchez dans votre deck 2 cartes Énergie {W}, montrez-les à votre adversaire et placez-les dans votre main. Ensuite, mélangez votre deck.",
 				de: "Durchsuche dein Deck nach bis zu 2 {W}-Energiekarten, zeige sie deinem Gegner und nimm sie auf die Hand. Mische dein Deck danach."
 			},
 

--- a/data/Platinum/Rising Rivals/8.ts
+++ b/data/Platinum/Rising Rivals/8.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Lucario GL",
-		fr: "Lucario  Niv. 32",
+		fr: "Lucario GL Niv. 32",
 		de: "Lucario GL"
 	},
 

--- a/data/Platinum/Rising Rivals/84.ts
+++ b/data/Platinum/Rising Rivals/84.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), if Trapinch is your Active Pokémon, you may search your discard pile for a basic Fighting card and attach it to Trapinch.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), si Kraknoix est votre Pokémon Actif, vous pouvez chercher dans votre pile de défausse une carte Énergie Fighting et l'attacher à Kraknoix.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), si Kraknoix est votre Pokémon Actif, vous pouvez chercher dans votre pile de défausse une carte Énergie {F} et l'attacher à Kraknoix.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du, wenn Knacklion dein Aktives Pokémon ist, deinen Ablagestapel nach 1 {F}-Basis-Energiekarte durchsuchen und sie an Knacklion anlegen."
 			}
 		},

--- a/data/Platinum/Rising Rivals/85.ts
+++ b/data/Platinum/Rising Rivals/85.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Turtwig GL",
-		fr: "Tortipouss  Niv. 20",
+		fr: "Tortipouss GL Niv. 20",
 		de: "Chelast GL"
 	},
 
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Turtwig GL's remaining HP is 60 or less, each of Turtwig GL's attacks does 30 more damage to the Defending Pokémon (before applying Weakness and Resistance).",
-				fr: "Tant qu'il ne reste à Tortipouss  qu'un maximum de 60 PV, chacune de ses attaques inflige 30 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
+				fr: "Tant qu'il ne reste à Tortipouss GL qu'un maximum de 60 PV, chacune de ses attaques inflige 30 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance).",
 				de: "Solange Chelast GL 60 oder weniger verbliebene KP hat, fügen alle Angriffe von Chelast GL den Aktiven Pokémon 30 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden)."
 			}
 		},
@@ -53,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "After your attack, remove from Turtwig GL the number of damage counters equal to the damage you did to the Defending Pokémon.",
-				fr: "Après votre attaque, retirez à Tortipouss  autant de marqueurs de dégât que vous avez infligé de dégâts au Pokémon Défenseur.",
+				fr: "Après votre attaque, retirez à Tortipouss GL autant de marqueurs de dégât que vous avez infligé de dégâts au Pokémon Défenseur.",
 				de: "Entferne nach deinem Angriff Schadensmarken von Chelast GL entsprechend der Höhe der Schadenspunkte, die dem Verteidigenden Pokémon durch diesen Angriff zugefügt wurden."
 			},
 			damage: 30,

--- a/data/Platinum/Rising Rivals/9.ts
+++ b/data/Platinum/Rising Rivals/9.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Luxray GL",
-		fr: "Luxray  Niv. 48",
+		fr: "Luxray GL Niv. 48",
 		de: "Luxtra GL"
 	},
 

--- a/data/Platinum/Rising Rivals/95.ts
+++ b/data/Platinum/Rising Rivals/95.ts
@@ -4,7 +4,7 @@ import Set from '../Rising Rivals'
 const card: Card = {
 	name: {
 		en: "Team Galactic's Invention G-107 Technical Machine G",
-		fr: "Machine Technique  Invention G-107 de Team Galaxie",
+		fr: "Machine Technique G Invention G-107 de Team Galaxie",
 		de: "Team Galaktiks Erfindung G-107 Technische Maschine"
 	},
 

--- a/data/Platinum/Rising Rivals/99.ts
+++ b/data/Platinum/Rising Rivals/99.ts
@@ -15,7 +15,7 @@ const card: Card = {
 
 	effect: {
 		en: "If the Pokémon Darkness Energy is attached to attacks, the attack does 10 more damage to the Active Pokémon (before applying Weakness and Resistance). Ignore this effect if the Pokémon that Darkness Energy is attached to isn't Darkness. Darkness Energy provides Darkness Energy. (Doesn't count as a basic Energy card.)",
-		fr: "Si le Pokémon auquel Énergie Obscurité est attachée attaque, cette attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance). Ignorez cet effet si le Pokémon auquel Énergie Obscurité est attachée n'est pas Darkness. Énergie Obscurité fournit de l'Énergie Darkness. (Elle ne compte pas comme carte Énergie de base).",
+		fr: "Si le Pokémon auquel Énergie Obscurité est attachée attaque, cette attaque inflige 10 dégâts supplémentaires au Pokémon Actif (avant application de la Faiblesse et de la Résistance). Ignorez cet effet si le Pokémon auquel Énergie Obscurité est attachée n'est pas {D}. Énergie Obscurité fournit de l'Énergie {D}. (Elle ne compte pas comme carte Énergie de base).",
 		de: "Falls das Pokémon, an das Finsternis-Energie angelegt ist, angreift, fügt der Angriff den Aktiven Pokémon 10 weitere Schadenspunkte zu (bevor Schwäche und Resistenz verrechnet werden). Dieser Effekt wirkt nur, wenn die Finsternis-Energie an einem Pokémon vom Typ {D} angelegt ist. Finsternis-Energie liefert {D}-Energie. (Zählt nicht als Basis-Energiekarte.)"
 	},
 

--- a/data/Platinum/Rising Rivals/RT1.ts
+++ b/data/Platinum/Rising Rivals/RT1.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may use this power. Fan Rotom's type is Colorless until the end of your turn.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Motisma Hélice est de type Colorless jusqu'à la fin de votre tour.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Motisma Hélice est de type {C} jusqu'à la fin de votre tour.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power benutzen. Wirbel-Rotoms Typ ist {C} bis zum Ende des Zuges."
 			}
 		},

--- a/data/Platinum/Rising Rivals/RT2.ts
+++ b/data/Platinum/Rising Rivals/RT2.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may use this power. Frost Rotom's type is Water until the end of your turn.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Motisma Froid est de type Water jusqu'à la fin de votre tour.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Motisma Froid est de type {W} jusqu'à la fin de votre tour.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power benutzen. Frost-Rotoms Typ ist {W} bis zum Ende des Zuges."
 			}
 		},
@@ -70,7 +70,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each Colorless Energy in the Defending Pokémon's Retreat Cost (after applying effects to the Retreat Cost).",
-				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie Colorless dans le Coût de retraite du Pokémon Défenseur (après application des effets sur le Coût de retraite).",
+				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {C} dans le Coût de retraite du Pokémon Défenseur (après application des effets sur le Coût de retraite).",
 				de: "Dieser Angriff fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede {C}-Energie in den Rückzugskosten des Verteidigenden Pokémon zu (nachdem Effekte auf die Rückzugskosten verrechnet wurden)."
 			},
 			damage: "40+",

--- a/data/Platinum/Rising Rivals/RT3.ts
+++ b/data/Platinum/Rising Rivals/RT3.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may use this power. Heat Rotom's type is Fire until the end of your turn.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Motisma Chaleur est de type Fire jusqu'à la fin de votre tour.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Motisma Chaleur est de type {R} jusqu'à la fin de votre tour.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power benutzen. HItze-Rotoms Typ ist {R} bis zum Ende des Zuges."
 			}
 		},
@@ -51,7 +51,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for a Fire Energy card and attach it to 1 of your Benched Pokémon. Shuffle your deck afterward.",
-				fr: "Cherchez dans votre deck une carte Énergie Fire et attachez-la à 1 des Pokémon de votre Banc. Ensuite, mélangez votre deck.",
+				fr: "Cherchez dans votre deck une carte Énergie {R} et attachez-la à 1 des Pokémon de votre Banc. Ensuite, mélangez votre deck.",
 				de: "Durchsuche dein Deck nach 1 {R}-Energiekarte und lege sie an 1 Pokémon auf deiner Bank an. Mische dein Deck danach."
 			},
 

--- a/data/Platinum/Rising Rivals/RT4.ts
+++ b/data/Platinum/Rising Rivals/RT4.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may use this power. Mow Rotom's type is Grass until the end of your turn.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Motisma Tonte est de type Grass jusqu'à la fin de votre tour.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Motisma Tonte est de type {G} jusqu'à la fin de votre tour.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power benutzen. Schneid-Rotoms Typ ist {G} bis zum Ende des Zuges."
 			}
 		},

--- a/data/Platinum/Rising Rivals/RT5.ts
+++ b/data/Platinum/Rising Rivals/RT5.ts
@@ -33,7 +33,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Once during your turn (before your attack), you may use this power. Wash Rotom's type is Water until the end of your turn.",
-				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Motisma Lavage est de type Water jusqu'à la fin de votre tour.",
+				fr: "Une seule fois lors de votre tour (avant votre attaque), vous pouvez utiliser ce pouvoir. Motisma Lavage est de type {W} jusqu'à la fin de votre tour.",
 				de: "Einmal während deines Zuges (vor deinem Angriff) kannst du diese Poké-Power benutzen. Wasch-Rotoms Typ ist {W} bis zum Ende des Zuges."
 			}
 		},


### PR DESCRIPTION
Two defects in the French text of Rising Rivals (`pl2`), as **two separate commits** so they can be reviewed one after the other. They are in one PR because eight strings carry both at once, on the same line.

## Commit 1 — the SP suffixes

`pl2` is a Platinum SP set: every Pokémon carries a suffix glyph between its name and its level. The French lost all of them, in the card names and in every rules string that names the Pokémon.

```
en: "Roserade GL"
fr: "Roserade  Niv. 22"
de: "Roserade GL"
```

**79 suffixes** across **46 cards** — 36 `4`, 33 `GL`, 10 `G`.

The suffix comes from the English name, **but not verbatim**: the English writes `E4` where French and German write `4`. Copying the English would have put `Simiabraz E4` on 22 of the 46 cards. Three sources agree on `4`:

- the French scans on Poképédia, showing a boxed `4` glyph and titling the cards [`Simiabraz 4`](https://www.pokepedia.fr/Simiabraz_4_(Platine_Rivaux_Émergeants_43)) and [`Roserade GL`](https://www.pokepedia.fr/Roserade_GL_(Platine_Rivaux_Émergeants_12));
- the sibling set `pl3` Vainqueurs Suprêmes, whose French names kept their suffixes — `Noctunoir FB`, `Colhomard G`, `Spiritomb C`;
- the German, which writes `Geowaz 4`, `Psiana 4`, `Simsala 4`.

`95` Machine Technique is the one card where the French word order moves the suffix off the end of the name. The [scan](https://www.pokepedia.fr/Machine_Technique_G_Invention_G-107_de_Team_Galaxie_(Platine_Rivaux_Émergeants_95)) shows `Machine Technique G INVENTION G-107 DE TEAM GALAXIE`, which is where the hole is.

Two strings had the same whitespace signature with nothing missing — `Si  Hippodocus 4` on `42` and `Le  Pokémon Défenseur` on `65` — and are simply collapsed.

## Commit 2 — the English type names

Where the French should carry an energy symbol, it carries the English type word.

```
en: "Discard a Fire Energy attached to Arcanine. ..."
fr: "Défaussez une Énergie Fire attachée à Arcanin. ..."
de: "Lege 1 {R}-Energie, die an Arkani angelegt ist, auf deinen Ablagestapel. ..."
```

**44 symbols** replacing **35 English type words** across **28 cards**. No English type word remains in any French string in the set.

The German carries the `{X}` token in the same position in **34 of the 35** cases, which is what makes this a transcription slip rather than a wording choice. The exception is `36` Kaimorse, whose German lost its token too and rests on the English `Water Energy cards`.

Two strings are not a single type. `67` Kecleon lists all nine at once, against the German `{G}{R}{W}{L}{P}{F}{D}{M}{C}`. `102` Énergie Sup carries a concatenated pair, `ColorlessColorless`, against the German `{C}{C}` — a word-boundary search misses that one.

`99` Énergie Obscurité and `100` Énergie Métal show the shape of the bug: their card *names* are already correctly translated, and only the type references inside the rules text stayed English.

## Both

Only `fr` values change — 99 lines in, 99 lines out across 67 files. Eight of those lines are touched by both commits, which is why this is one PR: the two changes cannot be merged from separate bases without conflicting.

`npm run validate` passes. No English or German string was modified.
