### PR TITLE
fix(data): Restore the energy symbols lost from Base Set French text

### DIFF
--- a/data/Base/Base Set/10.ts
+++ b/data/Base/Base Set/10.ts
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card attached to Mewtwo in order to use this attack. During your opponent's next turn, prevent all effects of attacks, including damage, done to Mewtwo.",
-				fr: "Défaussez 1 carte Énergie  attachée à Mewtwo pour pouvoir utiliser cette attaque. Pendant le prochain tour de votre adversaire, prévenez tous les effets ou attaques, y compris les dégâts, infligés à Mewtwo.",
+				fr: "Défaussez 1 carte Énergie {P} attachée à Mewtwo pour pouvoir utiliser cette attaque. Pendant le prochain tour de votre adversaire, prévenez tous les effets ou attaques, y compris les dégâts, infligés à Mewtwo.",
 				de: "Entferne eine auf Mewtu abgelegte {P} Energiekarte, um diesen Angriff auszuführen. Verhindere während des nächsten gegnerischen Zugs alle Auswirkungen von Angriffen auf Mewtu (einschließlich der Schadenspunkte).",
 				it: "Scarta una carta Energia Psico assegnata a Mewtwo per poter usare questo attacco. Durante il prossimo turno del tuo avversario, previeni tutti gli effetti degli attacchi inflitti a Mewtwo, compresi i danni."
 			},

--- a/data/Base/Base Set/12.ts
+++ b/data/Base/Base Set/12.ts
@@ -68,7 +68,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card attached to Ninetales in order to use this attack.",
-				fr: "Défaussez 1 carte Énergie  attachée à Feunard pour pouvoir utiliser cette attaque.",
+				fr: "Défaussez 1 carte Énergie {R} attachée à Feunard pour pouvoir utiliser cette attaque.",
 				de: "Entferne eine auf Vulnona abgelegte {R} Energiekarte, um diesen Angriff auszuführen.",
 				it: "Scarta una carta Energia Fuoco assegnata a Ninetales per poter usare questo attacco."
 			},

--- a/data/Base/Base Set/13.ts
+++ b/data/Base/Base Set/13.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 30 damage plus 10 more damage for each Water Energy attached to Poliwrath but not used to pay for this attack's Energy cost. Extra Water Energy after the 2nd doesn't count.",
-				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Tartard en plus du coût en Énergie de cette attaque. Les Énergies  supplémentaires après la seconde ne comptent pas.",
+				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {W} attachée à Tartard en plus du coût en Énergie de cette attaque. Les Énergies {W} supplémentaires après la seconde ne comptent pas.",
 				de: "Fügt 30 Schadenspunkte plus 10 weitere Schadenspunkte für jede auf Quappo abgelegte {W} Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Du kannst nicht mehr als 20 Schadenspunkte auf diese Weise hinzufügen.",
 				it: "Infligge 30 danni più altri 10 danni per ogni carta Energia Acqua assegnata a Poliwrath che non viene usata per pagare il costo di Energia di questo attacco. Altre carte Energia Acqua dopo la 2ª non contano."
 			},

--- a/data/Base/Base Set/15.ts
+++ b/data/Base/Base Set/15.ts
@@ -44,7 +44,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may take 1 Grass Energy card attached to 1 of your Pokémon and attach it to a different one. This power can't be used if Venusaur is Asleep, Confused, or Paralyzed.",
-				fr: "Aussi souvent que vous le souhaitez pendant votre tour (avant votre attaque), vous pouvez prendre 1 carte Énergie  attachée à 1 de vos Pokémon et l'attacher à un autre. Ce pouvoir ne peut être utilisé si Florizarre est Endormi, Confus ou Paralysé.",
+				fr: "Aussi souvent que vous le souhaitez pendant votre tour (avant votre attaque), vous pouvez prendre 1 carte Énergie {G} attachée à 1 de vos Pokémon et l'attacher à un autre. Ce pouvoir ne peut être utilisé si Florizarre est Endormi, Confus ou Paralysé.",
 				de: "Bist Du am Zug kannst Du (vor Deinem Angriff) beliebig oft eine auf einem Deiner Pokémon abgelegte {G} Energiekarte nehmen und auf ein anderes legen. Diese Fähigkeit kann nicht eingesetzt werden, falls Bisaflor schlafend, verwirrt oder gelähmt ist.",
 				it: "Quante volte vuoi durante il tuo turno (prima di attaccare), puoi prendere una carta Energia Erba assegnata a uno dei tuoi Pokémon ed assegnarla a un altro. Questo potere non può essere usato se Venusaur è Addormentato, Confuso o Paralizzato.",
 			},

--- a/data/Base/Base Set/2.ts
+++ b/data/Base/Base Set/2.ts
@@ -44,7 +44,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may attach 1 Water Energy Card to 1 of your Water Pokémon. (This doesn't use up your 1 Energy card attachment for the turn.) This power can't be used if Blastoise is Asleep, Confused, or Paralyzed.",
-				fr: "Aussi souvent que vous le souhaitez pendant votre tour (avant votre attaque), vous pouvez attacher 1 carte Énergie  à 1 de vos Pokémon  (En plus de la carte Énergie que vous pouvez attacher normalement.) Ce pouvoir ne peut être utilisé si Tortank est Endormi, Confus ou Paralysé.",
+				fr: "Aussi souvent que vous le souhaitez pendant votre tour (avant votre attaque), vous pouvez attacher 1 carte Énergie {W} à 1 de vos Pokémon {W} (En plus de la carte Énergie que vous pouvez attacher normalement.) Ce pouvoir ne peut être utilisé si Tortank est Endormi, Confus ou Paralysé.",
 				de: "Bist Du am Zug, kannst Du (vor Deinem Angriff) beliebig oft eine {W} Energiekarte auf eines Deiner Pokémon ablegen. (Damit ist die Ablegemöglichkeit von einer {W} Energiekarte pro Zug nicht aufgebraucht.) Diese Fähigkeit kann nicht eingesetzt werden, falls Turtok schlafend, verwirrt oder gelähmt ist.",
 				it: "Quante volte vuoi durante il tuo turno (prima di attaccare), puoi assegnare una carta Energia Acqua a uno dei tuoi Pokémon Acqua. (Questo non esaurisce la tua assegnazione di una carta Energia per turno.) Questo potere non può essere usato se Blastoise è Addormentato, Confuso o Paralizzato."
 			},
@@ -66,7 +66,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 40 damage plus 10 more damage for each attached Water Energy attached to Blastoise but not used to pay for this attack's Energy cost. Extra Water Energy after the 2nd doesn't count.",
-				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Tortank en plus du coût en Énergie de cette attaque. Les Énergies  supplémentaires après la seconde ne comptent pas.",
+				fr: "Inflige 40 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {W} attachée à Tortank en plus du coût en Énergie de cette attaque. Les Énergies {W} supplémentaires après la seconde ne comptent pas.",
 				de: "Fügt 40 Schadenspunkte plus 10 weitere Schadenspunkte für jede auf Turtok abgelegte {W} Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Du kannst nicht mehr als 20 Schadenspunkte auf diese Weise hinzufügen.",
 				it: "Infligge 40 danni più altri 10 danni per ogni carta Energia Acqua assegnata a Blastoise che non viene utilizzata per pagare il costo di Energia di questo attacco. Altre carte Energia Acqua dopo la 2ª non contano."
 			},

--- a/data/Base/Base Set/23.ts
+++ b/data/Base/Base Set/23.ts
@@ -48,7 +48,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card attached to Arcanine in order to use this attack.",
-				fr: "Défaussez 1 carte Énergie  attachée à Arcanin pour pouvoir utiliser cette attaque.",
+				fr: "Défaussez 1 carte Énergie {R} attachée à Arcanin pour pouvoir utiliser cette attaque.",
 				de: "Entferne eine auf Arkani abgelegte {R} Energiekarte, um diesen Angriff auszuführen.",
 				it: "Scarta una carta Energia Fuoco assegnata ad Arcanine per poter usare questo attacco."
 			},

--- a/data/Base/Base Set/24.ts
+++ b/data/Base/Base Set/24.ts
@@ -64,7 +64,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card attached to Charmeleon in order to use this attack.",
-				fr: "Défaussez 1 carte Énergie  attachée à Reptincel pour pouvoir utiliser cette attaque.",
+				fr: "Défaussez 1 carte Énergie {R} attachée à Reptincel pour pouvoir utiliser cette attaque.",
 				de: "Entferne eine auf Glutexo abgelegte {R} Energiekarte, um diesen Angriff auszuführen.",
 				it: "Scarta una carta Energia Fuoco assegnata a Charmeleon per poter usare questo attacco."
 			},

--- a/data/Base/Base Set/32.ts
+++ b/data/Base/Base Set/32.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card attached to Kadabra in order use this attack. Remove all damage counters from Kadabra.",
-				fr: "Défaussez 1 carte Énergie  attachée à Kadabra pour pouvoir utiliser cette attaque. Retirez tous les marqueurs de dégâts sur Kadabra.",
+				fr: "Défaussez 1 carte Énergie {P} attachée à Kadabra pour pouvoir utiliser cette attaque. Retirez tous les marqueurs de dégâts sur Kadabra.",
 				de: "Entferne eine auf Kadabra abgelegte {P} Energiekarte, um diesen Angriff auszuführen. Entferne alle Schadensmarken von Kadabra.",
 				it: "Scarta una carta Energia Psico assegnata a Kadabra per poter usare questo attacco. Togli tutti i segnalini danno da Kadabra.",
 			},

--- a/data/Base/Base Set/36.ts
+++ b/data/Base/Base Set/36.ts
@@ -56,7 +56,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card attached to Magmar in order to use this attack.",
-				fr: "Défaussez 1 carte Énergie  attachée à Magmar pour pouvoir utiliser cette attaque.",
+				fr: "Défaussez 1 carte Énergie {R} attachée à Magmar pour pouvoir utiliser cette attaque.",
 				de: "Entferne eine auf Magmar abgelegte {R} Energiekarte, um diesen Angriff auszuführen.",
 				it: "Scarta una carta Energia Fuoco assegnata a Magmar per poter usare questo attacco."
 			},

--- a/data/Base/Base Set/4.ts
+++ b/data/Base/Base Set/4.ts
@@ -44,7 +44,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may turn all Energy attached to Charizard into Fire Energy for the rest of the turn. This power can't be used if Charizard is Asleep, Confused, or Paralyzed.",
-				fr: "Aussi souvent que vous le souhaitez pendant votre tour (avant votre attaque), vous pouvez transformer toutes les Énergies attachées à Dracaufeu en Énergie  jusqu'à la fin du tour. Ce pouvoir ne peut être utilisé si Dracaufeu est Endormi, Confus ou Paralysé.",
+				fr: "Aussi souvent que vous le souhaitez pendant votre tour (avant votre attaque), vous pouvez transformer toutes les Énergies attachées à Dracaufeu en Énergie {R} jusqu'à la fin du tour. Ce pouvoir ne peut être utilisé si Dracaufeu est Endormi, Confus ou Paralysé.",
 				de: "Bist Du am Zug, kannst Du (vor Deinem Angriff) beliebig oft alle auf Glurak abgelegte Energie in {R} Energie für den Rest des Zugs verwandeln. Diese Fähigkeit kann nicht eingesetzt werden, falls Glurak schlafend, verwirrt oder gelähmt ist.",
 				it: "Quante volte vuoi durante il tuo turno (prima di attaccare), puoi trasformare tutte le carte Energia assegnate a Charizard in carte Energia Fuoco per il resto del turno. Questo potere non può essere usato se Charizard è Addormentato, Confuso o Paralizzato."
 			},

--- a/data/Base/Base Set/46.ts
+++ b/data/Base/Base Set/46.ts
@@ -54,7 +54,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card attached to Charmander in order to use this attack.",
-				fr: "Défaussez 1 carte Énergie  attachée à Salamèche pour pouvoir utiliser cette attaque.",
+				fr: "Défaussez 1 carte Énergie {R} attachée à Salamèche pour pouvoir utiliser cette attaque.",
 				de: "Entferne eine auf Glumanda abgelegte {R} Energiekarte, um diesen Angriff auszuführen.",
 				it: "Scarta una carta Energia Fuoco assegnata a Charmander per poter usare questo attacco.",
 			},

--- a/data/Base/Base Set/50.ts
+++ b/data/Base/Base Set/50.ts
@@ -58,7 +58,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card attached to Gastly in order to use this attack. If a Pokémon Knocks Out Gastly during your opponent's next turn, Knock Out that Pokémon.",
-				fr: "Défaussez 1 carte Énergie  attachée à Fantominus pour pouvoir utiliser cette attaque. Si un Pokémon met Fantominus K.O. pendant le prochain tour de votre adversaire, mettez ce Pokémon K.O.",
+				fr: "Défaussez 1 carte Énergie {P} attachée à Fantominus pour pouvoir utiliser cette attaque. Si un Pokémon met Fantominus K.O. pendant le prochain tour de votre adversaire, mettez ce Pokémon K.O.",
 				de: "Entferne eine auf Nebulak abgelegte {P} Energiekarte, um diesen Angriff auszuführen. Falls ein Pokémon Nebulak während des nächsten gegnerischen Zugs kampfunfähig macht, mache dieses Pokémon kampfunfähig.",
 				it: "Scarta una carta Energia Psico assegnata a Gastly per usare questo attacco. Se un Pokémon mette K.O. Gastly durante il prossimo turno del tuo avversario, anche quel Pokémon verrà messo K.O."
 			},

--- a/data/Base/Base Set/59.ts
+++ b/data/Base/Base Set/59.ts
@@ -39,7 +39,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 10 damage plus 10 damage for each Energy attached to Poliwag but not used to pay for this attack's Energy cost. Extra Energy after the end don't count.",
-				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Ptitard en plus du coût en Énergie de cette attaque. Les Énergies  supplémentaires après la seconde ne comptent pas.",
+				fr: "Inflige 30 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {W} attachée à Ptitard en plus du coût en Énergie de cette attaque. Les Énergies {W} supplémentaires après la seconde ne comptent pas.",
 				de: "Fügt 10 Schadenspunkte plus 10 weitere Schadenspunkte für jede auf Quapsel abgelegte {W} Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Du kannst nicht mehr als 20 Schadenspunkte auf diese Weise hinzufügen.",
 				it: "Infligge 10 danni più altri 10 danni per ogni Energia Acqua assegnata a Poliwag che non viene usata per pagare il costo di Energia di questo attacco. Altre carte Energia Acqua dopo la 2ª non contano."
 			},

--- a/data/Base/Base Set/64.ts
+++ b/data/Base/Base Set/64.ts
@@ -47,7 +47,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 1 Energy card to Starmie in order to use this attack. Remove all damage counters from Starmie.",
-				fr: "Défaussez 1 carte Énergie  attachée à Staross pour pouvoir utiliser cette attaque. Retirez tous les marqueurs de dégâts sur Staross.",
+				fr: "Défaussez 1 carte Énergie {W} attachée à Staross pour pouvoir utiliser cette attaque. Retirez tous les marqueurs de dégâts sur Staross.",
 				de: "Entferne eine auf Starmie abgelegte {W} Energiekarte, um diesen Angriff auszuführen. Entferne alle Schadensmarken von Starmie.",
 				it: "Scarta una carta Energia Acqua assegnata a Starmie per poter usare questo attacco. Togli tutti i segnalini danno da Starmie.",
 			},

--- a/data/Base/Base Set/96.ts
+++ b/data/Base/Base Set/96.ts
@@ -19,7 +19,7 @@ const card: Card = {
 		en: "Provides {C}{C} energy.\nDoesn't count as a basic Energy card.",
 		de: "Liefert {C}{C} Energie. Zählt nicht als Basis-Energiekarte.",
 		it: "Fornisce energia Incolore Incolore. Non conta come carta Energia base.",
-		fr: "Fournit Incolore Incolore énergies. Ne compte pas comme une carte Énergie de base.",
+		fr: "Fournit {C}{C} énergies. Ne compte pas comme une carte Énergie de base.",
 	},
 
 	variants: [


### PR DESCRIPTION
## Changes

The inline `{X}` energy symbols were dropped from 16 French strings across 15 Base Set
cards, leaving a double space where the symbol used to be — the same defect already fixed
for Aquapolis (#2273), Neo Destiny (#2274), Expedition (#2275), Power Keepers (#2276),
XY promos (#2277), EX Dragon (#2278), EX Deoxys (#2279), EX Sandstorm (#2281), Neo Genesis
(#2282), SWSH promos (#2283), EX Legend Maker (#2308), EX Unseen Forces (#2309), EX Delta
Species (#2310), EX Ruby & Sapphire (#2311), EX Hidden Legends (#2312) and Rising Rivals
(#2313).

```
en: Discard 1 Energy card attached to Ninetales in order to use this attack.
fr: Défaussez 1 carte Énergie  attachée à Feunard pour pouvoir utiliser cette attaque.
de: Entferne eine auf Vulnona abgelegte {R} Energiekarte, um diesen Angriff auszuführen.
```

**21 symbols restored, in 16 strings across 15 cards. Only `fr` values change — 16 lines in,
16 lines out.**

## Details

Every one of the 21 symbols was read off the French card page on Poképédia, and the German
`{X}` token in the same field agrees on all 15 cards. No value is derived from the English
alone, and none is invented.

- **`{R}`** — [`base1-4`](https://www.pokepedia.fr/Dracaufeu_(Set_de_Base_4)) (Dracaufeu),
  [`base1-12`](https://www.pokepedia.fr/Feunard_(Set_de_Base_12)) (Feunard),
  [`base1-23`](https://www.pokepedia.fr/Arcanin_(Set_de_Base_23)) (Arcanin),
  [`base1-24`](https://www.pokepedia.fr/Reptincel_(Set_de_Base_24)) (Reptincel),
  [`base1-36`](https://www.pokepedia.fr/Magmar_(Set_de_Base_36)) (Magmar),
  [`base1-46`](https://www.pokepedia.fr/Salamèche_(Set_de_Base_46)) (Salamèche).
- **`{P}`** — [`base1-10`](https://www.pokepedia.fr/Mewtwo_(Set_de_Base_10)) (Mewtwo),
  [`base1-32`](https://www.pokepedia.fr/Kadabra_(Set_de_Base_32)) (Kadabra),
  [`base1-50`](https://www.pokepedia.fr/Fantominus_(Set_de_Base_50)) (Fantominus).
- **`{W}`** — [`base1-2`](https://www.pokepedia.fr/Tortank_(Set_de_Base_2)) (Tortank, 4),
  [`base1-13`](https://www.pokepedia.fr/Tartard_(Set_de_Base_13)) (Tartard, 2),
  [`base1-59`](https://www.pokepedia.fr/Ptitard_(Set_de_Base_59)) (Ptitard, 2),
  [`base1-64`](https://www.pokepedia.fr/Staross_(Set_de_Base_64)) (Staross).
- **`{G}`** — [`base1-15`](https://www.pokepedia.fr/Florizarre_(Set_de_Base_15)) (Florizarre).
- **`{C}{C}`** — [`base1-96`](https://www.pokepedia.fr/Double_Énergie_Incolore_(Set_de_Base_96)).

Three cards needed more than a lookup:

- **`base1-2` (Tortank), Danse de la pluie** — two holes but a single `{W}` in the German.
  The French card resolves it: `1 carte Énergie {W} à 1 de vos Pokémon {W} (En plus…`, two
  symbols, and **no period** before the parenthesis. Restored to match exactly.
- **`base1-15` (Florizarre), Transfert d'Énergie** — the mirror case, and the reason the
  double-space count can be trusted as the guide: the card carries **one** symbol, after
  `carte Énergie`, and none after `Pokémon` — matching its single hole.
- **`base1-96` (Double Énergie Incolore)** — the only card where the symbol was not dropped
  but replaced by the French word in clear: `Fournit Incolore Incolore énergies.` The card
  shows two Colorless icons and the lowercase plural `énergies`, so this becomes
  `Fournit {C}{C} énergies.`

One thing deliberately left alone: `base1-59` (Ptitard) reads "Inflige 30 dégâts" against a
printed `10+` damage. That is a misprint on the French card itself, documented as such on
Poképédia, so the text is reproduced as printed.

Placement follows the repo convention, symbol after the noun (`carte Énergie {R}`,
`Pokémon {G}`), which is also exactly where the double spaces sit — the corruption stripped
only the `{X}` token and left surrounding punctuation untouched, so no punctuation is added
or removed here.

`npm run validate` passes. No English string was modified.

Sixteenth set in the French energy-symbol series.
