### PR TITLE
fix(data): Restore the energy symbols lost from EX FireRed & LeafGreen French text

### DIFF
--- a/data/EX/FireRed & LeafGreen/104.ts
+++ b/data/EX/FireRed & LeafGreen/104.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), you may attach a Water Energy card from your hand to 1 of your Pokémon. Put 1 damage counter on that Pokémon. This power can't be used if Blastoise ex is affected by a Special Condition.",
-				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez attacher une carte Énergie  de votre main à 1 de vos Pokémon. Placez 1 marqueur de dégât sur ce Pokémon. Ce pouvoir ne peut pas être utilisé si Tortank ex est affecté par un État Spécial.",
+				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez attacher une carte Énergie {W} de votre main à 1 de vos Pokémon. Placez 1 marqueur de dégât sur ce Pokémon. Ce pouvoir ne peut pas être utilisé si Tortank ex est affecté par un État Spécial.",
 				de: "As often as you like during your turn (before your attack), you may attach a Water Energy card from your hand to 1 of your Pokémon. Put 1 damage counter on that Pokémon. This power can't be used if Blastoise ex is affected by a Special Condition."
 			},
 		},

--- a/data/EX/FireRed & LeafGreen/105.ts
+++ b/data/EX/FireRed & LeafGreen/105.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "All Energy attached to Charizard ex are Fire Energy instead of its usual type.",
-				fr: "Toutes les Énergies attachées à Dracaufeu ex sont des Énergies .",
+				fr: "Toutes les Énergies attachées à Dracaufeu ex sont des Énergies {R}.",
 				de: "All Energy attached to Charizard ex are  Energy instead of its usual type."
 			},
 		},
@@ -77,7 +77,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard 5 Fire Energy attached to Charizard ex. This attack's damage isn't affected by Weakness, Resistance, Poké-Powers, Poké-Bodies, and any other effects on the Defending Pokémon.",
-				fr: "Défaussez 5 Énergies  attachées à Dracaufeu ex. Les dégâts de cette attaque ne sont pas affectés la Faiblesse, la Résistance, les Poké-Powers, les Poké-Bodies ou tout autre effet sur le Pokémon Défenseur.",
+				fr: "Défaussez 5 Énergies {R} attachées à Dracaufeu ex. Les dégâts de cette attaque ne sont pas affectés la Faiblesse, la Résistance, les Poké-Powers, les Poké-Bodies ou tout autre effet sur le Pokémon Défenseur.",
 				de: "Discard 5  Energy attached to Charizard ex. This attack's\ndamage isn't affected by Weakness, Resistance,\nPoké-Powers, Poké-Bodies, and any other effects on the\nDefending Pokémon."
 			},
 			damage: 200,

--- a/data/EX/FireRed & LeafGreen/106.ts
+++ b/data/EX/FireRed & LeafGreen/106.ts
@@ -43,7 +43,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Choose 1 of the Defending Pokémon's attacks. Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) (No matter what type that Pokémon is, Clefable ex's type is still Colorless.) Clefable ex performs that attack. \"",
-				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Métronome copie cette attaque sans tenir compte du Coût en Énergie. (Vous devez tout de même respecter les autres étapes si vous voulez utiliser cette attaque.) (Peu importe le type du Pokémon Défenseur, le type de Mélodelfe ex reste .) C'est Mélodelfe ex qui utilise cette attaque.",
+				fr: "Choisissez 1 des attaques du Pokémon Défenseur. Métronome copie cette attaque sans tenir compte du Coût en Énergie. (Vous devez tout de même respecter les autres étapes si vous voulez utiliser cette attaque.) (Peu importe le type du Pokémon Défenseur, le type de Mélodelfe ex reste {C}.) C'est Mélodelfe ex qui utilise cette attaque.",
 				de: "Choose 1 of the Defending Pokémon's attacks. Metronome copies that attack except for its Energy cost. (You must still do anything else in order to use that attack.) (No matter what type that Pokémon is, Clefable ex's type is still .) Clefable ex performs that attack."
 			},
 

--- a/data/EX/FireRed & LeafGreen/112.ts
+++ b/data/EX/FireRed & LeafGreen/112.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As often as you like during your turn (before your attack), move a Grass Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Venusaur ex is affected by a Special Condition.",
-				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez déplacer une carte Énergie  d'1 de vos Pokémon à 1 autre de vos Pokémon. Ce pouvoir ne peut pas être utilisé si Florizarre ex est affecté par un État Spécial.",
+				fr: "Autant de fois que vous le voulez lors de votre tour (avant votre attaque), vous pouvez déplacer une carte Énergie {G} d'1 de vos Pokémon à 1 autre de vos Pokémon. Ce pouvoir ne peut pas être utilisé si Florizarre ex est affecté par un État Spécial.",
 				de: "As often as you like during your turn (before yxour attack), mova a  Energy card attached to 1 of your Pokémon to another of your Pokémon. This power can't be used if Venusaur ex is affected by a Special Condition."
 			},
 		},

--- a/data/EX/FireRed & LeafGreen/114.ts
+++ b/data/EX/FireRed & LeafGreen/114.ts
@@ -62,7 +62,7 @@ const card: Card = {
 		},
 
 		effect: {
-			fr: "Une seule fois lors de votre tour, lorsque vous déplacez Artikodin ex de votre main à votre Banc, vous pouvez échanger 1 de vos Pokémon Actifs avec Artikodin ex. Dans ce cas, vous pouvez également déplacer autant de cartes Énergie de base  attachées à votre Pokémon que vous le voulez et les placer sur Artikodin ex.",
+			fr: "Une seule fois lors de votre tour, lorsque vous déplacez Artikodin ex de votre main à votre Banc, vous pouvez échanger 1 de vos Pokémon Actifs avec Artikodin ex. Dans ce cas, vous pouvez également déplacer autant de cartes Énergie de base {W} attachées à votre Pokémon que vous le voulez et les placer sur Artikodin ex.",
 			de: "Once during your turn, when you put Articuno ex from your hand onto your Bench, you may switch 1 of your Active Pokémon with Articuno ex. If you do, you may also move any number of basic  Energy cards attached to your Pokémon to Articuno ex."
 		},
 

--- a/data/EX/FireRed & LeafGreen/115.ts
+++ b/data/EX/FireRed & LeafGreen/115.ts
@@ -62,7 +62,7 @@ const card: Card = {
 		},
 
 		effect: {
-			fr: "Une seule fois lors de votre tour, lorsque vous déplacez Sulfura ex de votre main à votre Banc, vous pouvez échanger 1 de vos Pokémon Actifs avec Sulfura ex. Dans ce cas, vous pouvez également déplacer autant de cartes Énergie de base  attachées à votre Pokémon que vous le voulez et les placer sur Sulfura ex.",
+			fr: "Une seule fois lors de votre tour, lorsque vous déplacez Sulfura ex de votre main à votre Banc, vous pouvez échanger 1 de vos Pokémon Actifs avec Sulfura ex. Dans ce cas, vous pouvez également déplacer autant de cartes Énergie de base {R} attachées à votre Pokémon que vous le voulez et les placer sur Sulfura ex.",
 			de: "Once during your turn, when you put Moltres ex from your hand onto your Bench, you may switch 1 of your Active Pokémon with Moltres ex. If you do, you may also move any number of basic  Energy cards attached to your Pokémon to Moltres ex."
 		},
 

--- a/data/EX/FireRed & LeafGreen/116.ts
+++ b/data/EX/FireRed & LeafGreen/116.ts
@@ -62,7 +62,7 @@ const card: Card = {
 		},
 
 		effect: {
-			fr: "Une seule fois lors de votre tour, lorsque vous déplacez Élector ex de votre main à votre Banc, vous pouvez échanger 1 de vos Pokémon Actifs avec Élector ex. Dans ce cas, vous pouvez également déplacer autant de cartes Énergie de base  attachées à votre Pokémon que vous le voulez et les placer sur Élector ex.",
+			fr: "Une seule fois lors de votre tour, lorsque vous déplacez Élector ex de votre main à votre Banc, vous pouvez échanger 1 de vos Pokémon Actifs avec Élector ex. Dans ce cas, vous pouvez également déplacer autant de cartes Énergie de base {L} attachées à votre Pokémon que vous le voulez et les placer sur Élector ex.",
 			de: "Once during your turn, when you put Zapdos ex from your hand onto your Bench, you may switch 1 of your Active Pokémon with Zapdos ex. If you do, you may also move any number of basic  Energy cards attached to your Pokémon to Zapdos ex."
 		},
 

--- a/data/EX/FireRed & LeafGreen/12.ts
+++ b/data/EX/FireRed & LeafGreen/12.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for up to 2 Lightning Energy cards and attach them to Raichu. Shuffle your deck afterward.",
-				fr: "Cherchez dans votre deck jusqu'à 2 cartes Énergie  et attachez-les à Raichu. Ensuite, mélangez votre deck.",
+				fr: "Cherchez dans votre deck jusqu'à 2 cartes Énergie {L} et attachez-les à Raichu. Ensuite, mélangez votre deck.",
 				de: "Durchsuche dein Deck nach bis zu 2  - Energiekarten und lege sie an Raichu an. Mische dein Deck danach."
 			},
 
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You may move any number of Lightning Energy cards attached to Raichu to another of your Pokémon.",
-				fr: "Vous pouvez déplacer autant de cartes Énergie  attachées à Raichu que vous le voulez sur un autre de vos Pokémon.",
+				fr: "Vous pouvez déplacer autant de cartes Énergie {L} attachées à Raichu que vous le voulez sur un autre de vos Pokémon.",
 				de: "Du kannst beliebig viele an Raichu angelegte  - Energiekarten an ein anderes deiner Pokémon anlegen."
 			},
 			damage: 50,

--- a/data/EX/FireRed & LeafGreen/21.ts
+++ b/data/EX/FireRed & LeafGreen/21.ts
@@ -40,7 +40,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Dodrio is on your Bench, you pay Colorless Colorless less to retreat your Active Pokémon (excluding Pokémon-ex and Baby Pokémon).\"",
-				fr: "Tant que Dodrio est sur votre Banc, vous n'avez pas à payer  pour faire battre en retraite votre Pokémon Actif (sauf pour les Pokémon-ex et les Bébés Pokémon).",
+				fr: "Tant que Dodrio est sur votre Banc, vous n'avez pas à payer {C}{C} pour faire battre en retraite votre Pokémon Actif (sauf pour les Pokémon-ex et les Bébés Pokémon).",
 				de: "Solange sich Dodri auf deiner Bank befindet, kostet dich der Rückzug deiner Aktiven Pokémon (außer Pokémon-ex und Baby-Pokémon).   weniger."
 			},
 		},

--- a/data/EX/FireRed & LeafGreen/26.ts
+++ b/data/EX/FireRed & LeafGreen/26.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for up to 2 Water Energy cards and attach them to Kingler. Shuffle your deck afterward.",
-				fr: "Cherchez dans votre deck jusqu'à 2 cartes Énergie  et attachez-les à Krabboss. Ensuite, mélangez votre deck.",
+				fr: "Cherchez dans votre deck jusqu'à 2 cartes Énergie {W} et attachez-les à Krabboss. Ensuite, mélangez votre deck.",
 				de: "Search your deck for up to 2  Energy cards and attach them to Kingler. Shuffle your deck afterward."
 			},
 

--- a/data/EX/FireRed & LeafGreen/50.ts
+++ b/data/EX/FireRed & LeafGreen/50.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Water Energy attached to Wartortle but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way.",
-				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à Carabaffe qui n'a pas été utilisée pour payer le Coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
+				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {W} attachée à Carabaffe qui n'a pas été utilisée pour payer le Coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 20 dégâts de cette façon.",
 				de: "Does 20 damage plus 10 more damage for each  Energy attached to Wartortle but not used to pay for this attack's Energy cost. You can't add more than 20 damage in this way."
 			},
 			damage: "20+",

--- a/data/EX/FireRed & LeafGreen/74.ts
+++ b/data/EX/FireRed & LeafGreen/74.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Flip a coin. If heads, search your discard pile for a Lightning Energy card and attach it to Pikachu.",
-				fr: "Lancez une pièce. Si c'est face, cherchez une carte Énergie  dans votre pile de défausse et attachez-la à Pikachu.",
+				fr: "Lancez une pièce. Si c'est face, cherchez une carte Énergie {L} dans votre pile de défausse et attachez-la à Pikachu.",
 				de: "Flip a coin. If heads, search your discard pile for a  Energy card and attach it to Pikachu."
 			},
 			damage: 10,

--- a/data/EX/FireRed & LeafGreen/86.ts
+++ b/data/EX/FireRed & LeafGreen/86.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Search your deck for up to 2 Grass Basic Pokémon and put them onto your Bench. Shuffle your deck afterward.",
-				fr: "Cherchez dans votre deck jusqu'à 2 Pokémon de base  et placez-les sur votre Banc. Ensuite, mélangez votre deck.",
+				fr: "Cherchez dans votre deck jusqu'à 2 Pokémon de base {G} et placez-les sur votre Banc. Ensuite, mélangez votre deck.",
 				de: "Search your deck for up to 2  Basic Pokémon and put them onto your bench. Suffle your deck afterward."
 			},
 
@@ -53,7 +53,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Grass Energy card attached to Weedle. The Defending Pokémon is now Poisoned.",
-				fr: "Défaussez une carte Énergie  attachée à Aspicot. Le Pokémon Défenseur est maintenant Empoisonné.",
+				fr: "Défaussez une carte Énergie {G} attachée à Aspicot. Le Pokémon Défenseur est maintenant Empoisonné.",
 				de: "Discard a  Energy Card attached to Weedle. The Defending Pokémon is now Poisoned."
 			},
 


### PR DESCRIPTION
## Changes

The inline `{X}` energy symbols were dropped from 16 French strings across 13 EX FireRed &
LeafGreen cards, the same defect already fixed for Aquapolis (#2273), Neo Destiny (#2274),
Expedition (#2275), Power Keepers (#2276), XY promos (#2277), EX Dragon (#2278), EX Deoxys
(#2279), EX Sandstorm (#2281), Neo Genesis (#2282), SWSH promos (#2283), EX Legend Maker
(#2308), EX Unseen Forces (#2309), EX Delta Species (#2310), EX Ruby & Sapphire (#2311),
EX Hidden Legends (#2312), Rising Rivals (#2313) and Base Set (#2315).

```
en: Search your deck for up to 2 Lightning Energy cards and attach them to Raichu. Shuffle your deck afterward.
fr: Cherchez dans votre deck jusqu'à 2 cartes Énergie  et attachez-les à Raichu. Ensuite, mélangez votre deck.
de: Durchsuche dein Deck nach bis zu 2  - Energiekarten und lege sie an Raichu an. Mische dein Deck danach.
```

**17 symbols restored, in 16 strings across 13 cards. Only `fr` values change — 16 lines in,
16 lines out.**

## Details

This set differs from the previous ones in the series: **the German text is corrupted too**
(see the `de` line above, and several `de` fields here are simply an English copy), so it
could not be used as the source. Every symbol below was instead read off the French card
page on Poképédia, and cross-checked against the English wherever the English names the type.

- **`{L}`** — [`ex6-12`](https://www.pokepedia.fr/Raichu_(EX_Rouge_Feu_&_Vert_Feuille_12))
  (Raichu, both attacks),
  [`ex6-74`](https://www.pokepedia.fr/Pikachu_(EX_Rouge_Feu_&_Vert_Feuille_74)) (Pikachu),
  [`ex6-116`](https://www.pokepedia.fr/Élector_ex_(EX_Rouge_Feu_&_Vert_Feuille_116)) (Élector ex).
- **`{W}`** — [`ex6-26`](https://www.pokepedia.fr/Krabboss_(EX_Rouge_Feu_&_Vert_Feuille_26))
  (Krabboss),
  [`ex6-50`](https://www.pokepedia.fr/Carabaffe_(EX_Rouge_Feu_&_Vert_Feuille_50)) (Carabaffe),
  [`ex6-104`](https://www.pokepedia.fr/Tortank_ex_(EX_Rouge_Feu_&_Vert_Feuille_104)) (Tortank ex),
  [`ex6-114`](https://www.pokepedia.fr/Artikodin_ex_(EX_Rouge_Feu_&_Vert_Feuille_114)) (Artikodin ex).
- **`{G}`** — [`ex6-86`](https://www.pokepedia.fr/Aspicot_(EX_Rouge_Feu_&_Vert_Feuille_86))
  (Aspicot, both attacks),
  [`ex6-112`](https://www.pokepedia.fr/Florizarre_ex_(EX_Rouge_Feu_&_Vert_Feuille_112)) (Florizarre ex).
- **`{R}`** — [`ex6-105`](https://www.pokepedia.fr/Dracaufeu_ex_(EX_Rouge_Feu_&_Vert_Feuille_105))
  (Dracaufeu ex, Poké-Body and attack),
  [`ex6-115`](https://www.pokepedia.fr/Sulfura_ex_(EX_Rouge_Feu_&_Vert_Feuille_115)) (Sulfura ex).
- **`{C}`** — [`ex6-106`](https://www.pokepedia.fr/Mélodelfe_ex_(EX_Rouge_Feu_&_Vert_Feuille_106)) (Mélodelfe ex).

Cards that needed a judgement call:

- **`ex6-114`, `ex6-115`, `ex6-116` (Artikodin ex, Sulfura ex, Élector ex)** — these three
  have **no English effect text at all** (`en` is `undefined`) and their German is stripped
  in the same place, so the scan was the only source. It gives Eau, Feu and Électrique
  respectively, matching each Pokémon's own type.
- **`ex6-21` (Dodrio)** — a single hole, but two symbols: the English reads "you pay
  Colorless Colorless less to retreat" and
  [the card](https://www.pokepedia.fr/Dodrio_(EX_Rouge_Feu_&_Vert_Feuille_21)) shows two
  Incolore icons side by side, so this one slot becomes `{C}{C}`.
- **`ex6-105` (Dracaufeu ex) and `ex6-106` (Mélodelfe ex)** — here the symbol sat at the end
  of a sentence, so the corruption left a space before the full stop rather than a double
  space (`sont des Énergies .`, `le type de Mélodelfe ex reste .`).

One card matched the detector but is **not** a lost symbol and is left untouched:
`ex6-101` (Potion) reads `Soignez 30 dégâts à 1 de vos Pokémon .` — a Trainer Item with no
type reference anywhere on it. [The card](https://www.pokepedia.fr/Potion_(EX_Rouge_Feu_&_Vert_Feuille_101))
carries no energy icon, so the stray space is a typo, not a hole.

`npm run validate` passes. No English string was modified.

Seventeenth set in the French energy-symbol series.
