### PR TITLE
fix(data): Restore the energy symbols and ☆ suffix lost from EX Crystal Guardians French text

### DIFF
--- a/data/EX/Crystal Guardians/14.ts
+++ b/data/EX/Crystal Guardians/14.ts
@@ -61,7 +61,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 50 damage plus 20 more damage for each Water Energy attached to Blastoise but not used to pay for this attack's Energy cost. You can't add more than 40 damage in this way.",
-				fr: "Inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque Énergie  attachée à Tortank qui n'a pas été utilisée pour payer le Coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 40 dégâts de cette façon.",
+				fr: "Inflige 50 dégâts plus 20 dégâts supplémentaires pour chaque Énergie {W} attachée à Tortank qui n'a pas été utilisée pour payer le Coût en Énergie de cette attaque. Vous ne pouvez pas ajouter plus de 40 dégâts de cette façon.",
 				de: "Dieser Angriff fügt 50 Schadenspunkte plus 20 weitere Schadenspunkte für jede an Turtok angelegte {W}-Energie zu, die nicht zum Zahlen der Energiekosten für diesen Angriff verwendet wurde. Es lassen sich so nicht mehr als 40 Schadenspunkte hinzufügen."
 			},
 			damage: "50+",

--- a/data/EX/Crystal Guardians/17.ts
+++ b/data/EX/Crystal Guardians/17.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Dusclops is your Active Pokémon, your opponent can't attach any Special Energy cards (except for Darkness and Metal Energy cards) from his or her hand to his or her Active Pokémon.",
-				fr: "Tant que Teraclope est votre Pokémon Actif, votre adversaire ne peut pas attacher de cartes Énergie spéciale (cartes Énergie  et  exceptées) de sa main à son Pokémon Actif.",
+				fr: "Tant que Teraclope est votre Pokémon Actif, votre adversaire ne peut pas attacher de cartes Énergie spéciale (cartes Énergie {D} et {M} exceptées) de sa main à son Pokémon Actif.",
 				de: "Solange Zwirrklop dein Aktives Pokémon ist, kann dein Gegner keine Spezialenergiekarten (außer {D}- und {M}-Energiekarten) von seiner Hand an sein Aktives Pokémon anlegen."
 			},
 		},

--- a/data/EX/Crystal Guardians/20.ts
+++ b/data/EX/Crystal Guardians/20.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Any damage done to Grumpig by attacks from Fire Pokémon and Water Pokémon is reduced by 30 (after applying Weakness and Resistance).",
-				fr: "Tous dégâts infligés à Groret par des attaques de Pokémon  et  sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
+				fr: "Tous dégâts infligés à Groret par des attaques de Pokémon {R} et {W} sont réduits de 30 (après application de la Faiblesse et de la Résistance).",
 				de: "Jeder Schaden, der Groink durch Angriffe von {R}-Pokémon und {W}-Pokémon zugefügt wird, wird um 30 Schadenspunkte reduziert (nachdem Schwäche und Resistenz verrechnet wurden)."
 			},
 		},

--- a/data/EX/Crystal Guardians/21.ts
+++ b/data/EX/Crystal Guardians/21.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "You pay Colorless less to retreat your Jigglypuff, Wigglytuff, Wigglytuff ex, and Igglybuff.",
-				fr: "Vous payez un  de moins pour faire battre Rondoudou, Groudoudou, Grodoudou ex et Toudoudou en retraite.",
+				fr: "Vous payez un {C} de moins pour faire battre Rondoudou, Groudoudou, Grodoudou ex et Toudoudou en retraite.",
 				de: "Der Rückzug deiner Pummeluff, Knuddeluff, Knuddeluff ex und Fluffeluff kostet dich {C} weniger.",
 			},
 		},

--- a/data/EX/Crystal Guardians/25.ts
+++ b/data/EX/Crystal Guardians/25.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as Medicham has any Psychic Energy cards attached to it, Medicham is both Psychic and Fighting type.",
-				fr: "Tant que Charmina possède des cartes Énergie , il est de type  et .",
+				fr: "Tant que Charmina possède des cartes Énergie {P}, il est de type {P} et {F}.",
 				de: "Solange an Meditalis mindestens eine {P}-Energiekarte angelegt ist, ist Meditalis ein Pokémon vom Typ {P} und {F}."
 			},
 		},

--- a/data/EX/Crystal Guardians/28.ts
+++ b/data/EX/Crystal Guardians/28.ts
@@ -41,7 +41,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "All Energy cards that provide only Colorless Energy attached to your Grass Pokémon provide Grass Energy instead.",
-				fr: "Toutes les cartes Énergie fournissant uniquement de l'Énergie  attachées à vos Pokémon  fournissent de l'Énergie .",
+				fr: "Toutes les cartes Énergie fournissant uniquement de l'Énergie {C} attachées à vos Pokémon {G} fournissent de l'Énergie {G}.",
 				de: "Alle Energiekarten, die nur {C}-Energie liefern und an deine Pokémon vom Typ {G} angelegt sind, liefern stattdessen {G}-Energie."
 			},
 		},
@@ -60,7 +60,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Does 20 damage plus 10 more damage for each Grass Energy attached to all of your Pokémon.",
-				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie  attachée à tous vos Pokémon.",
+				fr: "Inflige 20 dégâts plus 10 dégâts supplémentaires pour chaque Énergie {G} attachée à tous vos Pokémon.",
 				de: "Dieser Angriff fügt 20 Schadenspunkte plus 10 weitere Schadenspunkte für jede an deine Pokémon angelegte {G}-Energie zu."
 			},
 			damage: "20+",

--- a/data/EX/Crystal Guardians/29.ts
+++ b/data/EX/Crystal Guardians/29.ts
@@ -63,7 +63,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Fire Energy attached to Charmeleon.",
-				fr: "Défaussez une Énergie  attachée à Reptincel.",
+				fr: "Défaussez une Énergie {R} attachée à Reptincel.",
 				de: "Entferne 1 {R}-Energie von Glutexo und lege sie auf deinen Ablagestapel."
 			},
 			damage: 60,

--- a/data/EX/Crystal Guardians/39.ts
+++ b/data/EX/Crystal Guardians/39.ts
@@ -43,7 +43,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Attach a Darkness Energy card from your hand to Nuzleaf.",
-				fr: "Attachez une carte Énergie  de votre main à Pifeuil.",
+				fr: "Attachez une carte Énergie {D} de votre main à Pifeuil.",
 				de: "Lege eine {D}-Energiekarte von deiner Hand an Blanas an."
 			},
 

--- a/data/EX/Crystal Guardians/4.ts
+++ b/data/EX/Crystal Guardians/4.ts
@@ -63,7 +63,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard all Metal Energy attached to Charizard.",
-				fr: "Défaussez toutes les Énergies  attachées à Dracaufeu.",
+				fr: "Défaussez toutes les Énergies {M} attachées à Dracaufeu.",
 				de: "Lege alle an Glurak angelegte {M}-Energie auf deinen Ablagestapel."
 			},
 			damage: 120,

--- a/data/EX/Crystal Guardians/46.ts
+++ b/data/EX/Crystal Guardians/46.ts
@@ -37,7 +37,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Attach a Grass Energy card from your hand to Bulbasaur.",
-				fr: "Attachez une carte Énergie  de votre main à Bulbizarre.",
+				fr: "Attachez une carte Énergie {G} de votre main à Bulbizarre.",
 				de: "Lege eine {G}-Energiekarte von deiner Hand an Bisasam an."
 			},
 

--- a/data/EX/Crystal Guardians/55.ts
+++ b/data/EX/Crystal Guardians/55.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "If Lotad has any Water Energy attached to it, the Retreat Cost for Lotad is 0.",
-				fr: "Si Nenupiot possède une Énergie , son Coût de retraite est de 0.",
+				fr: "Si Nenupiot possède une Énergie {W}, son Coût de retraite est de 0.",
 				de: "Wenn mindestens 1 {W}-Energie an Loturzel angelegt ist, hat Loturzel Rückzugskosten 0."
 			},
 		},

--- a/data/EX/Crystal Guardians/76.ts
+++ b/data/EX/Crystal Guardians/76.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	effect: {
 		en: "Attach Crystal Shard to 1 of your Pokémon that doesn't already have a Pokémon Tool attached to it. If that Pokémon is Knocked Out, discard this card. As long as Crystal Shard is attached to a Pokémon, that Pokémon's type is Colorless. If that Pokémon attacks, discard this card at the end of the turn.",
-		fr: "Attachez Écharde de cristal à 1 de vos Pokémon qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez cette carte.\n\nTant qu'Écharde de cristal est attachée à un Pokémon, ce Pokémon est de type . S'il attaque, défaussez cette carte à la fin du tour.",
+		fr: "Attachez Écharde de cristal à 1 de vos Pokémon qui ne possède pas déjà d'Outil Pokémon. Si ce Pokémon est mis K.O, défaussez cette carte.\n\nTant qu'Écharde de cristal est attachée à un Pokémon, ce Pokémon est de type {C}. S'il attaque, défaussez cette carte à la fin du tour.",
 		de: "Lege Kristallsplitter an 1 deiner Pokémon an, an dem noch keine Pokémon-Ausrüstung anliegt. Wenn das Pokémon, an das Kristallsplitter angelegt ist, kampfunfähig gemacht wird, lege Kristallsplitter auf den Ablagestapel. Solange diese Karte an ein Pokémon angelegt ist, erhält das Pokémon den Typ {C}. Wenn das Pokémon angreift, lege diese Karte am Ende deines Zuges auf deinen Ablagestapel."
 	},
 

--- a/data/EX/Crystal Guardians/94.ts
+++ b/data/EX/Crystal Guardians/94.ts
@@ -35,7 +35,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "As long as your opponent has any Pokémon-ex or Stage 2 Evolved Pokémon in play, Jirachi ex pays Colorless less Energy to use Shield Beam or Super Psy Bolt.",
-				fr: "Tant que votre adversaire possède des Pokémon-ex ou des Pokémon Évolués de Niveau 2 en jeu, Jirachi ex paye une Énergie  de moins pour utiliser Rayon protecteur ou Super psy.",
+				fr: "Tant que votre adversaire possède des Pokémon-ex ou des Pokémon Évolués de Niveau 2 en jeu, Jirachi ex paye une Énergie {C} de moins pour utiliser Rayon protecteur ou Super psy.",
 				de: "Solange dein Gegner mindestens 1 Pokémon-ex oder ein entwickeltes Pokémon der Phase 2 im Spiel hat, kosten Jirachi ex' Schildstrahl und Super-Psischlag 1 {C} weniger."
 			},
 		},

--- a/data/EX/Crystal Guardians/96.ts
+++ b/data/EX/Crystal Guardians/96.ts
@@ -42,7 +42,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Each player's Pokémon-ex can't use any Poké-Powers and pays Colorless more Energy to use its attacks. Each Pokémon can't be affected by more than 1 Extra Liquid Poké-Body.",
-				fr: "Le Pokémon-ex de chaque joueur ne peut pas utiliser de Poké-Powers et paye une Énergie  de plus pour utiliser ses attaques. Chaque Pokémon ne peut pas être affecté par plus d'1 Poké-Body Liquide supplémentaire.",
+				fr: "Le Pokémon-ex de chaque joueur ne peut pas utiliser de Poké-Powers et paye une Énergie {C} de plus pour utiliser ses attaques. Chaque Pokémon ne peut pas être affecté par plus d'1 Poké-Body Liquide supplémentaire.",
 				de: "Die Pokémon-ex aller Spieler können keine Poké-Power einsetzen und ihre Angriffe kosten 1 {C} mehr. Jedes Pokémon kann nur von 1 Extraflüssigkeit Poké-Body betroffen sein."
 			},
 		},

--- a/data/EX/Crystal Guardians/99.ts
+++ b/data/EX/Crystal Guardians/99.ts
@@ -55,7 +55,7 @@ const card: Card = {
 			},
 			effect: {
 				en: "Discard a Basic Pokémon or Evolution card from your hand. Choose 1 of that card's attacks. Skill Copy copies that attack. This attack does nothing if Alakazam Star doesn't have the Energy necessary to use that attack. (You must still do anything else required for that attack.) Alakazam Star performs that attack.",
-				fr: "Défaussez un Pokémon de base ou une carte Évolution de votre main. Choisissez 1 des attaques de cette carte. Copiage pro copie cette attaque. Cette attaque est sans effet si Alakazam ☆ ne possède pas l'Énergie nécessaire pour utiliser cette attaque. (Vous devez faire tout ce qui est spécifié pour cette attaque.) Alakazam  utilise cette attaque.",
+				fr: "Défaussez un Pokémon de base ou une carte Évolution de votre main. Choisissez 1 des attaques de cette carte. Copiage pro copie cette attaque. Cette attaque est sans effet si Alakazam ☆ ne possède pas l'Énergie nécessaire pour utiliser cette attaque. (Vous devez faire tout ce qui est spécifié pour cette attaque.) Alakazam ☆ utilise cette attaque.",
 				de: "Lege 1 Basis-Pokémon-Karte oder Evolutionskarte von deiner Hand auf deinen Ablagestapel. Wähle 1 Angriff auf dieser Karte. Fertigkeitskopie kopiert diesen Angriff. Dieser Angriff hat keine Auswirkungen, wenn an Simsala ☆ nicht die für den kopierten Angriff benötigte Energie angelegt ist. (Du musst immer noch alles tun, was verlangt wird, um diesen Angriff durchzuführen.) Simsala ☆ benutzt den kopierten Angriff."
 			},
 


### PR DESCRIPTION
## Changes

The inline `{X}` energy symbols were dropped from 15 French strings across 14 EX Crystal
Guardians cards, and the `☆` suffix from a 16th. Same defect as Aquapolis (#2273), Neo
Destiny (#2274), Expedition (#2275), Power Keepers (#2276), XY promos (#2277), EX Dragon
(#2278), EX Deoxys (#2279), EX Sandstorm (#2281), Neo Genesis (#2282), SWSH promos (#2283),
EX Legend Maker (#2308), EX Unseen Forces (#2309), EX Delta Species (#2310), EX Ruby &
Sapphire (#2311), EX Hidden Legends (#2312), Rising Rivals (#2313), Base Set (#2315) and
EX FireRed & LeafGreen (#2316).

```
en: As long as Medicham has any Psychic Energy cards attached to it, Medicham is both Psychic and Fighting type.
fr: Tant que Charmina possède des cartes Énergie , il est de type  et .
de: Solange an Meditalis mindestens eine {P}-Energiekarte angelegt ist, ist Meditalis ein Pokémon vom Typ {P} und {F}.
```

**22 symbols restored, in 16 strings across 15 cards. Only `fr` values change — 16 lines in,
16 lines out.**

## Details

The German text of this set is intact, so every symbol has two independent sources: the
German `{X}` token and the French card page on Poképédia. They agree on all 15 cards.

- **`{C}`** — [`ex14-21`](https://www.pokepedia.fr/Toudoudou_(EX_Gardiens_de_Cristal_21)) (Toudoudou),
  [`ex14-76`](https://www.pokepedia.fr/Écharde_de_cristal_(EX_Gardiens_de_Cristal_76)) (Écharde de cristal),
  [`ex14-94`](https://www.pokepedia.fr/Jirachi_ex_(EX_Gardiens_de_Cristal_94)) (Jirachi ex),
  [`ex14-96`](https://www.pokepedia.fr/Jungko_ex_δ_(EX_Gardiens_de_Cristal_96)) (Jungko ex δ).
- **`{G}`** — [`ex14-46`](https://www.pokepedia.fr/Bulbizarre_(EX_Gardiens_de_Cristal_46)) (Bulbizarre).
- **`{R}`** — [`ex14-29`](https://www.pokepedia.fr/Reptincel_(EX_Gardiens_de_Cristal_29)) (Reptincel).
- **`{W}`** — [`ex14-14`](https://www.pokepedia.fr/Tortank_(EX_Gardiens_de_Cristal_14)) (Tortank),
  [`ex14-55`](https://www.pokepedia.fr/Nenupiot_(EX_Gardiens_de_Cristal_55)) (Nenupiot).
- **`{M}`** — [`ex14-4`](https://www.pokepedia.fr/Dracaufeu_δ_(EX_Gardiens_de_Cristal_4)) (Dracaufeu δ).
- **`{D}`** — [`ex14-39`](https://www.pokepedia.fr/Pifeuil_(EX_Gardiens_de_Cristal_39)) (Pifeuil).

Five strings carry more than one symbol, and there the order matters. Each was read off the
card:

- **[`ex14-17`](https://www.pokepedia.fr/Teraclope_(EX_Gardiens_de_Cristal_17)) (Teraclope)**
  — `(cartes Énergie {D} et {M} exceptées)`, Obscurité then Métal, matching the English
  "except for Darkness and Metal Energy cards".
- **[`ex14-20`](https://www.pokepedia.fr/Groret_(EX_Gardiens_de_Cristal_20)) (Groret)**
  — `attaques de Pokémon {R} et {W}`, Feu then Eau.
- **[`ex14-25`](https://www.pokepedia.fr/Charmina_(EX_Gardiens_de_Cristal_25)) (Charmina)**
  — three symbols in one sentence: `cartes Énergie {P}, il est de type {P} et {F}`.
- **[`ex14-28`](https://www.pokepedia.fr/Florizarre_(EX_Gardiens_de_Cristal_28)) (Florizarre)**
  — four across its two strings: the Poké-Body reads `de l'Énergie {C} attachées à vos
  Pokémon {G} fournissent de l'Énergie {G}`, and its attack takes a fourth `{G}`.

One card is not an energy symbol and is called out separately:

- **[`ex14-99`](https://www.pokepedia.fr/Alakazam_☆_(EX_Gardiens_de_Cristal_99)) (Alakazam ☆)**
  — the string writes `Alakazam ☆` correctly once, then loses the `☆` on its final
  occurrence (`Alakazam  utilise cette attaque.`). The card shows the star there, and the
  German keeps it in both places. Restored for consistency with #2313, which likewise
  covered a lost suffix alongside type symbols.

Where the symbol sat before a comma or a full stop, the corruption left a single space
rather than a double one (`cartes Énergie ,`, `de type  et .`); those slots are filled the
same way, and no punctuation is added or removed.

`npm run validate` passes. No English string was modified.

Eighteenth set in the French energy-symbol series.
