### PR TITLE
refactor: Recommend EditorConfig extension for VS Code

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+	"recommendations": [
+		"EditorConfig.EditorConfig"
+	]
+}


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes #2318

## Changes

Recommend the EditorConfig for VS Code extension through `.vscode/extensions.json`.

## Details

The project uses `.editorconfig` to define formatting conventions, but VS Code does not read this file by default. Recommending `EditorConfig.EditorConfig` helps contributors discover and install the extension needed to apply these settings.

The recommendation does not automatically install the extension; it simply suggests installing it in VS Code.