### PR TITLE
fix(data): Add missing player-rewards-program stamp variant of swsh7/8

### DIFF
--- a/data/Sword & Shield/Evolving Skies/8.ts
+++ b/data/Sword & Shield/Evolving Skies/8.ts
@@ -92,6 +92,14 @@ const card: Card = {
 				tcgplayer: 246691
 			}
 		},
+		{
+			type: 'holo',
+			stamp: ['player-rewards-program'],
+			thirdParty: {
+				cardmarket: 574032,
+				tcgplayer: 475976
+			}
+		},
 	],
 }
 


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

Add missing player-rewards-program stamp variant of swsh7/8 (Leafeon VMAX)

## Details

<!-- You can also give more details about your changes -->
Player-rewards-program stamp variant on tcgplayer: https://www.tcgplayer.com/product/475976?Language=English