### PR TITLE
fix(data): Add normal variants of swsh7/16

### DIFF
--- a/data/Sword & Shield/Evolving Skies/16.ts
+++ b/data/Sword & Shield/Evolving Skies/16.ts
@@ -108,7 +108,7 @@ const card: Card = {
 		{
 			type: 'normal',
 			thirdParty: {
-				cardmarket: 574040,
+				cardmarket: 701491,
 				tcgplayer: 247422
 			}
 		},
@@ -116,7 +116,7 @@ const card: Card = {
 			type: 'normal',
 			stamp: ['player-rewards-program'],
 			thirdParty: {
-				cardmarket: 574040,
+				cardmarket: 697069,
 				tcgplayer: 475978
 			}
 		},

--- a/data/Sword & Shield/Evolving Skies/16.ts
+++ b/data/Sword & Shield/Evolving Skies/16.ts
@@ -105,6 +105,21 @@ const card: Card = {
 				tcgplayer: 246831
 			}
 		},
+		{
+			type: 'normal',
+			thirdParty: {
+				cardmarket: 574040,
+				tcgplayer: 247422
+			}
+		},
+		{
+			type: 'normal',
+			stamp: ['player-rewards-program'],
+			thirdParty: {
+				cardmarket: 574040,
+				tcgplayer: 475978
+			}
+		},
 	],
 }
 


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

Add missing normal variants of swsh7/16 (Eldegoss)

## Details
Added variants:  
- [Normal variant without stamp](https://www.tcgplayer.com/product/247422?Language=English)
- [Normal variant with player-rewards-program stamp](https://www.tcgplayer.com/product/475978?Language=English)

