### PR TITLE
fix(data): Add missing player-rewards-program stamp variant for swsh7/18

### DIFF
--- a/data/Sword & Shield/Evolving Skies/18.ts
+++ b/data/Sword & Shield/Evolving Skies/18.ts
@@ -71,6 +71,14 @@ const card: Card = {
 				tcgplayer: 246712
 			}
 		},
+		{
+			type: 'holo',
+			stamp: ['player-rewards-program'],
+			thirdParty: {
+				cardmarket: 705109,
+				tcgplayer: 475985
+			}
+		},
 	],
 }
 


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

Add missing player-rewards-program stamp variant for swsh7/18 (Flareon VMAX)

## Details

Added variant:

- [Holo variant with player-rewards-program stamp](https://www.tcgplayer.com/product/475985?Language=English)

