### PR TITLE
fix(data): Add player-rewards-program variant of swsh7/8

### DIFF
--- a/data/Sword & Shield/Evolving Skies/8.ts
+++ b/data/Sword & Shield/Evolving Skies/8.ts
@@ -92,6 +92,14 @@ const card: Card = {
 				tcgplayer: 246691
 			}
 		},
+		{
+			type: 'holo',
+			stamp: ['player-rewards-program'],
+			thirdParty: {
+				cardmarket: 574032,
+				tcgplayer: 475976
+			}
+		},
 	],
 }
 

--- a/data/Sword & Shield/Evolving Skies/8.ts
+++ b/data/Sword & Shield/Evolving Skies/8.ts
@@ -92,11 +92,19 @@ const card: Card = {
 				tcgplayer: 246691
 			}
 		},
-		{
+		{ // Play! Pokémon Prize Pack Series One
 			type: 'holo',
 			stamp: ['player-rewards-program'],
 			thirdParty: {
-				cardmarket: 574032,
+				cardmarket: 697067,
+				tcgplayer: 475976
+			}
+		},
+		{ // Play! Pokémon Prize Pack Series Two
+			type: 'holo',
+			stamp: ['player-rewards-program'],
+			thirdParty: {
+				cardmarket: 705127,
 				tcgplayer: 475976
 			}
 		},


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

closes # <!-- Indicate the issue number here -->

## Changes

Add the player-rewards-program variants for swsh7/8.

## Details

swsh7/8 (Leafeon VMAX 008/203) is included in both Play! Pokémon Prize Pack Series 1 and Series 2.

The cards are visually identical, but the two Prize Pack Series have separate Cardmarket IDs. This variant is therefore added to represent the Prize Pack printing for both series.