### PR TITLE
fix(data): Add Noble Victories Archen-line reverse variants

### DIFF
--- a/data/Black & White/Noble Victories/66.ts
+++ b/data/Black & White/Noble Victories/66.ts
@@ -76,10 +76,22 @@ const card: Card = {
 		de: "Man nennt es den Urvater der Vogel-Pokémon. Da es nicht fliegen kann, bewegt es sich hüpfend von Ast zu Ast."
 	},
 
-	thirdParty: {
-		cardmarket: 280189,
-		tcgplayer: 83607
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 280189,
+				tcgplayer: 83607
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 280189,
+				tcgplayer: 83607
+			}
+		}
+	]
 }
 
 export default card

--- a/data/Black & White/Noble Victories/67.ts
+++ b/data/Black & White/Noble Victories/67.ts
@@ -92,10 +92,22 @@ const card: Card = {
 		de: "Bevor es abhebt, nimmt es am Boden Anlauf. Es ist schlau genug, seine Beute zusammen mit Artgenossen zu jagen."
 	},
 
-	thirdParty: {
-		cardmarket: 280190,
-		tcgplayer: 83609
-	}
+	variants: [
+		{
+			type: "normal",
+			thirdParty: {
+				cardmarket: 280190,
+				tcgplayer: 83609
+			}
+		},
+		{
+			type: "reverse",
+			thirdParty: {
+				cardmarket: 280190,
+				tcgplayer: 83609
+			}
+		}
+	]
 }
 
 export default card


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

## Changes

Noble Victories Archen `bw3-66` and Archeops `bw3-67` currently export as normal-only (`variants.reverse: false` across EN/FR/DE/IT/ES/PT). Both clearly trade as reverse holos (TCGPlayer lists reverse-holofoil for both). First party evidence is that I own a lot of these cards.

## Details

- `66.ts` Archen (Uncommon): `normal` + `reverse`
- `67.ts` Archeops (Rare, non-holo pack card): `normal` + `reverse`
- Marketplace IDs moved to variant-level `thirdParty` (same shape as merged Plasma Blast / Unified Minds Archen-line PRs. following maintainer ad-hoc request)

## Notes

- Variants live on the card files only (no language-specific overlays for these records - software support for this is unclear regardless).