### PR TITLE
fix(data): Add Spanish name for Plasma Blast

### DIFF
--- a/data/Black & White/Plasma Blast.ts
+++ b/data/Black & White/Plasma Blast.ts
@@ -7,6 +7,7 @@ const bw10: Set = {
 	name: {
 		en: "Plasma Blast",
 		fr: "Explosion Plasma",
+		es: "Explosión Plasma",
 		it: "Esplosione Plasma",
 		de: "Plasma-Blaster",
 		pt: "Explosão de Plasma" // also "Explosão Plasma" in the PTCGO


### PR DESCRIPTION
<!--
Contribution guide: https://github.com/tcgdex/cards-database/blob/master/CONTRIBUTING.md
please submit changes up to 1 set at most.
-->

## Changes

Add the missing official Spanish name for Black & White—Plasma Blast:

- `es: "Explosión Plasma"`

## Details

The set file previously had `en`/`fr`/`it`/`de`/`pt` but no `es`. The compiler skips a set for any language missing from `set.name`, so **the entire Spanish `bw10` set (including Archen 53 / Archeops 54) was absent** even though card records already contain top-level Spanish names and Spanish asset images exist under `assets.tcgdex.net/es/bw/bw10/…`.

This mirrors the Italian set-name fix (#1960): narrow set-metadata correction only.

## Evidence

- WikiDex: [Negro y Blanco (TCG): Explosión Plasma](https://www.wikidex.net/wiki/Negro_y_Blanco_(TCG):_Explosi%C3%B3n_Plasma)
- Spanish naming pattern for the Plasma trilogy: Tormenta Plasma (`bw8`), Glaciación Plasma (`bw9`), Explosión Plasma (`bw10`)
- Note: physical Spanish product was not commercially distributed; Spanish is available digitally (PTCGO) and assets already exist — same unlock pattern as Italian for card generation

## Gap citation

Archeops Documentarian gap 2 — ES missing Plasma Blast Archen/Archeops (`bw10-53` / `bw10-54`) by Western ID.