### PR TITLE
fix(data): Rayquaza (McDonald's Collection 2024 14) is Colorless, not Dragon

### DIFF
--- a/data/McDonald's Collection/McDonald's Collection 2024/14.ts
+++ b/data/McDonald's Collection/McDonald's Collection 2024/14.ts
@@ -20,7 +20,7 @@ const card: Card = {
 
 	hp: 130,
 
-	types: ["Dragon"],
+	types: ["Colorless"],
 
 	stage: "Basic",
 


### PR DESCRIPTION
## Changes

`data/McDonald's Collection/McDonald's Collection 2024/14.ts` types Rayquaza
as `Dragon`. The printed card is `Colorless`.

## Details

On the card itself:
- both attacks (Jaw Lock, Power Blast) cost Colorless energy only
- Weakness Lightning ×2, Resistance Fighting -30

Bulbapedia also lists `#14` as Colorless.

Photo of my own copy (M24 14/15, French print):
<img width="400" alt="20260909_220637" src="https://github.com/user-attachments/assets/d3ba0434-7e5f-4a72-ab98-ec1f6a3e4122" />
