### PR TITLE
Fix wrong dexId on 10 cards and wrong French names on 2 Celebrations Classic Collection cards

### DIFF
--- a/data/Mega Evolution/Mega Evolution/086.ts
+++ b/data/Mega Evolution/Mega Evolution/086.ts
@@ -21,7 +21,7 @@ const card: Card = {
 	hp: 280,
 	types: ["Darkness"],
 	stage: "Basic",
-	dexId: [351],
+	dexId: [359],
 
 	attacks: [{
 		cost: ["Darkness", "Colorless"],

--- a/data/Scarlet & Violet/Obsidian Flames/073.ts
+++ b/data/Scarlet & Violet/Obsidian Flames/073.ts
@@ -2,7 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Obsidian Flames"
 
 const card: Card = {
-	dexId: [921],
+	dexId: [923],
 	set: Set,
 
 	name: {

--- a/data/Sun & Moon/SM Black Star Promos/SM45.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM45.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	set: Set,
 	dexId: [
-		785,
+		786,
 	],
 	hp: 110,
 	types: [

--- a/data/Sun & Moon/SM Black Star Promos/SM61.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM61.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	set: Set,
 	dexId: [
-		786,
+		787,
 	],
 	hp: 130,
 	types: [

--- a/data/Sun & Moon/SM Black Star Promos/SM92.ts
+++ b/data/Sun & Moon/SM Black Star Promos/SM92.ts
@@ -16,7 +16,7 @@ const card: Card = {
 
 	set: Set,
 	dexId: [
-		787,
+		788,
 	],
 	hp: 120,
 	types: [

--- a/data/Sword & Shield/Celebrations Classic Collection/CC005.ts
+++ b/data/Sword & Shield/Celebrations Classic Collection/CC005.ts
@@ -7,7 +7,7 @@ const card: Card = {
 
 	name: {
 		en: "Dark Gyarados",
-		fr: "Pikachu Surfeur-V"
+		fr: "Léviator obscur"
 	},
 
 	illustrator: "Kagemaru Himeno",
@@ -20,7 +20,7 @@ const card: Card = {
 	attacks: [{
 		name: {
 			en: "Ice Beam",
-			fr: "Surf"
+			fr: "Laser Glace"
 		},
 
 		effect: {

--- a/data/Sword & Shield/Celebrations Classic Collection/CC011.ts
+++ b/data/Sword & Shield/Celebrations Classic Collection/CC011.ts
@@ -7,7 +7,7 @@ const card: Card = {
 
 	name: {
 		en: "Team Magma's Groudon",
-		fr: "Pikachu Surfeur-VMAX"
+		fr: "Groudon de Team Magma"
 	},
 
 	illustrator: "Kazuo Yazawa",
@@ -35,11 +35,11 @@ const card: Card = {
 		{
 			name: {
 				en: "Linear Attack",
-				fr: "Surfeuromax",
+				fr: "Attaque Linéaire",
 			},
 			effect: {
 				en: "Choose 1 of your opponent's Pokémon. This attack does 20 damage to that Pokémon. (Don't apply Weakness and Resistance for Benched Pokémon.)",
-				fr: "Cette attaque inflige aussi 30 dégâts à chacun des Pokémon de Banc de votre adversaire. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
+				fr: "Choisissez 1 des Pokémon de votre adversaire. Cette attaque inflige 20 dégâts à ce Pokémon. (N'appliquez ni la Faiblesse ni la Résistance aux Pokémon de Banc.)",
 			},
 			cost: [
 				"Fighting",

--- a/data/Sword & Shield/Fusion Strike/1.ts
+++ b/data/Sword & Shield/Fusion Strike/1.ts
@@ -2,7 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Fusion Strike"
 
 const card: Card = {
-	dexId: [251],
+	dexId: [10],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Fusion Strike/266.ts
+++ b/data/Sword & Shield/Fusion Strike/266.ts
@@ -2,7 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Fusion Strike"
 
 const card: Card = {
-	dexId: [888],
+	dexId: [818],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Fusion Strike/79.ts
+++ b/data/Sword & Shield/Fusion Strike/79.ts
@@ -2,7 +2,7 @@ import { Card } from "../../../interfaces"
 import Set from "../Fusion Strike"
 
 const card: Card = {
-	dexId: [888],
+	dexId: [818],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Rebel Clash/195.ts
+++ b/data/Sword & Shield/Rebel Clash/195.ts
@@ -2,7 +2,7 @@ import { Card } from '../../../interfaces'
 import Set from '../Rebel Clash'
 
 const card: Card = {
-	dexId: [888],
+	dexId: [818],
 	set: Set,
 
 	name: {

--- a/data/Sword & Shield/Rebel Clash/50.ts
+++ b/data/Sword & Shield/Rebel Clash/50.ts
@@ -17,7 +17,7 @@ const card: Card = {
 	set: Set,
 
 	dexId: [
-		888,
+		818,
 	],
 
 	hp: 320,


### PR DESCRIPTION
## Changes

Twelve one-line data corrections found while cross-checking `dexId` against card names over the whole French catalogue (name-based matching vs the `dexId` field, ~15 500 cards where both answer; every disagreement was checked against the card image / the number printed on the card).

**Wrong `dexId` (10 cards):**

| Card | Was | Now | Why |
| -- | -- | -- | -- |
| Fusion Strike 1 — Caterpie | 251 (Celebi) | 10 | No. 010 printed on the card |
| Rebel Clash 50, 195 · Fusion Strike 79, 266 — Inteleon VMAX | 888 (Zacian) | 818 | Inteleon |
| Obsidian Flames 073 — Pawmot ex | 921 (Pawmi) | 923 | Pawmot |
| Mega Evolution 086 — Mega Absol ex | 351 (Castform) | 359 | Absol |
| SM Black Star Promos SM45 — Tapu Lele | 785 | 786 | No. 786 printed on the card |
| SM Black Star Promos SM61 — Tapu Bulu | 786 | 787 | Tapu Bulu |
| SM Black Star Promos SM92 — Tapu Fini | 787 | 788 | No. 788 printed on the card |

**Wrong French name (2 cards, `dexId` was right):** Celebrations Classic Collection CC005 (Dark Gyarados) and CC011 (Team Magma's Groudon) carried the French names and attack names of the Celebrations Surfing Pikachu V / VMAX (`Pikachu Surfeur-V`, `Surf`, `Surfeuromax`…). Restored the original French names (`Léviator obscur`, `Groudon de Team Magma`, as on Team Rocket 8 and EX Team Magma vs Team Aqua 9), `Laser Glace` for Ice Beam, `Attaque Linéaire` and its effect text for Linear Attack.

## Details

Sorry for spanning several sets in one PR — it is 12 lines total; happy to split it per set if you prefer.

Found by https://pokefeuille.app (French collection tracker built on TCGdex — thank you for the database). The same check runs weekly on our side, so I may open similar small PRs if new mismatches show up.
