### PR TITLE
fix(data): correct Black Bolt marketplace ids and variants

### DIFF
--- a/data/Scarlet & Violet/Black Bolt/001.ts
+++ b/data/Scarlet & Violet/Black Bolt/001.ts
@@ -72,6 +72,7 @@ const card: Card = {
 			foil: "tinsel",
 			thirdParty: {
 				cardmarket: 836667,
+				tcgplayer: 645571
 			}
 		},
 		{

--- a/data/Scarlet & Violet/Black Bolt/007.ts
+++ b/data/Scarlet & Violet/Black Bolt/007.ts
@@ -101,7 +101,7 @@ const card: Card = {
 			foil: "masterball",
 			thirdParty: {
 				cardmarket: 836274,
-				tcgplayer: 642701
+				tcgplayer: 642629
 			}
 		}
 	],

--- a/data/Scarlet & Violet/Black Bolt/013.ts
+++ b/data/Scarlet & Violet/Black Bolt/013.ts
@@ -44,7 +44,7 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
-				cardmarket: 835929,
+				cardmarket: 835928,
 				tcgplayer: 642462
 			}
 		},
@@ -72,9 +72,6 @@ const card: Card = {
 			}
 		}
 	],
-	 // thirdParty: {
-	 //	cardmarket: 835928
-	 // }
 }
 
 export default card

--- a/data/Scarlet & Violet/Black Bolt/014.ts
+++ b/data/Scarlet & Violet/Black Bolt/014.ts
@@ -87,14 +87,14 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
-				cardmarket: 835069,
+				cardmarket: 835929,
 				tcgplayer: 642463
 			}
 		},
 		{
 			type: "reverse",
 			thirdParty: {
-				cardmarket: 835069,
+				cardmarket: 835929,
 				tcgplayer: 642463
 			}
 		},

--- a/data/Scarlet & Violet/Black Bolt/027.ts
+++ b/data/Scarlet & Violet/Black Bolt/027.ts
@@ -66,14 +66,14 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
-				cardmarket: 835994,
+				cardmarket: 835953,
 				tcgplayer: 642479
 			}
 		},
 		{
 			type: "reverse",
 			thirdParty: {
-				cardmarket: 835994,
+				cardmarket: 835953,
 				tcgplayer: 642479
 			}
 		},

--- a/data/Scarlet & Violet/Black Bolt/028.ts
+++ b/data/Scarlet & Violet/Black Bolt/028.ts
@@ -73,6 +73,22 @@ const card: Card = {
 				tcgplayer: 642480
 			}
 		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 864375,
+				tcgplayer: 671619
+			}
+		},
+		{
+			type: "holo",
+			size: "jumbo",
+			thirdParty: {
+				cardmarket: 867785,
+				tcgplayer: 668961
+			}
+		},
 	],
 }
 

--- a/data/Scarlet & Violet/Black Bolt/030.ts
+++ b/data/Scarlet & Violet/Black Bolt/030.ts
@@ -78,7 +78,16 @@ const card: Card = {
 				cardmarket: 836333,
 				tcgplayer: 642654
 			}
-		}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 894191,
+				tcgplayer: 704465
+			}
+		},
 	]
 }
 

--- a/data/Scarlet & Violet/Black Bolt/031.ts
+++ b/data/Scarlet & Violet/Black Bolt/031.ts
@@ -103,7 +103,23 @@ const card: Card = {
 				cardmarket: 836336,
 				tcgplayer: 642655
 			}
-		}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 864358,
+				tcgplayer: 671320
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["gym-challenge"],
+			thirdParty: {
+				tcgplayer: 714873
+			}
+		},
 	],
 }
 

--- a/data/Scarlet & Violet/Black Bolt/034.ts
+++ b/data/Scarlet & Violet/Black Bolt/034.ts
@@ -81,6 +81,29 @@ const card: Card = {
 				tcgplayer: 668957
 			}
 		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 864406,
+				tcgplayer: 704471
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 894193,
+				tcgplayer: 671743
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["ultra-ball-league"],
+			thirdParty: {
+				cardmarket: 855692
+			}
+		},
 	],
 }
 

--- a/data/Scarlet & Violet/Black Bolt/049.ts
+++ b/data/Scarlet & Violet/Black Bolt/049.ts
@@ -113,7 +113,15 @@ const card: Card = {
 				cardmarket: 836376,
 				tcgplayer: 642670
 			}
-		}
+		},
+		{
+			type: "normal",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 864353,
+				tcgplayer: 671308
+			}
+		},
 	]
 }
 

--- a/data/Scarlet & Violet/Black Bolt/059.ts
+++ b/data/Scarlet & Violet/Black Bolt/059.ts
@@ -111,7 +111,7 @@ const card: Card = {
 			foil: "masterball",
 			thirdParty: {
 				cardmarket: 836412,
-				tcgplayer: 642753
+				tcgplayer: 642680
 			}
 		}
 	]

--- a/data/Scarlet & Violet/Black Bolt/060.ts
+++ b/data/Scarlet & Violet/Black Bolt/060.ts
@@ -87,7 +87,7 @@ const card: Card = {
 			foil: "masterball",
 			thirdParty: {
 				cardmarket: 836414,
-				tcgplayer: 642756
+				tcgplayer: 642683
 			}
 		}
 	]

--- a/data/Scarlet & Violet/Black Bolt/065.ts
+++ b/data/Scarlet & Violet/Black Bolt/065.ts
@@ -77,14 +77,14 @@ const card: Card = {
 		{
 			type: "normal",
 			thirdParty: {
-				cardmarket: 836009,
+				cardmarket: 836043,
 				tcgplayer: 642516
 			}
 		},
 		{
 			type: "reverse",
 			thirdParty: {
-				cardmarket: 836009,
+				cardmarket: 836043,
 				tcgplayer: 642516
 			}
 		},

--- a/data/Scarlet & Violet/Black Bolt/067.ts
+++ b/data/Scarlet & Violet/Black Bolt/067.ts
@@ -82,7 +82,30 @@ const card: Card = {
 				cardmarket: 836046,
 				tcgplayer: 642518
 			}
-		}
+		},
+		{
+			type: "holo",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 864365,
+				tcgplayer: 671556
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["liao-fu-guan"],
+			thirdParty: {
+				cardmarket: 884294,
+				tcgplayer: 689618
+			}
+		},
+		{
+			type: "holo",
+			stamp: ["gym-challenge"],
+			thirdParty: {
+				tcgplayer: 714874
+			}
+		},
 	]
 }
 

--- a/data/Scarlet & Violet/Black Bolt/069.ts
+++ b/data/Scarlet & Violet/Black Bolt/069.ts
@@ -101,7 +101,7 @@ const card: Card = {
 			foil: "masterball",
 			thirdParty: {
 				cardmarket: 836450,
-				tcgplayer: 642761
+				tcgplayer: 642688
 			}
 		}
 	]

--- a/data/Scarlet & Violet/Black Bolt/075.ts
+++ b/data/Scarlet & Violet/Black Bolt/075.ts
@@ -77,7 +77,7 @@ const card: Card = {
 			type: "reverse",
 			foil: "masterball",
 			thirdParty: {
-				cardmarket: 836463,
+				cardmarket: 836462,
 				tcgplayer: 642694
 			}
 		}

--- a/data/Scarlet & Violet/Black Bolt/079.ts
+++ b/data/Scarlet & Violet/Black Bolt/079.ts
@@ -53,6 +53,47 @@ const card: Card = {
 				tcgplayer: 642771
 			}
 		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			stamp: ["player-rewards-program"],
+			thirdParty: {
+				cardmarket: 864407,
+				tcgplayer: 675552
+			}
+		},
+		{
+			type: "holo",
+			foil: "cosmos",
+			stamp: ["great-ball-league"],
+			thirdParty: {
+				cardmarket: 855028,
+				tcgplayer: 696170
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["gym-challenge"],
+			thirdParty: {
+				tcgplayer: 714875
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["liao-fu-guan"],
+			thirdParty: {
+				cardmarket: 884311,
+				tcgplayer: 690279
+			}
+		},
+		{
+			type: "normal",
+			stamp: ["jose-cruz-galindo-resendiz"],
+			thirdParty: {
+				cardmarket: 884410,
+				tcgplayer: 690510
+			}
+		},
 	]
 }
 

--- a/data/Scarlet & Violet/Black Bolt/084.ts
+++ b/data/Scarlet & Violet/Black Bolt/084.ts
@@ -53,6 +53,14 @@ const card: Card = {
 				tcgplayer: 644830
 			}
 		},
+		{
+			type: "normal",
+			stamp: ["liao-fu-guan"],
+			thirdParty: {
+				cardmarket: 884309,
+				tcgplayer: 690277
+			}
+		},
 	]
 }
 

--- a/data/Scarlet & Violet/Black Bolt/085.ts
+++ b/data/Scarlet & Violet/Black Bolt/085.ts
@@ -53,6 +53,15 @@ const card: Card = {
 				tcgplayer: 642772
 			}
 		},
+		{
+			type: "reverse",
+			foil: "pokeball",
+			stamp: ["professor-program"],
+			thirdParty: {
+				cardmarket: 878014,
+				tcgplayer: 704476
+			}
+		},
 	]
 }
 

--- a/data/Scarlet & Violet/Black Bolt/114.ts
+++ b/data/Scarlet & Violet/Black Bolt/114.ts
@@ -77,7 +77,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 836139,
+				cardmarket: 836137,
 				tcgplayer: 642567
 			}
 		},

--- a/data/Scarlet & Violet/Black Bolt/115.ts
+++ b/data/Scarlet & Violet/Black Bolt/115.ts
@@ -87,7 +87,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 836137,
+				cardmarket: 836139,
 				tcgplayer: 642568
 			}
 		},

--- a/data/Scarlet & Violet/Black Bolt/139.ts
+++ b/data/Scarlet & Violet/Black Bolt/139.ts
@@ -54,7 +54,7 @@ const card: Card = {
 		{
 			type: "holo",
 			thirdParty: {
-				cardmarket: 836199,
+				cardmarket: 836205,
 				tcgplayer: 642261
 			}
 		},

--- a/interfaces.d.ts
+++ b/interfaces.d.ts
@@ -21,7 +21,7 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'wotc' | 'd-edition-error' | '1st-edition-scratch-error' | "1st-edition-error" | '1st-movie' | '1st-movie-inverted'
 	| 'pokemon-4-ever' | 'pokemon-center-ny' | "winner" | '25th-celebration' | 'chris-fulop' | 'tsuguyoshi-yamato'
 	| 'reed-weichler' | 'kevin-nguyen' | 'professor-program' | 'takashi-yoneda' | 'michael-gonzalez' | 'curran-hill'
-	| 'jeremy-maron' | 'jimmy-ballard' | 'miska-saari' | 'hiroki-yano' | 'jason-klaczynski' | 'state-championships'
+	| 'jeremy-maron' | 'jimmy-ballard' | 'miska-saari' | 'hiroki-yano' | 'jason-klaczynski' | 'liao-fu-guan' | 'state-championships'
 	| 'national-championships' | 'gym-challenge' | 'city-championships' | 'jeremy-scharff-kim' | 'destiny-deoxys'
 	| 'pokemon-day' | 'regional-championships' | 'international-championships' | 'stadium-challenge' | '10th-anniversary' | 'wizard-world-philadelphia'
 	| 'wizard-world-chicago' | 'comic-con' | 'nintendo-world' | 'gen-con' | 'akira-miyazaki' | 'tom-roos'
@@ -32,11 +32,12 @@ export type VariantStamps = '1st-edition' | 'w-promo' | 'pre-release' | 'pokemon
 	| 'yuka-furusawa' | 'jason-martinez' | 'yuta-komatsuda' | 'origins-2008' | 'platinum' | 'worlds-2010'
 	| 'ross-cawthorn' | 'gustavo-wada' | 'christopher-kan' | 'player-rewards-program' | 'igor-costa'
 	| 'zachary-bokhari' | 'shuto-itagaki' | 'snowflake' | 'trick-or-trade' | 'horizons' | 'gamestop' | 'eb-games'
-	| 'illustration-contest-2022' | 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "poke-ball-league" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
+	| 'illustration-contest-2022' | 'illustration-contest-2024' | 'worlds-2025' | 'top-eight' | "champion" | "poke-ball-league" | "great-ball-league" | "master-ball-league" | "ultra-ball-league" | "judge" | "asia-promo"
 	| "international-championship-europe" | "international-championship-latin-america" | "international-championship-north-america" | 'ace-trainer'
 	| 'pikachu' | 'bulbasaur' | 'squirtle' | 'charmander' | 'pokeball' | '30th-pokeday' | 'mcdonalds' | 'pokemon-together' | 'rain-city' | 'tournament-collection' | 'fossil-museum'
 	| 'worlds-2024' | 'worlds-2023' | 'worlds-2022' | 'asia-2023-24' | 'thank-you' | 'jr-stamp-rally' | 'grey-star' | 'pop-tournament' | 'chase-moloney' | 'chicago-2009' | 'scrye' | 'inquest-gamer'
 	| 'jesse-parker' | 'gabriel-fernandez' | 'sakuya-ota' | 'shao-tong-yen' | 'poketour-99'
+	| 'jose-cruz-galindo-resendiz'
 
 export interface variant_detailed {
 	/**

--- a/meta/translations/de.json
+++ b/meta/translations/de.json
@@ -240,6 +240,7 @@
 		"master-ball-league": "master-ball-league",
 		"ultra-ball-league": "ultra-ball-league",
 		"poke-ball-league": "poke-ball-league",
+		"great-ball-league": "great-ball-league",
 		"asia-promo": "asia-promo",
 		"judge": "richter",
 		"international-championship-europe": "international-championship-europe",
@@ -271,6 +272,8 @@
 		"jesse-parker": "jesse-parker",
 		"gabriel-fernandez": "gabriel-fernandez",
 		"shao-tong-yen": "shao-tong-yen",
+		"liao-fu-guan": "liao-fu-guan",
+		"jose-cruz-galindo-resendiz": "Jose Cruz Galindo-Resendiz",
 		"sakuya-ota": "sakuya-ota",
 		"poketour-99": "PokeTour 1999",
 		"fossil-museum": "Fossil Museum"

--- a/meta/translations/es.json
+++ b/meta/translations/es.json
@@ -240,6 +240,7 @@
 		"master-ball-league": "liga-master-ball",
 		"ultra-ball-league": "liga-ultra-ball",
 		"poke-ball-league": "liga-poke-ball",
+		"great-ball-league": "liga-great-ball",
 		"asia-promo": "asia-promo",
 		"judge": "juez",
 		"international-championship-europe": "campeonato-internacional-europa",
@@ -271,6 +272,8 @@
 		"jesse-parker": "jesse-parker",
 		"gabriel-fernandez": "gabriel-fernandez",
 		"shao-tong-yen": "shao-tong-yen",
+		"liao-fu-guan": "liao-fu-guan",
+		"jose-cruz-galindo-resendiz": "Jose Cruz Galindo-Resendiz",
 		"sakuya-ota": "sakuya-ota",
 		"poketour-99": "PokeTour 1999",
 		"fossil-museum": "Fossil Museum"

--- a/meta/translations/fr.json
+++ b/meta/translations/fr.json
@@ -239,6 +239,7 @@
 		"master-ball-league": "ligue-master-ball",
 		"ultra-ball-league": "ligue-ultra-ball",
 		"poke-ball-league": "ligue-poke-ball",
+		"great-ball-league": "ligue-great-ball",
 		"asia-promo": "asia-promo",
 		"judge": "juge",
 		"international-championship-europe": "championnat-international-europe",
@@ -270,6 +271,8 @@
 		"jesse-parker": "jesse-parker",
 		"gabriel-fernandez": "gabriel-fernandez",
 		"shao-tong-yen": "shao-tong-yen",
+		"liao-fu-guan": "liao-fu-guan",
+		"jose-cruz-galindo-resendiz": "Jose Cruz Galindo-Resendiz",
 		"sakuya-ota": "sakuya-ota",
 		"poketour-99": "PokeTour 1999",
 		"fossil-museum": "Fossil Museum"

--- a/meta/translations/it.json
+++ b/meta/translations/it.json
@@ -240,6 +240,7 @@
 		"master-ball-league": "lega-master-ball",
 		"ultra-ball-league": "lega-ultra-ball",
 		"poke-ball-league": "lega-poke-ball",
+		"great-ball-league": "lega-great-ball",
 		"asia-promo": "asia-promo",
 		"judge": "giudice",
 		"international-championship-europe": "campionato-internazionale-europa",
@@ -271,6 +272,8 @@
 		"jesse-parker": "jesse-parker",
 		"gabriel-fernandez": "gabriel-fernandez",
 		"shao-tong-yen": "shao-tong-yen",
+		"liao-fu-guan": "liao-fu-guan",
+		"jose-cruz-galindo-resendiz": "Jose Cruz Galindo-Resendiz",
 		"sakuya-ota": "sakuya-ota",
 		"poketour-99": "PokeTour 1999",
 		"fossil-museum": "Fossil Museum"

--- a/meta/translations/pt.json
+++ b/meta/translations/pt.json
@@ -239,6 +239,7 @@
 		"master-ball-league": "liga-master-ball",
 		"ultra-ball-league": "liga-ultra-ball",
 		"poke-ball-league": "liga-poke-ball",
+		"great-ball-league": "liga-great-ball",
 		"asia-promo": "asia-promo",
 		"judge": "juiz",
 		"international-championship-europe": "campeonato-internacional-europa",
@@ -270,6 +271,8 @@
 		"jesse-parker": "jesse-parker",
 		"gabriel-fernandez": "gabriel-fernandez",
 		"shao-tong-yen": "shao-tong-yen",
+		"liao-fu-guan": "liao-fu-guan",
+		"jose-cruz-galindo-resendiz": "Jose Cruz Galindo-Resendiz",
 		"sakuya-ota": "sakuya-ota",
 		"poketour-99": "PokeTour 1999",
 		"fossil-museum": "Fossil Museum"


### PR DESCRIPTION
## Changes

Missing marketplace ids and variants for Black Bolt.

## Details

- Corrected Cardmarket and TCGplayer ids, including Master Ball reverses and Zekrom ex stamp pairings.
- Added Prize Pack, GYM, league, World Championship deck and Professor Program variants.
- Added the Kyurem ex jumbo variant and Snivy tinsel TCGplayer id.
- Added missing stamp values.