### PR TITLE
Fix several Ascended Heroes Prize Pack variants

### DIFF
--- a/data/Mega Evolution/Ascended Heroes/007.ts
+++ b/data/Mega Evolution/Ascended Heroes/007.ts
@@ -115,7 +115,7 @@ const card: Card = {
 			foil: "cosmos",
 			thirdParty: {
 				cardmarket: 870106,
-				tcgplayer: 679249
+				tcgplayer: 679253
 			}
 		},
 	],

--- a/data/Mega Evolution/Ascended Heroes/039.ts
+++ b/data/Mega Evolution/Ascended Heroes/039.ts
@@ -86,7 +86,7 @@ const card: Card = {
 	},
 	{
 		type: "normal",
-		stamp: ["pokemon-center"],
+		stamp: ["player-rewards-program"],
 		thirdParty: {
 			cardmarket: 894183,
 			tcgplayer: 704451
@@ -94,7 +94,8 @@ const card: Card = {
 	},
 	{
 		type: "holo",
-		stamp: ["pokemon-center"],
+		foil: "cosmos",
+		stamp: ["player-rewards-program"],
 		thirdParty: {
 			cardmarket: 894184,
 			tcgplayer: 704452

--- a/data/Mega Evolution/Ascended Heroes/086.ts
+++ b/data/Mega Evolution/Ascended Heroes/086.ts
@@ -87,8 +87,8 @@ const card: Card = {
 		}
 	},
 	{
-		type: "holo",
-		stamp: ["pokemon-center"],
+		type: "normal",
+		stamp: ["player-rewards-program"],
 		thirdParty: {
 			cardmarket: 894173,
 			tcgplayer: 704442

--- a/data/Mega Evolution/Ascended Heroes/150.ts
+++ b/data/Mega Evolution/Ascended Heroes/150.ts
@@ -55,8 +55,8 @@ const card: Card = {
 		}
 	},
 	{
-		type: "holo",
-		stamp: ["pokemon-center"],
+		type: "normal",
+		stamp: ["player-rewards-program"],
 		thirdParty: {
 			cardmarket: 894128,
 			tcgplayer: 704413

--- a/data/Mega Evolution/Ascended Heroes/155.ts
+++ b/data/Mega Evolution/Ascended Heroes/155.ts
@@ -90,7 +90,7 @@ const card: Card = {
 	},
 	{
 		type: "normal",
-		stamp: ["pokemon-center"],
+		stamp: ["player-rewards-program"],
 		thirdParty: {
 			cardmarket: 894179,
 			tcgplayer: 704446
@@ -98,7 +98,8 @@ const card: Card = {
 	},
 	{
 		type: "holo",
-		stamp: ["pokemon-center"],
+		foil: "cosmos",
+		stamp: ["player-rewards-program"],
 		thirdParty: {
 			cardmarket: 894178,
 			tcgplayer: 704447

--- a/data/Mega Evolution/Ascended Heroes/183.ts
+++ b/data/Mega Evolution/Ascended Heroes/183.ts
@@ -48,7 +48,7 @@ const card: Card = {
 	},
 	{
 		type: "normal",
-		stamp: ["pokemon-center"],
+		stamp: ["player-rewards-program"],
 		thirdParty: {
 			cardmarket: 894199,
 			tcgplayer: 704398
@@ -56,7 +56,8 @@ const card: Card = {
 	},
 	{
 		type: "holo",
-		stamp: ["pokemon-center"],
+		foil: "cosmos",
+		stamp: ["player-rewards-program"],
 		thirdParty: {
 			cardmarket: 894200,
 			tcgplayer: 704399

--- a/data/Mega Evolution/Ascended Heroes/185.ts
+++ b/data/Mega Evolution/Ascended Heroes/185.ts
@@ -48,7 +48,8 @@ const card: Card = {
 	},
 	{
 		type: "holo",
-		stamp: ["pokemon-center"],
+		foil: "cosmos",
+		stamp: ["player-rewards-program"],
 		thirdParty: {
 			cardmarket: 894203,
 			tcgplayer: 704401


### PR DESCRIPTION
## Changes

Fixes several Ascended Heros  Prize Pack Varients

## Details

- Updated Erika’s Tangela 7/217 — Corrected Cosmos holo TCGplayer ID from 679249 to 679253.
- Updated Psyduck 39/217 — Corrected stamp to player-rewards-program on normal and holo variants; added cosmos foil to the holo variant.
- Updated Mismagius 86/217 — Corrected stamp to player-rewards-program and changed the stamped variant from holo to normal.
- Updated Dratini 150/217 — Corrected stamp to player-rewards-program and changed the stamped variant from holo to normal.
- Updated N’s Zekrom 155/217 — Corrected stamp to player-rewards-program on normal and holo variants; added cosmos foil to the holo variant.
- Updated Boss’s Orders 183/217 — Corrected stamp to player-rewards-program on normal and holo variants; added cosmos foil to the holo variant.
- Updated Canari 185/217 — Corrected stamp to player-rewards-program and added cosmos foil to the stamped holo variant.